### PR TITLE
Use faster way to get unix time

### DIFF
--- a/lib/AbstractFlatOperation.ts
+++ b/lib/AbstractFlatOperation.ts
@@ -7,7 +7,7 @@ export abstract class AbstractFlatOperation<
   public getInMemoryOnly(key: string, resolveParams?: ResolveParams): LoadedValue | undefined | null {
     if (this.inMemoryCache.ttlLeftBeforeRefreshInMsecs && !this.runningLoads.has(key)) {
       const expirationTime = this.inMemoryCache.getExpirationTime(key)
-      if (expirationTime && expirationTime - new Date().getTime() < this.inMemoryCache.ttlLeftBeforeRefreshInMsecs) {
+      if (expirationTime && expirationTime - Date.now() < this.inMemoryCache.ttlLeftBeforeRefreshInMsecs) {
         void this.getAsyncOnly(key, resolveParams)
       }
     }

--- a/lib/AbstractGroupedOperation.ts
+++ b/lib/AbstractGroupedOperation.ts
@@ -22,7 +22,7 @@ export abstract class AbstractGroupedOperation<LoadedValue, ResolveParams = unde
       const groupLoads = this.resolveGroupLoads(group)
       if (!groupLoads.has(key)) {
         const expirationTime = this.inMemoryCache.getExpirationTimeFromGroup(key, group)
-        if (expirationTime && expirationTime - new Date().getTime() < this.inMemoryCache.ttlLeftBeforeRefreshInMsecs) {
+        if (expirationTime && expirationTime - Date.now() < this.inMemoryCache.ttlLeftBeforeRefreshInMsecs) {
           void this.getAsyncOnly(key, group, resolveParams)
         }
       }

--- a/test/InMemoryCache.spec.ts
+++ b/test/InMemoryCache.spec.ts
@@ -20,7 +20,7 @@ describe('InMemoryCache', () => {
       const expiresAt = cache.getExpirationTime('key')
 
       // should be 0 if everything happens in the same msec, but typically slightly differs
-      const timeDifference = expiresAt! - IN_MEMORY_CACHE_CONFIG.ttlInMsecs - new Date().getTime()
+      const timeDifference = expiresAt! - IN_MEMORY_CACHE_CONFIG.ttlInMsecs - Date.now()
       expect(timeDifference < 10).toBe(true)
     })
 
@@ -32,12 +32,12 @@ describe('InMemoryCache', () => {
       await setTimeout(500)
 
       const expiresAtPre = cache.getExpirationTime('key')
-      const timeLeftPre = expiresAtPre! - new Date().getTime()
+      const timeLeftPre = expiresAtPre! - Date.now()
 
       cache.set('key', 'value')
 
       const expiresAtPost = cache.getExpirationTime('key')
-      const timeLeftPost = expiresAtPost! - new Date().getTime()
+      const timeLeftPost = expiresAtPost! - Date.now()
 
       expect(timeLeftPre < 520).toBe(true)
       expect(timeLeftPre > 480).toBe(true)
@@ -62,7 +62,7 @@ describe('InMemoryCache', () => {
       const expiresAt = cache.getExpirationTimeFromGroup('key', 'group')
 
       // should be 0 if everything happens in the same msec, but typically slightly differs
-      const timeDifference = expiresAt! - IN_MEMORY_CACHE_CONFIG.ttlInMsecs - new Date().getTime()
+      const timeDifference = expiresAt! - IN_MEMORY_CACHE_CONFIG.ttlInMsecs - Date.now()
       expect(timeDifference < 10).toBe(true)
     })
 
@@ -74,12 +74,12 @@ describe('InMemoryCache', () => {
       await setTimeout(500)
 
       const expiresAtPre = cache.getExpirationTimeFromGroup('key', 'group')
-      const timeLeftPre = expiresAtPre! - new Date().getTime()
+      const timeLeftPre = expiresAtPre! - Date.now()
 
       cache.setForGroup('key', 'value', 'group')
 
       const expiresAtPost = cache.getExpirationTimeFromGroup('key', 'group')
-      const timeLeftPost = expiresAtPost! - new Date().getTime()
+      const timeLeftPost = expiresAtPost! - Date.now()
 
       expect(timeLeftPre < 520).toBe(true)
       expect(timeLeftPre > 480).toBe(true)


### PR DESCRIPTION
See https://github.com/RafaelGSS/nodejs-bench-operations/blob/main/v18/RESULTS-v18_14_0.md#getting-unix-time

Date.now() is 2.5 times faster.
