### PR TITLE
Reset loader memory after value resolution

### DIFF
--- a/lib/CachingOperation.ts
+++ b/lib/CachingOperation.ts
@@ -93,7 +93,7 @@ export class CachingOperation<LoadedValue> {
           }
         })
 
-      if (resolvedValue) {
+      if (resolvedValue !== undefined) {
         // update caches
         this.cacheIndexes
           .filter((cacheIndex) => {
@@ -109,9 +109,11 @@ export class CachingOperation<LoadedValue> {
               })
           })
 
+        this.runningLoads.delete(key)
         return resolvedValue
       }
     }
+    this.runningLoads.delete(key)
     return undefined
   }
 

--- a/lib/GroupedCachingOperation.ts
+++ b/lib/GroupedCachingOperation.ts
@@ -87,7 +87,7 @@ export class GroupedCachingOperation<LoadedValue> {
           }
         })
 
-      if (resolvedValue) {
+      if (resolvedValue !== undefined) {
         // update caches
         this.cacheIndexes
           .filter((cacheIndex) => {
@@ -107,9 +107,11 @@ export class GroupedCachingOperation<LoadedValue> {
               })
           })
 
+        this.runningLoads.delete(key)
         return resolvedValue
       }
     }
+    this.runningLoads.delete(key)
     return undefined
   }
 

--- a/lib/LoadingOperation.ts
+++ b/lib/LoadingOperation.ts
@@ -8,7 +8,7 @@ export type LoadingOperationConfig = {
   cacheUpdateErrorHandler: LoaderErrorHandler
   loadErrorHandler: LoaderErrorHandler
   loadingOperationMemorySize: number
-  loadingOperationMememoryTtl: number
+  loadingOperationMemoryTtl: number
 }
 
 export type LoaderErrorHandler = (err: Error, key: string | undefined, loader: Loader<any>, logger: Logger) => void
@@ -27,7 +27,7 @@ const DEFAULT_CONFIG: LoadingOperationConfig = {
   cacheUpdateErrorHandler: DEFAULT_CACHE_ERROR_HANDLER,
   loadErrorHandler: DEFAULT_LOAD_ERROR_HANDLER,
   loadingOperationMemorySize: 100,
-  loadingOperationMememoryTtl: 1000 * 30,
+  loadingOperationMemoryTtl: 1000 * 30,
 }
 
 export class LoadingOperation<LoadedValue> {
@@ -42,7 +42,7 @@ export class LoadingOperation<LoadedValue> {
       ...params,
     }
     this.loaders = loaders
-    this.runningLoads = lru(params.loadingOperationMemorySize, params.loadingOperationMememoryTtl)
+    this.runningLoads = lru(params.loadingOperationMemorySize, params.loadingOperationMemoryTtl)
 
     this.cacheIndexes = loaders.reduce((result, value, index) => {
       if (value.isCache) {
@@ -104,7 +104,7 @@ export class LoadingOperation<LoadedValue> {
           }
         })
 
-      if (resolvedValue) {
+      if (resolvedValue !== undefined) {
         // update caches
         this.cacheIndexes
           .filter((cacheIndex) => {
@@ -138,7 +138,8 @@ export class LoadingOperation<LoadedValue> {
           if (resolvedValue === undefined && this.params.throwIfUnresolved) {
             return reject(new Error(`Failed to resolve value for key "${key}"`))
           }
-          return resolve(resolvedValue)
+          resolve(resolvedValue)
+          this.runningLoads.delete(key)
         })
         .catch(reject)
     })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "layered-loader",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "Data loader with support for caching and fallback data sources ",
   "license": "MIT",
   "maintainers": [

--- a/test/utils/DummyCache.ts
+++ b/test/utils/DummyCache.ts
@@ -1,7 +1,7 @@
 import { Cache } from '../../lib/DataSources'
 
 export class DummyCache implements Cache<string> {
-  private value: string | undefined
+  value: string | undefined | null
   name = 'Dummy cache'
   isCache = true
 

--- a/test/utils/DummyGroupedCache.ts
+++ b/test/utils/DummyGroupedCache.ts
@@ -4,7 +4,7 @@ import { cloneDeep } from './cloneUtils'
 
 export class DummyGroupedCache implements GroupedCache<User> {
   private value: User | undefined
-  private groupValues: GroupValues
+  groupValues: GroupValues
 
   name = 'Dummy cache'
   isCache = true

--- a/test/utils/DummyLoader.ts
+++ b/test/utils/DummyLoader.ts
@@ -1,7 +1,7 @@
 import { Loader } from '../../lib/DataSources'
 
 export class DummyLoader implements Loader<string> {
-  private readonly value: string | undefined
+  value: string | undefined | null
   name = 'Dummy loader'
   isCache = false
 

--- a/test/utils/TemporaryThrowingCache.ts
+++ b/test/utils/TemporaryThrowingCache.ts
@@ -1,0 +1,23 @@
+import { Cache } from '../../lib/DataSources'
+
+export class TemporaryThrowingCache implements Cache<string> {
+  name = 'Throwing loader'
+  isCache = false
+  isThrowing = true
+  returnedValue = ''
+
+  constructor(value: string) {
+    this.returnedValue = value
+  }
+
+  async set() {}
+  async clear() {}
+  async delete() {}
+
+  async get(): Promise<string | undefined | null> {
+    if (this.isThrowing) {
+      throw new Error('Error has occurred')
+    }
+    return this.returnedValue
+  }
+}

--- a/test/utils/TemporaryThrowingLoader.ts
+++ b/test/utils/TemporaryThrowingLoader.ts
@@ -1,0 +1,19 @@
+import { Loader } from '../../lib/DataSources'
+
+export class TemporaryThrowingLoader implements Loader<string> {
+  name = 'Throwing loader'
+  isCache = false
+  isThrowing = true
+  returnedValue = ''
+
+  constructor(value: string) {
+    this.returnedValue = value
+  }
+
+  async get(): Promise<string | undefined | null> {
+    if (this.isThrowing) {
+      throw new Error('Error has occurred')
+    }
+    return this.returnedValue
+  }
+}


### PR DESCRIPTION
Previously deduplication mechanism for concurrent loading by the same key did not get correctly reset after value is actually resolved (doesn't matter whether to actual value or null/undefined).