### PR TITLE
feat: add @layered-loader/sqs SNS/SQS invalidation adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,9 @@ jobs:
       - name: Run Tests
         run: pnpm run test:coverage
 
+      # @layered-loader/sqs uses fauxqs as a test fixture, which requires Node >= 22.5
       - name: Run @layered-loader/sqs Tests
+        if: matrix.node-version != '20.x'
         run: pnpm --filter @layered-loader/sqs test
 
       - name: Stop Docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,16 +37,19 @@ jobs:
         run: pnpm run docker:start
 
       - name: Build
-        run: pnpm run build
+        run: pnpm -r --include-workspace-root run build
 
       - name: Run Tests
         run: pnpm run test:coverage
+
+      - name: Run @layered-loader/sqs Tests
+        run: pnpm --filter @layered-loader/sqs test
 
       - name: Stop Docker
         run: pnpm run docker:stop
 
       - name: Run Linting
-        run: pnpm run lint
+        run: pnpm -r --include-workspace-root run lint
 
   automerge:
     needs: build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
         with:
+          # Full history so we can diff between the PR's base SHA and the
+          # merge commit SHA regardless of how the PR was merged
+          # (merge commit / squash / rebase).
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -38,12 +41,6 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build
-        run: pnpm run build:release
-
       - name: Determine version bump
         id: version
         run: |
@@ -55,19 +52,111 @@ jobs:
             echo "bump=patch" >> $GITHUB_OUTPUT
           fi
 
-      - name: Bump version
+      # Diff between the PR's base SHA and merge commit SHA to find which
+      # workspace packages received source-level changes. Only those packages
+      # are bumped, tagged, and published.
+      - name: Detect changed packages
+        id: changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          set -euo pipefail
+          echo "Diffing $BASE_SHA..$MERGE_SHA"
+          changed_files=$(git diff --name-only "$BASE_SHA" "$MERGE_SHA")
+          echo "Changed files:"
+          echo "$changed_files"
+
+          root=false
+          sqs=false
+
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            case "$file" in
+              packages/sqs/lib/*|packages/sqs/index.ts|packages/sqs/package.json|packages/sqs/README.md|packages/sqs/LICENSE|packages/sqs/tsconfig.json)
+                sqs=true
+                ;;
+              packages/*)
+                # Other workspace packages — currently no other publishable
+                # packages exist but this prevents future packages from
+                # accidentally triggering a root release.
+                ;;
+              lib/*|index.ts|package.json|README.md|LICENSE|tsconfig.json)
+                root=true
+                ;;
+            esac
+          done <<< "$changed_files"
+
+          echo "root=$root" >> $GITHUB_OUTPUT
+          echo "sqs=$sqs" >> $GITHUB_OUTPUT
+          echo "Detected: root=$root, @layered-loader/sqs=$sqs"
+
+      - name: Skip — no publishable changes
+        if: steps.changes.outputs.root != 'true' && steps.changes.outputs.sqs != 'true'
+        run: |
+          echo "::warning::PR is labelled for release but contains no source changes in any publishable package. Nothing to publish."
+          exit 0
+
+      - name: Install dependencies
+        if: steps.changes.outputs.root == 'true' || steps.changes.outputs.sqs == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        if: steps.changes.outputs.root == 'true' || steps.changes.outputs.sqs == 'true'
+        run: pnpm -r --include-workspace-root run lint
+
+      - name: Build
+        if: steps.changes.outputs.root == 'true' || steps.changes.outputs.sqs == 'true'
+        run: pnpm -r --include-workspace-root run build
+
+      - name: Bump root version
+        if: steps.changes.outputs.root == 'true'
+        run: npm version ${{ steps.version.outputs.bump }} --no-git-tag-version
+
+      - name: Bump @layered-loader/sqs version
+        if: steps.changes.outputs.sqs == 'true'
+        working-directory: packages/sqs
         run: npm version ${{ steps.version.outputs.bump }} --no-git-tag-version
 
       - name: Fix formatting
+        if: steps.changes.outputs.root == 'true' || steps.changes.outputs.sqs == 'true'
         run: pnpm run lint:fix
 
-      - name: Commit and push
+      - name: Commit and tag releases
+        if: steps.changes.outputs.root == 'true' || steps.changes.outputs.sqs == 'true'
         run: |
+          set -euo pipefail
           git add .
-          git commit -m "chore: release v$(node -p "require('./package.json').version")"
-          git tag "v$(node -p "require('./package.json').version")"
+
+          message="chore: release"
+          tags=()
+
+          if [ "${{ steps.changes.outputs.root }}" = "true" ]; then
+            v=$(node -p "require('./package.json').version")
+            message="$message layered-loader@$v"
+            tags+=("v$v")
+          fi
+          if [ "${{ steps.changes.outputs.sqs }}" = "true" ]; then
+            v=$(node -p "require('./packages/sqs/package.json').version")
+            message="$message @layered-loader/sqs@$v"
+            tags+=("@layered-loader/sqs@$v")
+          fi
+
+          git commit -m "$message"
+          for t in "${tags[@]}"; do
+            git tag "$t"
+          done
           git push
           git push --tags
 
-      - name: Publish to npm
-        run: npm publish --provenance --access public
+      # Publish layered-loader BEFORE @layered-loader/sqs: the child package
+      # declares a peer dependency on the new layered-loader version, so the
+      # parent must be visible on the registry first.
+      - name: Publish layered-loader
+        if: steps.changes.outputs.root == 'true'
+        run: pnpm publish --provenance --access public --no-git-checks
+
+      - name: Publish @layered-loader/sqs
+        if: steps.changes.outputs.sqs == 'true'
+        working-directory: packages/sqs
+        run: pnpm publish --provenance --access public --no-git-checks

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ dist
 package-lock.json
 yarn.lock
 dist
+*.rdb

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ await userLoader.invalidateCacheFor('key', 'group') // this will transparently i
 
 ### Flexible invalidation triggers
 
-In real-world systems most invalidation events do not originate inside the application that owns the cache — they come from *upstream* domain events such as `user.updated` published by another service onto an SNS topic, an SQS queue, RabbitMQ exchange, or Kafka topic. Wiring those upstream events into the cache cluster used to require bespoke glue per service.
+In server-oriented architectures, many invalidation events do not originate inside the application that owns the cache — they come from *upstream* domain events such as `user.updated` published by another service onto an SNS topic, an SQS queue, RabbitMQ exchange, or Kafka topic. Wiring those upstream events into the cache cluster typically requires bespoke glue per service.
 
 Layered-loader ships transport-agnostic primitives for this:
 

--- a/README.md
+++ b/README.md
@@ -266,6 +266,15 @@ await operation.get({ jwtToken: 'someTokenValue', entityId: 'key' })
 It is possible to mostly rely on fast in-memory caches and still keep data in sync across multiple nodes in a distributed system. In order to achieve this, you need to use Notification Publisher/Consumer pair.
 The way it works - whenever there is an invalidation event within the loader (`invalidate`, `invalidateFor` or `invalidatForGroup` methods are invoked), publisher sends a fanout notification to all subscribed consumers, and they invalidate their own caches as well.
 
+### Available notification adapters
+
+| Transport | Package | When to pick it |
+| --- | --- | --- |
+| Redis pub/sub | Built-in (`createNotificationPair` from `layered-loader`) | Default choice; you already run Redis. Lowest latency, no per-instance queue setup. |
+| AWS SNS + SQS | [`@layered-loader/sqs`](packages/sqs/README.md) | AWS-native deployments; lets you also drive invalidations from upstream domain-event topics via [flexible triggers](#flexible-invalidation-triggers). |
+
+The Redis example below uses the built-in adapter. For AWS deployments see the [`@layered-loader/sqs` README](packages/sqs/README.md), which keeps the same `notificationPublisher` / `notificationConsumer` contract.
+
 Here is an example:
 
 ```ts
@@ -347,6 +356,64 @@ await userLoader.init() // this will ensure that consumers have definitely finis
 
 await userLoader.invalidateCacheFor('key', 'group') // this will transparently invalidate cache across all instances of your application
 ```
+
+### Flexible invalidation triggers
+
+In real-world systems most invalidation events do not originate inside the application that owns the cache — they come from *upstream* domain events such as `user.updated` published by another service onto an SNS topic, an SQS queue, RabbitMQ exchange, or Kafka topic. Wiring those upstream events into the cache cluster used to require bespoke glue per service.
+
+Layered-loader ships transport-agnostic primitives for this:
+
+- `InvalidationAction` / `GroupInvalidationAction` — the invalidation operations a resolver may emit.
+- `InvalidationResolver<TMessage, TAction>` — a pure function `(message) => action | action[] | null` that maps an upstream message to invalidations.
+- `InvalidationTrigger` — `start()` / `stop()` lifecycle interface implemented by every adapter.
+
+A trigger consumes from an upstream source, runs your resolver, and dispatches the emitted actions through any `NotificationPublisher` (the same kind you build with `createNotificationPair`). The cache cluster reacts as if the invalidations originated locally, but the upstream system stays oblivious to the cache.
+
+The first concrete adapter ships in [`@layered-loader/sqs`](packages/sqs/README.md) and supports both:
+
+- Subscribing to an **existing SNS topic** (the trigger creates an SQS queue subscribed to it), and
+- Consuming from an **existing SQS queue** directly.
+
+Sketch with the SQS adapter:
+
+```ts
+import { z } from 'zod'
+import { randomUUID } from 'node:crypto'
+import { Loader } from 'layered-loader'
+import {
+  createNotificationPair,
+  SqsNotificationPublisher,
+  SqsInvalidationTrigger,
+} from '@layered-loader/sqs'
+
+const USER_EVENT = z.object({ type: z.literal('user.updated'), userId: z.string() })
+
+// Cache cluster's invalidation pair
+const { publisher, consumer } = createNotificationPair<User>({ /* ... */ })
+
+// Trigger publisher needs a fresh serverUuid so the LOCAL cache also reacts
+const triggerPublisher = new SqsNotificationPublisher<User>({
+  serverUuid: randomUUID(),
+  dependencies,
+  locatorConfig: { topicName: 'user-cache-invalidations' },
+})
+
+const trigger = new SqsInvalidationTrigger({
+  sourceType: 'sns-topic',
+  dependencies: consumerDeps,
+  creationConfig: {
+    topic: { Name: 'domain-events.users' }, // upstream service's topic
+    queue: { QueueName: `cache-trigger-${process.env.HOSTNAME}` },
+  },
+  messageSchema: USER_EVENT,
+  publisher: triggerPublisher,
+  resolver: (msg) => ({ kind: 'delete', key: msg.userId }),
+})
+
+await trigger.start()
+```
+
+Future adapters (RabbitMQ, Kafka, Google Pub/Sub, ...) reuse the same `InvalidationAction` / resolver primitives — only the consumer wiring changes. See the [package README](packages/sqs/README.md#flexible-invalidation-triggers) for the full reference, including group triggers, the `serverUuid` rule, and error handling.
 
 ## Cache statistics
 

--- a/biome.json
+++ b/biome.json
@@ -34,7 +34,7 @@
       "./biome.json",
       "./package.json"
     ],
-    "ignore": ["./dist", "./coverage", "./node_modules"]
+    "ignore": ["./dist", "./coverage", "./node_modules", "./packages"]
   },
   "formatter": {
     "enabled": true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,3 +21,9 @@ services:
       - WAIT_HOSTS_TIMEOUT=300
       - WAIT_SLEEP_INTERVAL=30
       - WAIT_HOST_CONNECT_TIMEOUT=30
+
+  fauxqs:
+    image: "kibertoad/fauxqs:latest"
+
+    ports:
+      - "4566:4566"

--- a/index.ts
+++ b/index.ts
@@ -16,8 +16,19 @@ export { RedisGroupNotificationPublisher } from './lib/redis/RedisGroupNotificat
 export type { RedisNotificationConfig } from './lib/redis/RedisNotificationFactory'
 export type { RedisPublisherConfig } from './lib/redis/RedisNotificationPublisher'
 export type { RedisConsumerConfig } from './lib/redis/RedisNotificationConsumer'
-export type { NotificationPublisher } from './lib/notifications/NotificationPublisher'
+export type {
+  NotificationPublisher,
+  PublisherErrorHandler,
+} from './lib/notifications/NotificationPublisher'
 export type { GroupNotificationPublisher } from './lib/notifications/GroupNotificationPublisher'
+export type { ConsumerErrorHandler } from './lib/notifications/AbstractNotificationConsumer'
+export type {
+  SynchronousCache,
+  SynchronousGroupCache,
+  SynchronousWriteCache,
+  SynchronousWriteGroupCache,
+  GetManyResult,
+} from './lib/types/SyncDataSources'
 export type { InMemoryCacheConfiguration } from './lib/memory/InMemoryCache'
 export type { RedisCacheConfiguration } from './lib/redis/AbstractRedisCache'
 export type { RedisGroupCacheConfiguration } from './lib/redis/RedisGroupCache'

--- a/packages/sqs/README.md
+++ b/packages/sqs/README.md
@@ -1,0 +1,423 @@
+# @layered-loader/sqs
+
+SNS/SQS remote-invalidation adapter for [`layered-loader`](https://github.com/kibertoad/layered-loader).
+
+This package provides:
+
+- **Notification publishers and consumers** that fan cache invalidations out across a cluster via an SNS topic and per-instance SQS queues — a drop-in alternative to the built-in Redis adapter for AWS-native deployments.
+- **Flexible invalidation triggers** that subscribe to an *existing* upstream SNS topic or SQS queue (one that knows nothing about the caching layer) and translate domain events such as `user.updated` into cache invalidations propagated through your notification pair.
+
+The implementation is built on top of [`@message-queue-toolkit/sns`](https://github.com/kibertoad/message-queue-toolkit) and is tested against [fauxqs](https://github.com/kibertoad/fauxqs), an in-process SNS/SQS emulator.
+
+## Contents
+
+- [Installation](#installation)
+- [Quick start: notification pair](#quick-start-notification-pair)
+- [Group notification pair](#group-notification-pair)
+- [Locator vs creation config](#locator-vs-creation-config)
+- [How invalidation flows through SNS/SQS](#how-invalidation-flows-through-snssqs)
+- [Self-message filtering and `serverUuid`](#self-message-filtering-and-serveruuid)
+- [Flexible invalidation triggers](#flexible-invalidation-triggers)
+  - [Triggering from an existing SNS topic](#triggering-from-an-existing-sns-topic)
+  - [Triggering from an existing SQS queue](#triggering-from-an-existing-sqs-queue)
+  - [Group triggers](#group-triggers)
+  - [Resolver semantics](#resolver-semantics)
+  - [The trigger-publisher rule](#the-trigger-publisher-rule)
+  - [Error handling and retries](#error-handling-and-retries)
+- [Testing with fauxqs](#testing-with-fauxqs)
+- [API reference](#api-reference)
+
+## Installation
+
+```bash
+npm install @layered-loader/sqs layered-loader
+# Plus the AWS SDK clients and message-queue-toolkit (peer deps):
+npm install \
+  @aws-sdk/client-sns @aws-sdk/client-sqs @aws-sdk/client-sts \
+  @lokalise/node-core \
+  @message-queue-toolkit/core @message-queue-toolkit/sns @message-queue-toolkit/sqs \
+  zod
+```
+
+Node 20+ is required.
+
+## Quick start: notification pair
+
+The simplest setup mirrors the built-in Redis pair: each application instance gets a `publisher` (sends invalidations to a shared SNS topic) and a `consumer` (reads its own SQS queue subscribed to that topic and applies invalidations to its in-memory cache).
+
+```ts
+import { SNSClient } from '@aws-sdk/client-sns'
+import { SQSClient } from '@aws-sdk/client-sqs'
+import { STSClient } from '@aws-sdk/client-sts'
+import { globalLogger, NoopObservabilityManager } from '@lokalise/node-core'
+import { SnsConsumerErrorResolver } from '@message-queue-toolkit/sns'
+import { Loader } from 'layered-loader'
+import { createNotificationPair } from '@layered-loader/sqs'
+import type { User } from './types'
+
+const region = 'us-east-1'
+const snsClient = new SNSClient({ region })
+const sqsClient = new SQSClient({ region })
+const stsClient = new STSClient({ region })
+
+const errorReporter = { report: () => {} }
+
+const { publisher: notificationPublisher, consumer: notificationConsumer } =
+  createNotificationPair<User>({
+    publisher: {
+      dependencies: { snsClient, stsClient, logger: globalLogger, errorReporter },
+      creationConfig: { topic: { Name: 'user-cache-invalidations' } },
+    },
+    consumer: {
+      dependencies: {
+        snsClient,
+        sqsClient,
+        stsClient,
+        logger: globalLogger,
+        errorReporter,
+        consumerErrorResolver: new SnsConsumerErrorResolver(),
+        transactionObservabilityManager: new NoopObservabilityManager(),
+      },
+      creationConfig: {
+        topic: { Name: 'user-cache-invalidations' },
+        // Each instance MUST use a unique queue name (e.g. include the host id):
+        queue: { QueueName: `user-cache-invalidations-${process.env.HOSTNAME}` },
+      },
+    },
+  })
+
+const userLoader = new Loader<User>({
+  inMemoryCache: { ttlInMsecs: 1000 * 60 * 5 },
+  asyncCache: yourAsyncCache,
+  notificationConsumer,
+  notificationPublisher,
+})
+
+await userLoader.init()
+await userLoader.invalidateCacheFor('123') // fans out to every other instance
+```
+
+Each consumer needs its **own** SQS queue subscribed to the shared topic; SNS handles the fan-out. If two instances share a queue, only one of them will receive each invalidation message.
+
+## Group notification pair
+
+For `GroupLoader`, use `createGroupNotificationPair` with the same shape:
+
+```ts
+import { GroupLoader } from 'layered-loader'
+import { createGroupNotificationPair } from '@layered-loader/sqs'
+
+const { publisher: notificationPublisher, consumer: notificationConsumer } =
+  createGroupNotificationPair<User>({
+    publisher: { dependencies, creationConfig: { topic: { Name: 'tenant-cache-invalidations' } } },
+    consumer: {
+      dependencies: consumerDependencies,
+      creationConfig: {
+        topic: { Name: 'tenant-cache-invalidations' },
+        queue: { QueueName: `tenant-cache-invalidations-${process.env.HOSTNAME}` },
+      },
+    },
+  })
+
+const userLoader = new GroupLoader<User>({
+  inMemoryCache: { ttlInMsecs: 1000 * 60 * 5 },
+  asyncCache: yourAsyncCache,
+  notificationConsumer,
+  notificationPublisher,
+})
+
+await userLoader.invalidateCacheFor('user-1', 'tenant-A')
+```
+
+## Locator vs creation config
+
+Both publisher and consumer accept a discriminated config:
+
+| Field | Behaviour |
+| --- | --- |
+| `creationConfig` | Auto-creates the resource (`topic`, `queue`, `subscription`) on `subscribe()` if it does not exist. |
+| `locatorConfig`  | Reuses pre-provisioned resources. Throws if they are missing. |
+
+For a consumer in `locatorConfig` mode, you must supply enough information to resolve the topic, queue, and subscription:
+
+```ts
+consumer: {
+  dependencies: consumerDependencies,
+  locatorConfig: {
+    topicArn: 'arn:aws:sns:us-east-1:000000000000:user-cache-invalidations',
+    queueUrl: 'https://sqs.us-east-1.amazonaws.com/000000000000/cache-q-host-1',
+    subscriptionArn: 'arn:aws:sns:...:subscription/...',
+  },
+}
+```
+
+You can grab those identifiers off a previously-initialised consumer/publisher:
+
+```ts
+await pair.publisher.subscribe()
+await pair.consumer.subscribe()
+console.log(pair.publisher.topicArn)
+console.log(pair.consumer.subscriptionArn, pair.consumer.queueUrl)
+```
+
+If you need to override defaults of the SNS subscription (filter policy, raw delivery, etc.), pass `subscriptionConfig: SqsSubscriptionOptions` to the consumer config.
+
+## How invalidation flows through SNS/SQS
+
+```
+┌──────────────────┐                    SNS topic                     ┌──────────────────┐
+│  Instance A      │   publisher ────────────────────────────▶  ┌──── │   Instance B     │
+│  Loader          │                                              │ ───┴── consumer.delete(key)
+│                  │   consumer ──── (own queue, self-skip)       │
+└──────────────────┘                                              │ ───┬── consumer.delete(key)
+                                                                  └──── │   Instance C    │
+                                                                        └──────────────────┘
+```
+
+Each `Loader.invalidateCacheFor(...)` call publishes a JSON command (`DELETE`, `DELETE_MANY`, `SET`, `CLEAR`) to the SNS topic. SNS fan-outs to every subscribed SQS queue, and each consumer applies the command to its local in-memory cache.
+
+## Self-message filtering and `serverUuid`
+
+Every published command carries an `originUuid`. A consumer skips a command whose `originUuid` matches its own `serverUuid`, preventing instance A from re-applying its own invalidations bouncing back through SNS.
+
+`createNotificationPair` (and `createGroupNotificationPair`) generate one `serverUuid` shared by both the publisher and the consumer it returns. You can override it with the `serverUuid` field if you need stable identifiers across restarts (e.g. when locating an existing subscription).
+
+## Flexible invalidation triggers
+
+A *trigger* lets you treat any upstream messaging system as a source of cache-invalidation events without that system knowing the cache exists. The trigger:
+
+1. Subscribes to a queue or topic you do not own.
+2. Validates each message with a Zod schema.
+3. Runs your **resolver** to extract entity ids (and optionally a group).
+4. Forwards the resulting actions through a configured `NotificationPublisher`, fanning them out to every cache instance.
+
+The actions and resolver shape are transport-agnostic — the same `InvalidationResolver`, `InvalidationAction`, dispatch helpers, and `InvalidationTrigger` interface can power future RabbitMQ / Kafka / Pub/Sub adapters. The SNS/SQS adapters live in this package.
+
+### Triggering from an existing SNS topic
+
+Use `sourceType: 'sns-topic'` with either creation or locator config. The trigger creates (or reuses) an SQS queue and subscribes it to the upstream topic.
+
+```ts
+import { randomUUID } from 'node:crypto'
+import { z } from 'zod'
+import {
+  createNotificationPair,
+  SqsInvalidationTrigger,
+  SqsNotificationPublisher,
+} from '@layered-loader/sqs'
+
+const USER_EVENT_SCHEMA = z.object({
+  type: z.enum(['user.updated', 'user.deleted', 'user.bulk-updated']),
+  userId: z.string().optional(),
+  userIds: z.array(z.string()).optional(),
+})
+
+// 1. The cache cluster's own invalidation pair (same as any deployment):
+const cachePair = createNotificationPair<User>({
+  publisher: { dependencies: pubDeps, creationConfig: { topic: { Name: 'user-cache-invalidations' } } },
+  consumer:  {
+    dependencies: consumerDeps,
+    creationConfig: {
+      topic: { Name: 'user-cache-invalidations' },
+      queue: { QueueName: `user-cache-invalidations-${process.env.HOSTNAME}` },
+    },
+  },
+})
+
+// 2. A separate publisher dedicated to trigger-emitted messages.
+//    Its serverUuid MUST be different from cachePair's so the local consumer
+//    treats trigger messages as foreign and applies them.
+const triggerPublisher = new SqsNotificationPublisher<User>({
+  serverUuid: randomUUID(),
+  dependencies: pubDeps,
+  locatorConfig: { topicName: 'user-cache-invalidations' },
+})
+
+// 3. The trigger itself, subscribed to an upstream domain-event topic
+//    owned by another service:
+const trigger = new SqsInvalidationTrigger<z.infer<typeof USER_EVENT_SCHEMA>>({
+  sourceType: 'sns-topic',
+  dependencies: consumerDeps,
+  creationConfig: {
+    topic: { Name: 'domain-events.users' }, // owned by an upstream service
+    queue: { QueueName: `cache-trigger-${process.env.HOSTNAME}` },
+  },
+  messageSchema: USER_EVENT_SCHEMA,
+  publisher: triggerPublisher,
+  resolver: (msg) => {
+    switch (msg.type) {
+      case 'user.updated':
+      case 'user.deleted':
+        return msg.userId ? { kind: 'delete', key: msg.userId } : null
+      case 'user.bulk-updated':
+        return msg.userIds?.length
+          ? { kind: 'deleteMany', keys: msg.userIds }
+          : null
+    }
+  },
+})
+
+await trigger.start()
+```
+
+### Triggering from an existing SQS queue
+
+If the upstream system writes directly to an SQS queue (no SNS topic in the middle), use `sourceType: 'sqs-queue'`:
+
+```ts
+import { SqsInvalidationTrigger } from '@layered-loader/sqs'
+
+const trigger = new SqsInvalidationTrigger<DomainEvent>({
+  sourceType: 'sqs-queue',
+  dependencies: sqsConsumerDeps,
+  locatorConfig: {
+    queueUrl: 'https://sqs.us-east-1.amazonaws.com/000000000000/domain-events',
+  },
+  messageSchema: DOMAIN_EVENT_SCHEMA,
+  publisher: triggerPublisher,
+  resolver: (msg) => /* ... */,
+})
+
+await trigger.start()
+```
+
+The pure-SQS source uses `@message-queue-toolkit/sqs`'s consumer directly and does not require SNS / STS clients in its dependencies.
+
+### Group triggers
+
+`SqsGroupInvalidationTrigger` mirrors the flat trigger but emits `GroupInvalidationAction`s:
+
+```ts
+import { SqsGroupInvalidationTrigger, SqsGroupNotificationPublisher } from '@layered-loader/sqs'
+
+const triggerPublisher = new SqsGroupNotificationPublisher<User>({
+  serverUuid: randomUUID(),
+  dependencies: pubDeps,
+  locatorConfig: { topicName: 'tenant-cache-invalidations' },
+})
+
+const trigger = new SqsGroupInvalidationTrigger<TenantEvent>({
+  sourceType: 'sns-topic',
+  dependencies: consumerDeps,
+  creationConfig: {
+    topic: { Name: 'tenant-events' },
+    queue: { QueueName: `tenant-trigger-${process.env.HOSTNAME}` },
+  },
+  messageSchema: TENANT_EVENT_SCHEMA,
+  publisher: triggerPublisher,
+  resolver: (msg) => {
+    if (msg.type === 'tenant.purged') return { kind: 'deleteGroup', group: msg.tenantId }
+    if (msg.type === 'tenant.user.updated' && msg.userId) {
+      return { kind: 'deleteFromGroup', key: msg.userId, group: msg.tenantId }
+    }
+    return null
+  },
+})
+
+await trigger.start()
+```
+
+### Resolver semantics
+
+A resolver receives the validated `TMessage` and returns:
+
+- A single `InvalidationAction` / `GroupInvalidationAction` — applied immediately.
+- An array of actions — applied sequentially, preserving emission order.
+- `null` or `undefined` — skip the message (the source treats it as successfully processed).
+
+Flat actions:
+
+```ts
+type InvalidationAction =
+  | { kind: 'delete'; key: string }
+  | { kind: 'deleteMany'; keys: readonly string[] }
+  | { kind: 'set'; key: string; value: unknown }
+  | { kind: 'clear' }
+```
+
+Group actions:
+
+```ts
+type GroupInvalidationAction =
+  | { kind: 'deleteFromGroup'; key: string; group: string }
+  | { kind: 'deleteGroup'; group: string }
+  | { kind: 'clear' }
+```
+
+Resolvers may be `async`; the trigger awaits before publishing.
+
+### The trigger-publisher rule
+
+> **The trigger's publisher MUST have a `serverUuid` distinct from any local notification pair.**
+
+Why: a `Loader` invalidates its own in-memory cache *before* publishing, so the pair's consumer is configured to skip messages with a matching `originUuid` (otherwise the pair would re-process its own invalidations). Trigger-emitted invalidations come from outside any Loader, so the pair's consumer must treat them as foreign and apply them. Sharing `serverUuid` means the local in-memory cache silently misses every trigger-driven invalidation.
+
+In practice: build the trigger publisher with `randomUUID()` even when it points at the same SNS topic as your `createNotificationPair` publisher. The example snippets above all show this pattern.
+
+### Error handling and retries
+
+If the resolver or publish step throws, the trigger:
+
+1. Invokes the optional `errorHandler(err, channel)` for observability.
+2. Re-throws so `message-queue-toolkit` can apply its standard SQS retry / dead-letter behaviour.
+
+For schema-violation errors, the message is failed by `message-queue-toolkit` before the resolver runs and goes back to the queue (and ultimately to a DLQ if you configured one). Configure DLQ on the trigger's queue creation config to bound retries.
+
+### Lifecycle
+
+```ts
+const trigger = new SqsInvalidationTrigger({ ... })
+
+await trigger.start() // idempotent; concurrent calls share one start
+await trigger.stop()  // idempotent; awaits any in-flight start
+await trigger.start() // restart is supported
+```
+
+## Testing with fauxqs
+
+For local development and tests, swap the AWS SDK endpoint for [fauxqs](https://github.com/kibertoad/fauxqs):
+
+```ts
+import { startFauxqs } from 'fauxqs'
+import { SNSClient } from '@aws-sdk/client-sns'
+import { SQSClient } from '@aws-sdk/client-sqs'
+import { STSClient } from '@aws-sdk/client-sts'
+
+const server = await startFauxqs({ port: 0, logger: false })
+const credentials = { accessKeyId: 'test', secretAccessKey: 'test' }
+const region = 'us-east-1'
+
+const snsClient = new SQSClient({ endpoint: server.address, region, credentials })
+// ...
+await server.stop()
+```
+
+This package's own integration tests run entirely against fauxqs in-process — see `packages/sqs/test`.
+
+## API reference
+
+### Notification pair
+
+| Symbol | Purpose |
+| --- | --- |
+| `createNotificationPair<T>(config)` | Returns `{ publisher, consumer }` for flat-cache invalidation. |
+| `createGroupNotificationPair<T>(config)` | Same, but for group caches. |
+| `SqsNotificationPublisher<T>` | Lower-level constructor; useful for trigger publishers (independent UUID). |
+| `SqsNotificationConsumer<T>` | Lower-level constructor; rarely used directly. |
+| `SqsGroupNotificationPublisher<T>` / `SqsGroupNotificationConsumer<T>` | Group-cache equivalents. |
+| `SqsSubscriptionOptions` | Type for `subscriptionConfig` overrides. |
+
+### Triggers
+
+| Symbol | Purpose |
+| --- | --- |
+| `SqsInvalidationTrigger<TMessage>` | Flat-cache trigger (SQS or SNS+SQS source). |
+| `SqsGroupInvalidationTrigger<TMessage>` | Group-cache trigger. |
+| `SqsTriggerSource` | Discriminated source config (`'sqs-queue'` or `'sns-topic'`, with `creationConfig` or `locatorConfig`). |
+| `InvalidationAction` / `GroupInvalidationAction` | Action ADTs returned by resolvers. |
+| `InvalidationResolver<TMessage, TAction>` | Resolver signature. |
+| `InvalidationTrigger` | `start()` / `stop()` lifecycle interface. |
+| `runFlatPipeline` / `runGroupPipeline` | Reusable resolver + dispatch helpers (transport-agnostic). |
+| `applyFlatAction` / `applyGroupAction` | Apply a single resolved action to a publisher. |
+| `AbstractSqsTrigger` | Base class for building custom SQS-based triggers. |
+| `deriveTriggerChannelName` | Helper that derives a logical channel name from a source config. |

--- a/packages/sqs/README.md
+++ b/packages/sqs/README.md
@@ -375,24 +375,34 @@ await trigger.start() // restart is supported
 
 ## Testing with fauxqs
 
-For local development and tests, swap the AWS SDK endpoint for [fauxqs](https://github.com/kibertoad/fauxqs):
+For local development and tests, swap the AWS SDK endpoint for [fauxqs](https://github.com/kibertoad/fauxqs). Two modes are useful in practice:
+
+### In-process (recommended for tests)
+
+Sub-second startup, no daemon required, isolated per test process. This package's own integration tests run this way — see `packages/sqs/test/globalSetup.ts`.
 
 ```ts
 import { startFauxqs } from 'fauxqs'
-import { SNSClient } from '@aws-sdk/client-sns'
 import { SQSClient } from '@aws-sdk/client-sqs'
-import { STSClient } from '@aws-sdk/client-sts'
 
 const server = await startFauxqs({ port: 0, logger: false })
 const credentials = { accessKeyId: 'test', secretAccessKey: 'test' }
 const region = 'us-east-1'
 
-const snsClient = new SQSClient({ endpoint: server.address, region, credentials })
+const sqsClient = new SQSClient({ endpoint: server.address, region, credentials })
 // ...
 await server.stop()
 ```
 
-This package's own integration tests run entirely against fauxqs in-process — see `packages/sqs/test`.
+### Docker-compose (for app smoke testing)
+
+The repository root's `docker-compose.yml` includes a `fauxqs` service on port `4566` for local app runs against a stable endpoint:
+
+```bash
+docker compose up fauxqs
+```
+
+Then point your AWS SDK clients at `http://localhost:4566`.
 
 ## API reference
 

--- a/packages/sqs/index.ts
+++ b/packages/sqs/index.ts
@@ -46,3 +46,30 @@ export {
   type DeleteGroupNotificationCommand,
   type GroupNotificationCommand,
 } from './lib/groupNotificationSchemas.js'
+
+// Flexible invalidation triggers
+export type {
+  GroupInvalidationAction,
+  InvalidationAction,
+  InvalidationResolver,
+  InvalidationTrigger,
+  ResolverOutput,
+  TriggerErrorHandler,
+} from './lib/triggers/types.js'
+export {
+  applyFlatAction,
+  applyGroupAction,
+  runFlatPipeline,
+  runGroupPipeline,
+} from './lib/triggers/dispatch.js'
+export {
+  SqsInvalidationTrigger,
+  type SqsInvalidationTriggerParams,
+  type SqsTriggerSourceConfig,
+  type TriggerSubscriptionOptions,
+} from './lib/triggers/SqsInvalidationTrigger.js'
+export {
+  SqsGroupInvalidationTrigger,
+  type SqsGroupInvalidationTriggerParams,
+  type SqsGroupTriggerSourceConfig,
+} from './lib/triggers/SqsGroupInvalidationTrigger.js'

--- a/packages/sqs/index.ts
+++ b/packages/sqs/index.ts
@@ -63,10 +63,14 @@ export {
   runGroupPipeline,
 } from './lib/triggers/dispatch.js'
 export {
+  AbstractSqsTrigger,
+  deriveTriggerChannelName,
+  type SqsTriggerSource,
+} from './lib/triggers/AbstractSqsTrigger.js'
+export {
   SqsInvalidationTrigger,
   type SqsInvalidationTriggerParams,
   type SqsTriggerSourceConfig,
-  type TriggerSubscriptionOptions,
 } from './lib/triggers/SqsInvalidationTrigger.js'
 export {
   SqsGroupInvalidationTrigger,

--- a/packages/sqs/index.ts
+++ b/packages/sqs/index.ts
@@ -1,0 +1,48 @@
+export {
+  SqsNotificationPublisher,
+  type SqsNotificationPublisherConfig,
+  type SqsNotificationPublisherParams,
+} from './lib/SqsNotificationPublisher.js'
+export {
+  SqsNotificationConsumer,
+  type SqsNotificationConsumerConfig,
+  type SqsNotificationConsumerParams,
+  type SqsSubscriptionOptions,
+} from './lib/SqsNotificationConsumer.js'
+export {
+  SqsGroupNotificationPublisher,
+  type SqsGroupNotificationPublisherConfig,
+  type SqsGroupNotificationPublisherParams,
+} from './lib/SqsGroupNotificationPublisher.js'
+export {
+  SqsGroupNotificationConsumer,
+  type SqsGroupNotificationConsumerConfig,
+  type SqsGroupNotificationConsumerParams,
+} from './lib/SqsGroupNotificationConsumer.js'
+export {
+  createNotificationPair,
+  type SqsNotificationConfig,
+} from './lib/SqsNotificationFactory.js'
+export {
+  createGroupNotificationPair,
+  type SqsGroupNotificationConfig,
+} from './lib/SqsGroupNotificationFactory.js'
+export {
+  CLEAR_COMMAND,
+  DELETE_COMMAND,
+  DELETE_MANY_COMMAND,
+  SET_COMMAND,
+  type ClearNotificationCommand,
+  type DeleteManyNotificationCommand,
+  type DeleteNotificationCommand,
+  type NotificationCommand,
+  type SetNotificationCommand,
+} from './lib/notificationSchemas.js'
+export {
+  DELETE_FROM_GROUP_COMMAND,
+  DELETE_GROUP_COMMAND,
+  type ClearGroupNotificationCommand,
+  type DeleteFromGroupNotificationCommand,
+  type DeleteGroupNotificationCommand,
+  type GroupNotificationCommand,
+} from './lib/groupNotificationSchemas.js'

--- a/packages/sqs/lib/SqsGroupNotificationConsumer.ts
+++ b/packages/sqs/lib/SqsGroupNotificationConsumer.ts
@@ -1,0 +1,158 @@
+import { MessageHandlerConfigBuilder } from '@message-queue-toolkit/core'
+import {
+  AbstractSnsSqsConsumer,
+  type SNSSQSConsumerDependencies,
+  type SNSSQSConsumerOptions,
+  type SNSSQSCreationConfig,
+  type SNSSQSQueueLocatorType,
+} from '@message-queue-toolkit/sns'
+import type { ConsumerErrorHandler, SynchronousGroupCache } from 'layered-loader'
+import { AbstractNotificationConsumer } from 'layered-loader'
+import type { SqsSubscriptionOptions } from './SqsNotificationConsumer.js'
+import {
+  CLEAR_GROUP_NOTIFICATION_SCHEMA,
+  DELETE_FROM_GROUP_NOTIFICATION_SCHEMA,
+  DELETE_GROUP_NOTIFICATION_SCHEMA,
+  type GroupNotificationCommand,
+  NOTIFICATION_ID_FIELD,
+  NOTIFICATION_TIMESTAMP_FIELD,
+  NOTIFICATION_TYPE_FIELD,
+} from './groupNotificationSchemas.js'
+
+export type SqsGroupNotificationConsumerConfig =
+  | { creationConfig: SNSSQSCreationConfig; locatorConfig?: never }
+  | { creationConfig?: never; locatorConfig: SNSSQSQueueLocatorType }
+
+export type SqsGroupNotificationConsumerParams = {
+  serverUuid: string
+  errorHandler?: ConsumerErrorHandler
+  dependencies: SNSSQSConsumerDependencies
+  subscriptionConfig?: SqsSubscriptionOptions
+} & SqsGroupNotificationConsumerConfig
+
+type ConsumerContext<LoadedValue> = {
+  serverUuid: string
+  targetCache: SynchronousGroupCache<LoadedValue>
+}
+
+class SnsSqsGroupInvalidationConsumer<LoadedValue> extends AbstractSnsSqsConsumer<
+  GroupNotificationCommand,
+  ConsumerContext<LoadedValue>
+> {
+  constructor(
+    dependencies: SNSSQSConsumerDependencies,
+    options: SNSSQSConsumerOptions<
+      GroupNotificationCommand,
+      ConsumerContext<LoadedValue>,
+      undefined
+    >,
+    context: ConsumerContext<LoadedValue>,
+  ) {
+    super(dependencies, options, context)
+  }
+
+  get publicTopicArn(): string {
+    return this.topicArn
+  }
+
+  get publicSubscriptionArn(): string {
+    return this.subscriptionArn
+  }
+
+  get publicQueueUrl(): string {
+    return this.queueUrl
+  }
+}
+
+export class SqsGroupNotificationConsumer<LoadedValue> extends AbstractNotificationConsumer<
+  LoadedValue,
+  SynchronousGroupCache<LoadedValue>
+> {
+  private readonly params: SqsGroupNotificationConsumerParams
+  private internalConsumer?: SnsSqsGroupInvalidationConsumer<LoadedValue>
+
+  constructor(params: SqsGroupNotificationConsumerParams) {
+    super(params.serverUuid, params.errorHandler)
+    this.params = params
+  }
+
+  async subscribe(): Promise<unknown> {
+    if (this.internalConsumer) {
+      return this.internalConsumer
+    }
+
+    if (!this.targetCache) {
+      throw new Error(
+        'targetCache must be set via setTargetCache() before subscribe() is called',
+      )
+    }
+
+    const handlers = new MessageHandlerConfigBuilder<
+      GroupNotificationCommand,
+      ConsumerContext<LoadedValue>
+    >()
+      .addConfig(DELETE_FROM_GROUP_NOTIFICATION_SCHEMA, async (message, ctx) => {
+        if (message.originUuid !== ctx.serverUuid) {
+          ctx.targetCache.deleteFromGroup(message.key, message.group)
+        }
+        return { result: 'success' }
+      })
+      .addConfig(DELETE_GROUP_NOTIFICATION_SCHEMA, async (message, ctx) => {
+        if (message.originUuid !== ctx.serverUuid) {
+          ctx.targetCache.deleteGroup(message.group)
+        }
+        return { result: 'success' }
+      })
+      .addConfig(CLEAR_GROUP_NOTIFICATION_SCHEMA, async (message, ctx) => {
+        if (message.originUuid !== ctx.serverUuid) {
+          ctx.targetCache.clear()
+        }
+        return { result: 'success' }
+      })
+      .build()
+
+    const options: SNSSQSConsumerOptions<
+      GroupNotificationCommand,
+      ConsumerContext<LoadedValue>,
+      undefined
+    > = {
+      handlers,
+      messageTypeResolver: { messageTypePath: NOTIFICATION_TYPE_FIELD },
+      messageIdField: NOTIFICATION_ID_FIELD,
+      messageTimestampField: NOTIFICATION_TIMESTAMP_FIELD,
+      subscriptionConfig: this.params.subscriptionConfig ?? { updateAttributesIfExists: false },
+      ...(this.params.creationConfig
+        ? { creationConfig: this.params.creationConfig }
+        : { locatorConfig: this.params.locatorConfig }),
+    }
+
+    this.internalConsumer = new SnsSqsGroupInvalidationConsumer<LoadedValue>(
+      this.params.dependencies,
+      options,
+      { serverUuid: this.serverUuid, targetCache: this.targetCache },
+    )
+
+    await this.internalConsumer.init()
+    await this.internalConsumer.start()
+    return this.internalConsumer
+  }
+
+  async close(): Promise<void> {
+    if (!this.internalConsumer) return
+    const consumer = this.internalConsumer
+    this.internalConsumer = undefined
+    await consumer.close()
+  }
+
+  get topicArn(): string | undefined {
+    return this.internalConsumer?.publicTopicArn
+  }
+
+  get subscriptionArn(): string | undefined {
+    return this.internalConsumer?.publicSubscriptionArn
+  }
+
+  get queueUrl(): string | undefined {
+    return this.internalConsumer?.publicQueueUrl
+  }
+}

--- a/packages/sqs/lib/SqsGroupNotificationConsumer.ts
+++ b/packages/sqs/lib/SqsGroupNotificationConsumer.ts
@@ -70,6 +70,7 @@ export class SqsGroupNotificationConsumer<LoadedValue> extends AbstractNotificat
 > {
   private readonly params: SqsGroupNotificationConsumerParams
   private internalConsumer?: SnsSqsGroupInvalidationConsumer<LoadedValue>
+  private subscribePromise?: Promise<SnsSqsGroupInvalidationConsumer<LoadedValue>>
 
   constructor(params: SqsGroupNotificationConsumerParams) {
     super(params.serverUuid, params.errorHandler)
@@ -79,6 +80,9 @@ export class SqsGroupNotificationConsumer<LoadedValue> extends AbstractNotificat
   async subscribe(): Promise<unknown> {
     if (this.internalConsumer) {
       return this.internalConsumer
+    }
+    if (this.subscribePromise) {
+      return this.subscribePromise
     }
 
     if (!this.targetCache) {
@@ -126,18 +130,34 @@ export class SqsGroupNotificationConsumer<LoadedValue> extends AbstractNotificat
         : { locatorConfig: this.params.locatorConfig }),
     }
 
-    this.internalConsumer = new SnsSqsGroupInvalidationConsumer<LoadedValue>(
+    const consumer = new SnsSqsGroupInvalidationConsumer<LoadedValue>(
       this.params.dependencies,
       options,
       { serverUuid: this.serverUuid, targetCache: this.targetCache },
     )
 
-    await this.internalConsumer.init()
-    await this.internalConsumer.start()
-    return this.internalConsumer
+    // Single-flight: concurrent subscribe() calls share one init/start; the
+    // internal consumer is only assigned once both succeed.
+    this.subscribePromise = (async () => {
+      try {
+        await consumer.init()
+        await consumer.start()
+        this.internalConsumer = consumer
+        return consumer
+      } catch (err) {
+        await consumer.close().catch(() => undefined)
+        throw err
+      } finally {
+        this.subscribePromise = undefined
+      }
+    })()
+    return this.subscribePromise
   }
 
   async close(): Promise<void> {
+    if (this.subscribePromise) {
+      await this.subscribePromise.catch(() => undefined)
+    }
     if (!this.internalConsumer) return
     const consumer = this.internalConsumer
     this.internalConsumer = undefined

--- a/packages/sqs/lib/SqsGroupNotificationFactory.ts
+++ b/packages/sqs/lib/SqsGroupNotificationFactory.ts
@@ -1,0 +1,74 @@
+import { randomUUID } from 'node:crypto'
+import type { SNSDependencies, SNSSQSConsumerDependencies } from '@message-queue-toolkit/sns'
+import type { ConsumerErrorHandler, PublisherErrorHandler } from 'layered-loader'
+import {
+  SqsGroupNotificationConsumer,
+  type SqsGroupNotificationConsumerConfig,
+} from './SqsGroupNotificationConsumer.js'
+import {
+  SqsGroupNotificationPublisher,
+  type SqsGroupNotificationPublisherConfig,
+} from './SqsGroupNotificationPublisher.js'
+import type { SqsSubscriptionOptions } from './SqsNotificationConsumer.js'
+
+export type SqsGroupNotificationConfig = {
+  channel?: string
+  serverUuid?: string
+  publisherErrorHandler?: PublisherErrorHandler
+  consumerErrorHandler?: ConsumerErrorHandler
+  publisher: {
+    dependencies: SNSDependencies
+  } & SqsGroupNotificationPublisherConfig
+  consumer: {
+    dependencies: SNSSQSConsumerDependencies
+    subscriptionConfig?: SqsSubscriptionOptions
+  } & SqsGroupNotificationConsumerConfig
+}
+
+export function createGroupNotificationPair<LoadedValue>(config: SqsGroupNotificationConfig): {
+  publisher: SqsGroupNotificationPublisher<LoadedValue>
+  consumer: SqsGroupNotificationConsumer<LoadedValue>
+} {
+  const serverUuid = config.serverUuid ?? randomUUID()
+
+  const publisherConfig = config.publisher
+  const consumerConfig = config.consumer
+
+  const publisher = new SqsGroupNotificationPublisher<LoadedValue>(
+    publisherConfig.creationConfig
+      ? {
+          serverUuid,
+          channel: config.channel,
+          errorHandler: config.publisherErrorHandler,
+          dependencies: publisherConfig.dependencies,
+          creationConfig: publisherConfig.creationConfig,
+        }
+      : {
+          serverUuid,
+          channel: config.channel,
+          errorHandler: config.publisherErrorHandler,
+          dependencies: publisherConfig.dependencies,
+          locatorConfig: publisherConfig.locatorConfig,
+        },
+  )
+
+  const consumer = new SqsGroupNotificationConsumer<LoadedValue>(
+    consumerConfig.creationConfig
+      ? {
+          serverUuid,
+          errorHandler: config.consumerErrorHandler,
+          dependencies: consumerConfig.dependencies,
+          subscriptionConfig: consumerConfig.subscriptionConfig,
+          creationConfig: consumerConfig.creationConfig,
+        }
+      : {
+          serverUuid,
+          errorHandler: config.consumerErrorHandler,
+          dependencies: consumerConfig.dependencies,
+          subscriptionConfig: consumerConfig.subscriptionConfig,
+          locatorConfig: consumerConfig.locatorConfig,
+        },
+  )
+
+  return { publisher, consumer }
+}

--- a/packages/sqs/lib/SqsGroupNotificationPublisher.ts
+++ b/packages/sqs/lib/SqsGroupNotificationPublisher.ts
@@ -1,0 +1,146 @@
+import { randomUUID } from 'node:crypto'
+import {
+  AbstractSnsPublisher,
+  type SNSCreationConfig,
+  type SNSDependencies,
+  type SNSPublisherOptions,
+  type SNSTopicLocatorType,
+} from '@message-queue-toolkit/sns'
+import type { GroupNotificationPublisher, PublisherErrorHandler } from 'layered-loader'
+import {
+  CLEAR_COMMAND,
+  DELETE_FROM_GROUP_COMMAND,
+  DELETE_GROUP_COMMAND,
+  GROUP_NOTIFICATION_SCHEMAS,
+  type GroupNotificationCommand,
+  NOTIFICATION_ID_FIELD,
+  NOTIFICATION_TIMESTAMP_FIELD,
+  NOTIFICATION_TYPE_FIELD,
+} from './groupNotificationSchemas.js'
+
+const DEFAULT_PUBLISHER_ERROR_HANDLER: PublisherErrorHandler = (err, channel, logger) => {
+  logger.error(`Error while publishing notification to channel ${channel}: ${err.message}`)
+}
+
+class SnsGroupInvalidationPublisher extends AbstractSnsPublisher<
+  GroupNotificationCommand
+> {
+  get publicTopicArn(): string {
+    return this.topicArn
+  }
+}
+
+export type SqsGroupNotificationPublisherConfig =
+  | { creationConfig: SNSCreationConfig; locatorConfig?: never }
+  | { creationConfig?: never; locatorConfig: SNSTopicLocatorType }
+
+export type SqsGroupNotificationPublisherParams = {
+  serverUuid: string
+  errorHandler?: PublisherErrorHandler
+  channel?: string
+  dependencies: SNSDependencies
+} & SqsGroupNotificationPublisherConfig
+
+export class SqsGroupNotificationPublisher<LoadedValue>
+  implements GroupNotificationPublisher<LoadedValue>
+{
+  public readonly channel: string
+  public readonly errorHandler: PublisherErrorHandler
+
+  private readonly serverUuid: string
+  private readonly publisher: SnsGroupInvalidationPublisher
+  private initPromise?: Promise<void>
+
+  constructor(params: SqsGroupNotificationPublisherParams) {
+    this.serverUuid = params.serverUuid
+    this.errorHandler = params.errorHandler ?? DEFAULT_PUBLISHER_ERROR_HANDLER
+    this.channel = resolveChannelName(params)
+
+    const options: SNSPublisherOptions<GroupNotificationCommand> = {
+      messageSchemas: GROUP_NOTIFICATION_SCHEMAS as unknown as ReadonlyArray<
+        // biome-ignore lint/suspicious/noExplicitAny: schema array is heterogeneous
+        any
+      >,
+      messageTypeResolver: { messageTypePath: NOTIFICATION_TYPE_FIELD },
+      messageIdField: NOTIFICATION_ID_FIELD,
+      messageTimestampField: NOTIFICATION_TIMESTAMP_FIELD,
+      ...(params.creationConfig
+        ? { creationConfig: params.creationConfig }
+        : { locatorConfig: params.locatorConfig }),
+    } as SNSPublisherOptions<GroupNotificationCommand>
+
+    this.publisher = new SnsGroupInvalidationPublisher(params.dependencies, options)
+  }
+
+  async subscribe(): Promise<unknown> {
+    if (!this.initPromise) {
+      this.initPromise = this.publisher.init()
+    }
+    return this.initPromise
+  }
+
+  deleteFromGroup(key: string, group: string): Promise<unknown> {
+    return this.publishCommand({
+      type: DELETE_FROM_GROUP_COMMAND,
+      key,
+      group,
+      ...this.buildEnvelope(),
+    })
+  }
+
+  deleteGroup(group: string): Promise<unknown> {
+    return this.publishCommand({
+      type: DELETE_GROUP_COMMAND,
+      group,
+      ...this.buildEnvelope(),
+    })
+  }
+
+  clear(): Promise<unknown> {
+    return this.publishCommand({
+      type: CLEAR_COMMAND,
+      ...this.buildEnvelope(),
+    })
+  }
+
+  async close(): Promise<void> {
+    await this.publisher.close()
+  }
+
+  get topicArn(): string | undefined {
+    return this.initPromise ? this.publisher.publicTopicArn : undefined
+  }
+
+  private async publishCommand(command: GroupNotificationCommand): Promise<void> {
+    await this.subscribe()
+    await this.publisher.publish(command as GroupNotificationCommand)
+  }
+
+  private buildEnvelope() {
+    return {
+      id: randomUUID(),
+      timestamp: new Date().toISOString(),
+      originUuid: this.serverUuid,
+    }
+  }
+}
+
+function resolveChannelName(params: SqsGroupNotificationPublisherParams): string {
+  if (params.channel) {
+    return params.channel
+  }
+
+  if (params.creationConfig?.topic?.Name) {
+    return params.creationConfig.topic.Name
+  }
+
+  if (params.locatorConfig?.topicName) {
+    return params.locatorConfig.topicName
+  }
+
+  if (params.locatorConfig?.topicArn) {
+    return params.locatorConfig.topicArn
+  }
+
+  return 'sqs-notification-channel'
+}

--- a/packages/sqs/lib/SqsGroupNotificationPublisher.ts
+++ b/packages/sqs/lib/SqsGroupNotificationPublisher.ts
@@ -7,6 +7,7 @@ import {
   type SNSTopicLocatorType,
 } from '@message-queue-toolkit/sns'
 import type { GroupNotificationPublisher, PublisherErrorHandler } from 'layered-loader'
+import { resolveChannelName } from './channelNameResolver.js'
 import {
   CLEAR_COMMAND,
   DELETE_FROM_GROUP_COMMAND,
@@ -50,31 +51,36 @@ export class SqsGroupNotificationPublisher<LoadedValue>
   private readonly serverUuid: string
   private readonly publisher: SnsGroupInvalidationPublisher
   private initPromise?: Promise<void>
+  private initialized = false
 
   constructor(params: SqsGroupNotificationPublisherParams) {
     this.serverUuid = params.serverUuid
     this.errorHandler = params.errorHandler ?? DEFAULT_PUBLISHER_ERROR_HANDLER
     this.channel = resolveChannelName(params)
 
-    const options: SNSPublisherOptions<GroupNotificationCommand> = {
-      messageSchemas: GROUP_NOTIFICATION_SCHEMAS as unknown as ReadonlyArray<
-        // biome-ignore lint/suspicious/noExplicitAny: schema array is heterogeneous
-        any
-      >,
+    // mqt's `messageSchemas` is `readonly ZodSchema<UnionType>[]`. Our schemas
+    // are narrower (one per command type) and `ZodSchema` is invariant in T,
+    // so the array of narrow schemas does not satisfy the broad type at the
+    // type level — even though mqt resolves them correctly at runtime via the
+    // configured `messageTypeResolver`.
+    const options = {
+      messageSchemas: GROUP_NOTIFICATION_SCHEMAS,
       messageTypeResolver: { messageTypePath: NOTIFICATION_TYPE_FIELD },
       messageIdField: NOTIFICATION_ID_FIELD,
       messageTimestampField: NOTIFICATION_TIMESTAMP_FIELD,
       ...(params.creationConfig
         ? { creationConfig: params.creationConfig }
         : { locatorConfig: params.locatorConfig }),
-    } as SNSPublisherOptions<GroupNotificationCommand>
+    } as unknown as SNSPublisherOptions<GroupNotificationCommand>
 
     this.publisher = new SnsGroupInvalidationPublisher(params.dependencies, options)
   }
 
   async subscribe(): Promise<unknown> {
     if (!this.initPromise) {
-      this.initPromise = this.publisher.init()
+      this.initPromise = this.publisher.init().then(() => {
+        this.initialized = true
+      })
     }
     return this.initPromise
   }
@@ -107,13 +113,18 @@ export class SqsGroupNotificationPublisher<LoadedValue>
     await this.publisher.close()
   }
 
+  /**
+   * Returns the resolved topic ARN. Available only after `subscribe()` (or the
+   * first publish) has fully completed; returns `undefined` while init is in
+   * flight or before it has been triggered.
+   */
   get topicArn(): string | undefined {
-    return this.initPromise ? this.publisher.publicTopicArn : undefined
+    return this.initialized ? this.publisher.publicTopicArn : undefined
   }
 
   private async publishCommand(command: GroupNotificationCommand): Promise<void> {
     await this.subscribe()
-    await this.publisher.publish(command as GroupNotificationCommand)
+    await this.publisher.publish(command)
   }
 
   private buildEnvelope() {
@@ -123,24 +134,4 @@ export class SqsGroupNotificationPublisher<LoadedValue>
       originUuid: this.serverUuid,
     }
   }
-}
-
-function resolveChannelName(params: SqsGroupNotificationPublisherParams): string {
-  if (params.channel) {
-    return params.channel
-  }
-
-  if (params.creationConfig?.topic?.Name) {
-    return params.creationConfig.topic.Name
-  }
-
-  if (params.locatorConfig?.topicName) {
-    return params.locatorConfig.topicName
-  }
-
-  if (params.locatorConfig?.topicArn) {
-    return params.locatorConfig.topicArn
-  }
-
-  return 'sqs-notification-channel'
 }

--- a/packages/sqs/lib/SqsGroupNotificationPublisher.ts
+++ b/packages/sqs/lib/SqsGroupNotificationPublisher.ts
@@ -76,13 +76,23 @@ export class SqsGroupNotificationPublisher<LoadedValue>
     this.publisher = new SnsGroupInvalidationPublisher(params.dependencies, options)
   }
 
-  async subscribe(): Promise<unknown> {
+  async subscribe(): Promise<void> {
+    if (this.initialized) return
+
     if (!this.initPromise) {
-      this.initPromise = this.publisher.init().then(() => {
-        this.initialized = true
-      })
+      this.initPromise = this.initializePublisher()
     }
     return this.initPromise
+  }
+
+  private async initializePublisher(): Promise<void> {
+    try {
+      await this.publisher.init()
+      this.initialized = true
+    } catch (err) {
+      this.initPromise = undefined
+      throw err
+    }
   }
 
   deleteFromGroup(key: string, group: string): Promise<unknown> {

--- a/packages/sqs/lib/SqsNotificationConsumer.ts
+++ b/packages/sqs/lib/SqsNotificationConsumer.ts
@@ -75,6 +75,7 @@ class SnsSqsInvalidationConsumer<LoadedValue> extends AbstractSnsSqsConsumer<
 export class SqsNotificationConsumer<LoadedValue> extends AbstractNotificationConsumer<LoadedValue> {
   private readonly params: SqsNotificationConsumerParams
   private internalConsumer?: SnsSqsInvalidationConsumer<LoadedValue>
+  private subscribePromise?: Promise<SnsSqsInvalidationConsumer<LoadedValue>>
 
   constructor(params: SqsNotificationConsumerParams) {
     super(params.serverUuid, params.errorHandler)
@@ -84,6 +85,9 @@ export class SqsNotificationConsumer<LoadedValue> extends AbstractNotificationCo
   async subscribe(): Promise<unknown> {
     if (this.internalConsumer) {
       return this.internalConsumer
+    }
+    if (this.subscribePromise) {
+      return this.subscribePromise
     }
 
     if (!this.targetCache) {
@@ -133,18 +137,35 @@ export class SqsNotificationConsumer<LoadedValue> extends AbstractNotificationCo
         : { locatorConfig: this.params.locatorConfig }),
     } as SNSSQSConsumerOptions<NotificationCommand, ConsumerContext<LoadedValue>, undefined>
 
-    this.internalConsumer = new SnsSqsInvalidationConsumer<LoadedValue>(
+    const consumer = new SnsSqsInvalidationConsumer<LoadedValue>(
       this.params.dependencies,
       options,
       { serverUuid: this.serverUuid, targetCache: this.targetCache },
     )
 
-    await this.internalConsumer.init()
-    await this.internalConsumer.start()
-    return this.internalConsumer
+    // Single-flight: concurrent subscribe() calls share one init/start; the
+    // internal consumer is only assigned once both succeed, so a partial
+    // failure leaves the instance in a re-tryable state.
+    this.subscribePromise = (async () => {
+      try {
+        await consumer.init()
+        await consumer.start()
+        this.internalConsumer = consumer
+        return consumer
+      } catch (err) {
+        await consumer.close().catch(() => undefined)
+        throw err
+      } finally {
+        this.subscribePromise = undefined
+      }
+    })()
+    return this.subscribePromise
   }
 
   async close(): Promise<void> {
+    if (this.subscribePromise) {
+      await this.subscribePromise.catch(() => undefined)
+    }
     if (!this.internalConsumer) return
     const consumer = this.internalConsumer
     this.internalConsumer = undefined

--- a/packages/sqs/lib/SqsNotificationConsumer.ts
+++ b/packages/sqs/lib/SqsNotificationConsumer.ts
@@ -1,0 +1,174 @@
+import type { SubscribeCommandInput } from '@aws-sdk/client-sns'
+import { MessageHandlerConfigBuilder } from '@message-queue-toolkit/core'
+import {
+  AbstractSnsSqsConsumer,
+  type SNSSQSConsumerDependencies,
+  type SNSSQSConsumerOptions,
+  type SNSSQSCreationConfig,
+  type SNSSQSQueueLocatorType,
+} from '@message-queue-toolkit/sns'
+import type { ConsumerErrorHandler, SynchronousCache } from 'layered-loader'
+import { AbstractNotificationConsumer } from 'layered-loader'
+import {
+  CLEAR_NOTIFICATION_SCHEMA,
+  DELETE_MANY_NOTIFICATION_SCHEMA,
+  DELETE_NOTIFICATION_SCHEMA,
+  type NotificationCommand,
+  NOTIFICATION_ID_FIELD,
+  NOTIFICATION_TIMESTAMP_FIELD,
+  NOTIFICATION_TYPE_FIELD,
+  SET_NOTIFICATION_SCHEMA,
+} from './notificationSchemas.js'
+
+/**
+ * Mirror of `SNSSubscriptionOptions` from `@message-queue-toolkit/sns/utils/snsSubscriber`,
+ * which is not re-exported from the package's main entry point.
+ */
+export type SqsSubscriptionOptions = Omit<
+  SubscribeCommandInput,
+  'TopicArn' | 'Endpoint' | 'Protocol' | 'ReturnSubscriptionArn'
+> & {
+  updateAttributesIfExists: boolean
+}
+
+export type SqsNotificationConsumerConfig =
+  | { creationConfig: SNSSQSCreationConfig; locatorConfig?: never }
+  | { creationConfig?: never; locatorConfig: SNSSQSQueueLocatorType }
+
+export type SqsNotificationConsumerParams = {
+  serverUuid: string
+  errorHandler?: ConsumerErrorHandler
+  dependencies: SNSSQSConsumerDependencies
+  subscriptionConfig?: SqsSubscriptionOptions
+} & SqsNotificationConsumerConfig
+
+type ConsumerContext<LoadedValue> = {
+  serverUuid: string
+  targetCache: SynchronousCache<LoadedValue>
+}
+
+class SnsSqsInvalidationConsumer<LoadedValue> extends AbstractSnsSqsConsumer<
+  NotificationCommand,
+  ConsumerContext<LoadedValue>
+> {
+  constructor(
+    dependencies: SNSSQSConsumerDependencies,
+    options: SNSSQSConsumerOptions<NotificationCommand, ConsumerContext<LoadedValue>, undefined>,
+    context: ConsumerContext<LoadedValue>,
+  ) {
+    super(dependencies, options, context)
+  }
+
+  get publicTopicArn(): string {
+    return this.topicArn
+  }
+
+  get publicSubscriptionArn(): string {
+    return this.subscriptionArn
+  }
+
+  get publicQueueUrl(): string {
+    return this.queueUrl
+  }
+}
+
+export class SqsNotificationConsumer<LoadedValue> extends AbstractNotificationConsumer<LoadedValue> {
+  private readonly params: SqsNotificationConsumerParams
+  private internalConsumer?: SnsSqsInvalidationConsumer<LoadedValue>
+
+  constructor(params: SqsNotificationConsumerParams) {
+    super(params.serverUuid, params.errorHandler)
+    this.params = params
+  }
+
+  async subscribe(): Promise<unknown> {
+    if (this.internalConsumer) {
+      return this.internalConsumer
+    }
+
+    if (!this.targetCache) {
+      throw new Error(
+        'targetCache must be set via setTargetCache() before subscribe() is called',
+      )
+    }
+
+    const handlers = new MessageHandlerConfigBuilder<
+      NotificationCommand,
+      ConsumerContext<LoadedValue>
+    >()
+      .addConfig(DELETE_NOTIFICATION_SCHEMA, async (message, ctx) => {
+        if (message.originUuid !== ctx.serverUuid) {
+          ctx.targetCache.delete(message.key)
+        }
+        return { result: 'success' }
+      })
+      .addConfig(DELETE_MANY_NOTIFICATION_SCHEMA, async (message, ctx) => {
+        if (message.originUuid !== ctx.serverUuid) {
+          ctx.targetCache.deleteMany(message.keys)
+        }
+        return { result: 'success' }
+      })
+      .addConfig(CLEAR_NOTIFICATION_SCHEMA, async (message, ctx) => {
+        if (message.originUuid !== ctx.serverUuid) {
+          ctx.targetCache.clear()
+        }
+        return { result: 'success' }
+      })
+      .addConfig(SET_NOTIFICATION_SCHEMA, async (message, ctx) => {
+        if (message.originUuid !== ctx.serverUuid) {
+          ctx.targetCache.set(message.key, (message.value as LoadedValue | null) ?? null)
+        }
+        return { result: 'success' }
+      })
+      .build()
+
+    const options = {
+      handlers,
+      messageTypeResolver: { messageTypePath: NOTIFICATION_TYPE_FIELD },
+      messageIdField: NOTIFICATION_ID_FIELD,
+      messageTimestampField: NOTIFICATION_TIMESTAMP_FIELD,
+      subscriptionConfig: this.params.subscriptionConfig ?? { updateAttributesIfExists: false },
+      ...(this.params.creationConfig
+        ? { creationConfig: this.params.creationConfig }
+        : { locatorConfig: this.params.locatorConfig }),
+    } as SNSSQSConsumerOptions<NotificationCommand, ConsumerContext<LoadedValue>, undefined>
+
+    this.internalConsumer = new SnsSqsInvalidationConsumer<LoadedValue>(
+      this.params.dependencies,
+      options,
+      { serverUuid: this.serverUuid, targetCache: this.targetCache },
+    )
+
+    await this.internalConsumer.init()
+    await this.internalConsumer.start()
+    return this.internalConsumer
+  }
+
+  async close(): Promise<void> {
+    if (!this.internalConsumer) return
+    const consumer = this.internalConsumer
+    this.internalConsumer = undefined
+    await consumer.close()
+  }
+
+  /**
+   * Returns the resolved topic ARN. Available only after subscribe() has completed.
+   */
+  get topicArn(): string | undefined {
+    return this.internalConsumer?.publicTopicArn
+  }
+
+  /**
+   * Returns the resolved subscription ARN. Available only after subscribe() has completed.
+   */
+  get subscriptionArn(): string | undefined {
+    return this.internalConsumer?.publicSubscriptionArn
+  }
+
+  /**
+   * Returns the resolved queue URL. Available only after subscribe() has completed.
+   */
+  get queueUrl(): string | undefined {
+    return this.internalConsumer?.publicQueueUrl
+  }
+}

--- a/packages/sqs/lib/SqsNotificationFactory.ts
+++ b/packages/sqs/lib/SqsNotificationFactory.ts
@@ -1,0 +1,82 @@
+import { randomUUID } from 'node:crypto'
+import type { SNSDependencies, SNSSQSConsumerDependencies } from '@message-queue-toolkit/sns'
+import type { ConsumerErrorHandler, PublisherErrorHandler } from 'layered-loader'
+import {
+  SqsNotificationConsumer,
+  type SqsNotificationConsumerConfig,
+  type SqsSubscriptionOptions,
+} from './SqsNotificationConsumer.js'
+import {
+  SqsNotificationPublisher,
+  type SqsNotificationPublisherConfig,
+} from './SqsNotificationPublisher.js'
+
+export type SqsNotificationConfig = {
+  /**
+   * Logical channel name used for error reporting.
+   * Defaults to the topic name/ARN derived from the publisher config.
+   */
+  channel?: string
+  /**
+   * Stable identifier for this process. When omitted, a random UUID is generated.
+   * Messages whose `originUuid` matches this value are treated as self-emitted and skipped.
+   */
+  serverUuid?: string
+  publisherErrorHandler?: PublisherErrorHandler
+  consumerErrorHandler?: ConsumerErrorHandler
+  publisher: {
+    dependencies: SNSDependencies
+  } & SqsNotificationPublisherConfig
+  consumer: {
+    dependencies: SNSSQSConsumerDependencies
+    subscriptionConfig?: SqsSubscriptionOptions
+  } & SqsNotificationConsumerConfig
+}
+
+export function createNotificationPair<LoadedValue>(config: SqsNotificationConfig): {
+  publisher: SqsNotificationPublisher<LoadedValue>
+  consumer: SqsNotificationConsumer<LoadedValue>
+} {
+  const serverUuid = config.serverUuid ?? randomUUID()
+
+  const publisherConfig = config.publisher
+  const consumerConfig = config.consumer
+
+  const publisher = new SqsNotificationPublisher<LoadedValue>(
+    publisherConfig.creationConfig
+      ? {
+          serverUuid,
+          channel: config.channel,
+          errorHandler: config.publisherErrorHandler,
+          dependencies: publisherConfig.dependencies,
+          creationConfig: publisherConfig.creationConfig,
+        }
+      : {
+          serverUuid,
+          channel: config.channel,
+          errorHandler: config.publisherErrorHandler,
+          dependencies: publisherConfig.dependencies,
+          locatorConfig: publisherConfig.locatorConfig,
+        },
+  )
+
+  const consumer = new SqsNotificationConsumer<LoadedValue>(
+    consumerConfig.creationConfig
+      ? {
+          serverUuid,
+          errorHandler: config.consumerErrorHandler,
+          dependencies: consumerConfig.dependencies,
+          subscriptionConfig: consumerConfig.subscriptionConfig,
+          creationConfig: consumerConfig.creationConfig,
+        }
+      : {
+          serverUuid,
+          errorHandler: config.consumerErrorHandler,
+          dependencies: consumerConfig.dependencies,
+          subscriptionConfig: consumerConfig.subscriptionConfig,
+          locatorConfig: consumerConfig.locatorConfig,
+        },
+  )
+
+  return { publisher, consumer }
+}

--- a/packages/sqs/lib/SqsNotificationPublisher.ts
+++ b/packages/sqs/lib/SqsNotificationPublisher.ts
@@ -75,13 +75,23 @@ export class SqsNotificationPublisher<LoadedValue>
     this.publisher = new SnsInvalidationPublisher(params.dependencies, options)
   }
 
-  async subscribe(): Promise<unknown> {
+  async subscribe(): Promise<void> {
+    if (this.initialized) return
+
     if (!this.initPromise) {
-      this.initPromise = this.publisher.init().then(() => {
-        this.initialized = true
-      })
+      this.initPromise = this.initializePublisher()
     }
     return this.initPromise
+  }
+
+  private async initializePublisher(): Promise<void> {
+    try {
+      await this.publisher.init()
+      this.initialized = true
+    } catch (err) {
+      this.initPromise = undefined
+      throw err
+    }
   }
 
   set(key: string, value: LoadedValue | null): Promise<unknown> {

--- a/packages/sqs/lib/SqsNotificationPublisher.ts
+++ b/packages/sqs/lib/SqsNotificationPublisher.ts
@@ -7,6 +7,7 @@ import {
   type SNSTopicLocatorType,
 } from '@message-queue-toolkit/sns'
 import type { NotificationPublisher, PublisherErrorHandler } from 'layered-loader'
+import { resolveChannelName } from './channelNameResolver.js'
 import {
   CLEAR_COMMAND,
   DELETE_COMMAND,
@@ -49,12 +50,18 @@ export class SqsNotificationPublisher<LoadedValue>
   private readonly serverUuid: string
   private readonly publisher: SnsInvalidationPublisher
   private initPromise?: Promise<void>
+  private initialized = false
 
   constructor(params: SqsNotificationPublisherParams) {
     this.serverUuid = params.serverUuid
     this.errorHandler = params.errorHandler ?? DEFAULT_PUBLISHER_ERROR_HANDLER
     this.channel = resolveChannelName(params)
 
+    // mqt's `messageSchemas` is `readonly ZodSchema<UnionType>[]`. Our schemas
+    // are narrower (one per command type) and `ZodSchema` is invariant in T,
+    // so the array of narrow schemas does not satisfy the broad type at the
+    // type level — even though mqt resolves them correctly at runtime via the
+    // configured `messageTypeResolver`.
     const options = {
       messageSchemas: NOTIFICATION_SCHEMAS,
       messageTypeResolver: { messageTypePath: NOTIFICATION_TYPE_FIELD },
@@ -70,7 +77,9 @@ export class SqsNotificationPublisher<LoadedValue>
 
   async subscribe(): Promise<unknown> {
     if (!this.initPromise) {
-      this.initPromise = this.publisher.init()
+      this.initPromise = this.publisher.init().then(() => {
+        this.initialized = true
+      })
     }
     return this.initPromise
   }
@@ -112,10 +121,12 @@ export class SqsNotificationPublisher<LoadedValue>
   }
 
   /**
-   * Returns the resolved topic ARN. Available only after subscribe() (or the first publish) has completed.
+   * Returns the resolved topic ARN. Available only after `subscribe()` (or the
+   * first publish) has fully completed; returns `undefined` while init is in
+   * flight or before it has been triggered.
    */
   get topicArn(): string | undefined {
-    return this.initPromise ? this.publisher.publicTopicArn : undefined
+    return this.initialized ? this.publisher.publicTopicArn : undefined
   }
 
   private async publishCommand(command: NotificationCommand): Promise<void> {
@@ -132,22 +143,3 @@ export class SqsNotificationPublisher<LoadedValue>
   }
 }
 
-function resolveChannelName(params: SqsNotificationPublisherParams): string {
-  if (params.channel) {
-    return params.channel
-  }
-
-  if (params.creationConfig?.topic?.Name) {
-    return params.creationConfig.topic.Name
-  }
-
-  if (params.locatorConfig?.topicName) {
-    return params.locatorConfig.topicName
-  }
-
-  if (params.locatorConfig?.topicArn) {
-    return params.locatorConfig.topicArn
-  }
-
-  return 'sqs-notification-channel'
-}

--- a/packages/sqs/lib/SqsNotificationPublisher.ts
+++ b/packages/sqs/lib/SqsNotificationPublisher.ts
@@ -1,0 +1,153 @@
+import { randomUUID } from 'node:crypto'
+import {
+  AbstractSnsPublisher,
+  type SNSCreationConfig,
+  type SNSDependencies,
+  type SNSPublisherOptions,
+  type SNSTopicLocatorType,
+} from '@message-queue-toolkit/sns'
+import type { NotificationPublisher, PublisherErrorHandler } from 'layered-loader'
+import {
+  CLEAR_COMMAND,
+  DELETE_COMMAND,
+  DELETE_MANY_COMMAND,
+  type NotificationCommand,
+  NOTIFICATION_ID_FIELD,
+  NOTIFICATION_SCHEMAS,
+  NOTIFICATION_TIMESTAMP_FIELD,
+  NOTIFICATION_TYPE_FIELD,
+  SET_COMMAND,
+} from './notificationSchemas.js'
+
+const DEFAULT_PUBLISHER_ERROR_HANDLER: PublisherErrorHandler = (err, channel, logger) => {
+  logger.error(`Error while publishing notification to channel ${channel}: ${err.message}`)
+}
+
+class SnsInvalidationPublisher extends AbstractSnsPublisher<NotificationCommand> {
+  get publicTopicArn(): string {
+    return this.topicArn
+  }
+}
+
+export type SqsNotificationPublisherConfig =
+  | { creationConfig: SNSCreationConfig; locatorConfig?: never }
+  | { creationConfig?: never; locatorConfig: SNSTopicLocatorType }
+
+export type SqsNotificationPublisherParams = {
+  serverUuid: string
+  errorHandler?: PublisherErrorHandler
+  channel?: string
+  dependencies: SNSDependencies
+} & SqsNotificationPublisherConfig
+
+export class SqsNotificationPublisher<LoadedValue>
+  implements NotificationPublisher<LoadedValue>
+{
+  public readonly channel: string
+  public readonly errorHandler: PublisherErrorHandler
+
+  private readonly serverUuid: string
+  private readonly publisher: SnsInvalidationPublisher
+  private initPromise?: Promise<void>
+
+  constructor(params: SqsNotificationPublisherParams) {
+    this.serverUuid = params.serverUuid
+    this.errorHandler = params.errorHandler ?? DEFAULT_PUBLISHER_ERROR_HANDLER
+    this.channel = resolveChannelName(params)
+
+    const options = {
+      messageSchemas: NOTIFICATION_SCHEMAS,
+      messageTypeResolver: { messageTypePath: NOTIFICATION_TYPE_FIELD },
+      messageIdField: NOTIFICATION_ID_FIELD,
+      messageTimestampField: NOTIFICATION_TIMESTAMP_FIELD,
+      ...(params.creationConfig
+        ? { creationConfig: params.creationConfig }
+        : { locatorConfig: params.locatorConfig }),
+    } as unknown as SNSPublisherOptions<NotificationCommand>
+
+    this.publisher = new SnsInvalidationPublisher(params.dependencies, options)
+  }
+
+  async subscribe(): Promise<unknown> {
+    if (!this.initPromise) {
+      this.initPromise = this.publisher.init()
+    }
+    return this.initPromise
+  }
+
+  set(key: string, value: LoadedValue | null): Promise<unknown> {
+    return this.publishCommand({
+      type: SET_COMMAND,
+      key,
+      value,
+      ...this.buildEnvelope(),
+    })
+  }
+
+  delete(key: string): Promise<unknown> {
+    return this.publishCommand({
+      type: DELETE_COMMAND,
+      key,
+      ...this.buildEnvelope(),
+    })
+  }
+
+  deleteMany(keys: string[]): Promise<unknown> {
+    return this.publishCommand({
+      type: DELETE_MANY_COMMAND,
+      keys,
+      ...this.buildEnvelope(),
+    })
+  }
+
+  clear(): Promise<unknown> {
+    return this.publishCommand({
+      type: CLEAR_COMMAND,
+      ...this.buildEnvelope(),
+    })
+  }
+
+  async close(): Promise<void> {
+    await this.publisher.close()
+  }
+
+  /**
+   * Returns the resolved topic ARN. Available only after subscribe() (or the first publish) has completed.
+   */
+  get topicArn(): string | undefined {
+    return this.initPromise ? this.publisher.publicTopicArn : undefined
+  }
+
+  private async publishCommand(command: NotificationCommand): Promise<void> {
+    await this.subscribe()
+    await this.publisher.publish(command)
+  }
+
+  private buildEnvelope() {
+    return {
+      id: randomUUID(),
+      timestamp: new Date().toISOString(),
+      originUuid: this.serverUuid,
+    }
+  }
+}
+
+function resolveChannelName(params: SqsNotificationPublisherParams): string {
+  if (params.channel) {
+    return params.channel
+  }
+
+  if (params.creationConfig?.topic?.Name) {
+    return params.creationConfig.topic.Name
+  }
+
+  if (params.locatorConfig?.topicName) {
+    return params.locatorConfig.topicName
+  }
+
+  if (params.locatorConfig?.topicArn) {
+    return params.locatorConfig.topicArn
+  }
+
+  return 'sqs-notification-channel'
+}

--- a/packages/sqs/lib/channelNameResolver.ts
+++ b/packages/sqs/lib/channelNameResolver.ts
@@ -1,0 +1,22 @@
+import type { SNSCreationConfig, SNSTopicLocatorType } from '@message-queue-toolkit/sns'
+
+export type ChannelNameSource = {
+  channel?: string
+  creationConfig?: SNSCreationConfig
+  locatorConfig?: SNSTopicLocatorType
+}
+
+const DEFAULT_CHANNEL_NAME = 'sqs-notification-channel'
+
+/**
+ * Derive a logical channel name (used in error messages and logs) from a
+ * publisher params object that has either an explicit `channel`, a
+ * `creationConfig.topic.Name`, or a `locatorConfig` with `topicName`/`topicArn`.
+ */
+export function resolveChannelName(source: ChannelNameSource): string {
+  if (source.channel) return source.channel
+  if (source.creationConfig?.topic?.Name) return source.creationConfig.topic.Name
+  if (source.locatorConfig?.topicName) return source.locatorConfig.topicName
+  if (source.locatorConfig?.topicArn) return source.locatorConfig.topicArn
+  return DEFAULT_CHANNEL_NAME
+}

--- a/packages/sqs/lib/groupNotificationSchemas.ts
+++ b/packages/sqs/lib/groupNotificationSchemas.ts
@@ -17,9 +17,9 @@ export {
 }
 
 const NOTIFICATION_BASE_SHAPE = {
-  id: z.string(),
-  timestamp: z.string(),
-  originUuid: z.string(),
+  id: z.string().uuid(),
+  timestamp: z.string().datetime(),
+  originUuid: z.string().uuid(),
 }
 
 export const CLEAR_GROUP_NOTIFICATION_SCHEMA = z.object({

--- a/packages/sqs/lib/groupNotificationSchemas.ts
+++ b/packages/sqs/lib/groupNotificationSchemas.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod'
+import {
+  CLEAR_COMMAND,
+  NOTIFICATION_ID_FIELD,
+  NOTIFICATION_TIMESTAMP_FIELD,
+  NOTIFICATION_TYPE_FIELD,
+} from './notificationSchemas.js'
+
+export const DELETE_GROUP_COMMAND = 'DELETE_GROUP'
+export const DELETE_FROM_GROUP_COMMAND = 'DELETE_FROM_GROUP'
+
+export {
+  CLEAR_COMMAND,
+  NOTIFICATION_ID_FIELD,
+  NOTIFICATION_TIMESTAMP_FIELD,
+  NOTIFICATION_TYPE_FIELD,
+}
+
+const NOTIFICATION_BASE_SHAPE = {
+  id: z.string(),
+  timestamp: z.string(),
+  originUuid: z.string(),
+}
+
+export const CLEAR_GROUP_NOTIFICATION_SCHEMA = z.object({
+  ...NOTIFICATION_BASE_SHAPE,
+  type: z.literal(CLEAR_COMMAND),
+})
+
+export const DELETE_GROUP_NOTIFICATION_SCHEMA = z.object({
+  ...NOTIFICATION_BASE_SHAPE,
+  type: z.literal(DELETE_GROUP_COMMAND),
+  group: z.string(),
+})
+
+export const DELETE_FROM_GROUP_NOTIFICATION_SCHEMA = z.object({
+  ...NOTIFICATION_BASE_SHAPE,
+  type: z.literal(DELETE_FROM_GROUP_COMMAND),
+  key: z.string(),
+  group: z.string(),
+})
+
+export type ClearGroupNotificationCommand = z.infer<typeof CLEAR_GROUP_NOTIFICATION_SCHEMA>
+export type DeleteGroupNotificationCommand = z.infer<typeof DELETE_GROUP_NOTIFICATION_SCHEMA>
+export type DeleteFromGroupNotificationCommand = z.infer<
+  typeof DELETE_FROM_GROUP_NOTIFICATION_SCHEMA
+>
+
+export type GroupNotificationCommand =
+  | ClearGroupNotificationCommand
+  | DeleteGroupNotificationCommand
+  | DeleteFromGroupNotificationCommand
+
+export const GROUP_NOTIFICATION_SCHEMAS = [
+  CLEAR_GROUP_NOTIFICATION_SCHEMA,
+  DELETE_GROUP_NOTIFICATION_SCHEMA,
+  DELETE_FROM_GROUP_NOTIFICATION_SCHEMA,
+] as const

--- a/packages/sqs/lib/notificationSchemas.ts
+++ b/packages/sqs/lib/notificationSchemas.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod'
+
+export const CLEAR_COMMAND = 'CLEAR'
+export const DELETE_COMMAND = 'DELETE'
+export const DELETE_MANY_COMMAND = 'DELETE_MANY'
+export const SET_COMMAND = 'SET'
+
+export const NOTIFICATION_TYPE_FIELD = 'type'
+export const NOTIFICATION_ID_FIELD = 'id'
+export const NOTIFICATION_TIMESTAMP_FIELD = 'timestamp'
+
+const NOTIFICATION_BASE_SHAPE = {
+  id: z.string(),
+  timestamp: z.string(),
+  originUuid: z.string(),
+}
+
+export const CLEAR_NOTIFICATION_SCHEMA = z.object({
+  ...NOTIFICATION_BASE_SHAPE,
+  type: z.literal(CLEAR_COMMAND),
+})
+
+export const DELETE_NOTIFICATION_SCHEMA = z.object({
+  ...NOTIFICATION_BASE_SHAPE,
+  type: z.literal(DELETE_COMMAND),
+  key: z.string(),
+})
+
+export const DELETE_MANY_NOTIFICATION_SCHEMA = z.object({
+  ...NOTIFICATION_BASE_SHAPE,
+  type: z.literal(DELETE_MANY_COMMAND),
+  keys: z.array(z.string()),
+})
+
+export const SET_NOTIFICATION_SCHEMA = z.object({
+  ...NOTIFICATION_BASE_SHAPE,
+  type: z.literal(SET_COMMAND),
+  key: z.string(),
+  value: z.unknown().nullable(),
+})
+
+export type ClearNotificationCommand = z.infer<typeof CLEAR_NOTIFICATION_SCHEMA>
+export type DeleteNotificationCommand = z.infer<typeof DELETE_NOTIFICATION_SCHEMA>
+export type DeleteManyNotificationCommand = z.infer<typeof DELETE_MANY_NOTIFICATION_SCHEMA>
+export type SetNotificationCommand = z.infer<typeof SET_NOTIFICATION_SCHEMA>
+
+export type NotificationCommand =
+  | ClearNotificationCommand
+  | DeleteNotificationCommand
+  | DeleteManyNotificationCommand
+  | SetNotificationCommand
+
+export const NOTIFICATION_SCHEMAS = [
+  CLEAR_NOTIFICATION_SCHEMA,
+  DELETE_NOTIFICATION_SCHEMA,
+  DELETE_MANY_NOTIFICATION_SCHEMA,
+  SET_NOTIFICATION_SCHEMA,
+] as const

--- a/packages/sqs/lib/notificationSchemas.ts
+++ b/packages/sqs/lib/notificationSchemas.ts
@@ -10,9 +10,9 @@ export const NOTIFICATION_ID_FIELD = 'id'
 export const NOTIFICATION_TIMESTAMP_FIELD = 'timestamp'
 
 const NOTIFICATION_BASE_SHAPE = {
-  id: z.string(),
-  timestamp: z.string(),
-  originUuid: z.string(),
+  id: z.string().uuid(),
+  timestamp: z.string().datetime(),
+  originUuid: z.string().uuid(),
 }
 
 export const CLEAR_NOTIFICATION_SCHEMA = z.object({

--- a/packages/sqs/lib/triggers/AbstractSqsTrigger.ts
+++ b/packages/sqs/lib/triggers/AbstractSqsTrigger.ts
@@ -1,0 +1,189 @@
+import type { MessageHandlerConfig } from '@message-queue-toolkit/core'
+import {
+  AbstractSnsSqsConsumer,
+  type SNSSQSConsumerDependencies,
+  type SNSSQSConsumerOptions,
+  type SNSSQSCreationConfig,
+  type SNSSQSQueueLocatorType,
+} from '@message-queue-toolkit/sns'
+import {
+  AbstractSqsConsumer,
+  type SQSConsumerDependencies,
+  type SQSConsumerOptions,
+  type SQSCreationConfig,
+  type SQSQueueLocatorType,
+} from '@message-queue-toolkit/sqs'
+import type { SqsSubscriptionOptions } from '../SqsNotificationConsumer.js'
+import type { InvalidationTrigger } from './types.js'
+
+/**
+ * Discriminated source config shared by every SQS-based trigger
+ * (flat or group, current and future variants).
+ */
+export type SqsTriggerSource =
+  | {
+      sourceType: 'sqs-queue'
+      dependencies: SQSConsumerDependencies
+      creationConfig: SQSCreationConfig
+      locatorConfig?: never
+    }
+  | {
+      sourceType: 'sqs-queue'
+      dependencies: SQSConsumerDependencies
+      creationConfig?: never
+      locatorConfig: SQSQueueLocatorType
+    }
+  | {
+      sourceType: 'sns-topic'
+      dependencies: SNSSQSConsumerDependencies
+      creationConfig: SNSSQSCreationConfig
+      locatorConfig?: never
+      subscriptionConfig?: SqsSubscriptionOptions
+    }
+  | {
+      sourceType: 'sns-topic'
+      dependencies: SNSSQSConsumerDependencies
+      creationConfig?: never
+      locatorConfig: SNSSQSQueueLocatorType
+      subscriptionConfig?: SqsSubscriptionOptions
+    }
+
+/** Minimal lifecycle slice we need from the underlying message-queue-toolkit consumer. */
+export interface InternalConsumerHandle {
+  init(): Promise<void>
+  start(): Promise<void>
+  close(abort?: boolean): Promise<void>
+}
+
+/**
+ * Concrete subclasses of `AbstractSnsSqsConsumer` / `AbstractSqsConsumer` are
+ * needed because the upstream classes are abstract. They add no behaviour;
+ * they just expose the constructor.
+ */
+class SqsQueueTriggerConsumer<TMessage extends object, TContext> extends AbstractSqsConsumer<
+  TMessage,
+  TContext
+> {
+  constructor(
+    dependencies: SQSConsumerDependencies,
+    options: SQSConsumerOptions<TMessage, TContext, undefined>,
+    context: TContext,
+  ) {
+    super(dependencies, options, context)
+  }
+}
+
+class SnsTopicTriggerConsumer<TMessage extends object, TContext> extends AbstractSnsSqsConsumer<
+  TMessage,
+  TContext
+> {
+  constructor(
+    dependencies: SNSSQSConsumerDependencies,
+    options: SNSSQSConsumerOptions<TMessage, TContext, undefined>,
+    context: TContext,
+  ) {
+    super(dependencies, options, context)
+  }
+}
+
+/**
+ * Shared lifecycle (start/stop with idempotency + concurrent-call protection)
+ * and consumer construction logic for SQS-based triggers. Subclasses provide
+ * the concrete handler configuration via {@link buildHandlers}.
+ */
+export abstract class AbstractSqsTrigger<TMessage extends object, TContext>
+  implements InvalidationTrigger
+{
+  private internalConsumer?: InternalConsumerHandle
+  private startPromise?: Promise<void>
+
+  protected abstract readonly source: SqsTriggerSource
+  protected abstract readonly messageType: string
+  protected abstract readonly channel: string
+
+  /** Build the handler configuration for the underlying consumer. */
+  protected abstract buildHandlers(): MessageHandlerConfig<TMessage, TContext, undefined>[]
+
+  /** Construct the per-trigger execution context that handlers receive. */
+  protected abstract buildContext(): TContext
+
+  async start(): Promise<void> {
+    if (this.startPromise) return this.startPromise
+    if (this.internalConsumer) return
+    this.startPromise = (async () => {
+      const consumer = this.createConsumer()
+      try {
+        await consumer.init()
+        await consumer.start()
+        this.internalConsumer = consumer
+      } finally {
+        this.startPromise = undefined
+      }
+    })()
+    return this.startPromise
+  }
+
+  async stop(): Promise<void> {
+    // Wait for any in-flight start to settle so we don't leak a consumer.
+    if (this.startPromise) {
+      await this.startPromise.catch(() => undefined)
+    }
+    const consumer = this.internalConsumer
+    if (!consumer) return
+    this.internalConsumer = undefined
+    await consumer.close()
+  }
+
+  private createConsumer(): InternalConsumerHandle {
+    const handlers = this.buildHandlers()
+    const context = this.buildContext()
+    const messageTypeResolver = { literal: this.messageType }
+
+    if (this.source.sourceType === 'sqs-queue') {
+      const base = {
+        handlers,
+        messageTypeResolver,
+      }
+      const options: SQSConsumerOptions<TMessage, TContext, undefined> = this.source.creationConfig
+        ? { ...base, creationConfig: this.source.creationConfig }
+        : { ...base, locatorConfig: this.source.locatorConfig }
+      return new SqsQueueTriggerConsumer<TMessage, TContext>(
+        this.source.dependencies,
+        options,
+        context,
+      )
+    }
+
+    const base = {
+      handlers,
+      messageTypeResolver,
+      subscriptionConfig: this.source.subscriptionConfig ?? { updateAttributesIfExists: false },
+    }
+    const options: SNSSQSConsumerOptions<TMessage, TContext, undefined> = this.source.creationConfig
+      ? { ...base, creationConfig: this.source.creationConfig }
+      : { ...base, locatorConfig: this.source.locatorConfig }
+    return new SnsTopicTriggerConsumer<TMessage, TContext>(
+      this.source.dependencies,
+      options,
+      context,
+    )
+  }
+}
+
+/**
+ * Derive a human-readable channel name from any {@link SqsTriggerSource} for
+ * use in error messages and logging.
+ */
+export function deriveTriggerChannelName(source: SqsTriggerSource): string {
+  if (source.sourceType === 'sqs-queue') {
+    if (source.creationConfig?.queue?.QueueName) return source.creationConfig.queue.QueueName
+    if (source.locatorConfig?.queueName) return source.locatorConfig.queueName
+    if (source.locatorConfig?.queueUrl) return source.locatorConfig.queueUrl
+    return 'sqs-invalidation-trigger'
+  }
+  if (source.creationConfig?.topic?.Name) return source.creationConfig.topic.Name
+  if (source.locatorConfig?.topicName) return source.locatorConfig.topicName
+  if (source.locatorConfig?.topicArn) return source.locatorConfig.topicArn
+  if (source.locatorConfig?.queueUrl) return source.locatorConfig.queueUrl
+  return 'sns-invalidation-trigger'
+}

--- a/packages/sqs/lib/triggers/SqsGroupInvalidationTrigger.ts
+++ b/packages/sqs/lib/triggers/SqsGroupInvalidationTrigger.ts
@@ -1,0 +1,194 @@
+import { MessageHandlerConfigBuilder } from '@message-queue-toolkit/core'
+import {
+  AbstractSnsSqsConsumer,
+  type SNSSQSConsumerDependencies,
+  type SNSSQSConsumerOptions,
+  type SNSSQSCreationConfig,
+  type SNSSQSQueueLocatorType,
+} from '@message-queue-toolkit/sns'
+import {
+  AbstractSqsConsumer,
+  type SQSConsumerDependencies,
+  type SQSConsumerOptions,
+  type SQSCreationConfig,
+  type SQSQueueLocatorType,
+} from '@message-queue-toolkit/sqs'
+import type { GroupNotificationPublisher } from 'layered-loader'
+import type { ZodSchema } from 'zod'
+import { runGroupPipeline } from './dispatch.js'
+import type { TriggerSubscriptionOptions } from './SqsInvalidationTrigger.js'
+import type {
+  GroupInvalidationAction,
+  InvalidationResolver,
+  InvalidationTrigger,
+  TriggerErrorHandler,
+} from './types.js'
+
+const GROUP_TRIGGER_MESSAGE_TYPE = 'layered-loader.group-invalidation-trigger'
+
+export type SqsGroupTriggerSourceConfig =
+  | {
+      sourceType: 'sqs-queue'
+      dependencies: SQSConsumerDependencies
+      creationConfig: SQSCreationConfig
+      locatorConfig?: never
+    }
+  | {
+      sourceType: 'sqs-queue'
+      dependencies: SQSConsumerDependencies
+      creationConfig?: never
+      locatorConfig: SQSQueueLocatorType
+    }
+  | {
+      sourceType: 'sns-topic'
+      dependencies: SNSSQSConsumerDependencies
+      creationConfig: SNSSQSCreationConfig
+      locatorConfig?: never
+      subscriptionConfig?: TriggerSubscriptionOptions
+    }
+  | {
+      sourceType: 'sns-topic'
+      dependencies: SNSSQSConsumerDependencies
+      creationConfig?: never
+      locatorConfig: SNSSQSQueueLocatorType
+      subscriptionConfig?: TriggerSubscriptionOptions
+    }
+
+export type SqsGroupInvalidationTriggerParams<TMessage extends object> = {
+  messageSchema: ZodSchema<TMessage>
+  resolver: InvalidationResolver<TMessage, GroupInvalidationAction>
+  /**
+   * The group notification publisher that propagates invalidation.
+   *
+   * Pass a publisher whose server UUID is distinct from any Loader's
+   * notification pair — otherwise the local pair's consumer treats trigger
+   * messages as self-emitted and drops them, leaving the local cache stale.
+   */
+  publisher: GroupNotificationPublisher<unknown>
+  errorHandler?: TriggerErrorHandler
+  channel?: string
+} & SqsGroupTriggerSourceConfig
+
+interface InternalConsumer {
+  init(): Promise<void>
+  start(): Promise<void>
+  close(abort?: boolean): Promise<void>
+}
+
+type TriggerExecutionContext<TMessage> = {
+  resolver: InvalidationResolver<TMessage, GroupInvalidationAction>
+  publisher: GroupNotificationPublisher<unknown>
+  channel: string
+  errorHandler: TriggerErrorHandler | undefined
+}
+
+class SqsQueueGroupTriggerConsumer<TMessage extends object> extends AbstractSqsConsumer<
+  TMessage,
+  TriggerExecutionContext<TMessage>
+> {
+  constructor(
+    dependencies: SQSConsumerDependencies,
+    options: SQSConsumerOptions<TMessage, TriggerExecutionContext<TMessage>, undefined>,
+    context: TriggerExecutionContext<TMessage>,
+  ) {
+    super(dependencies, options, context)
+  }
+}
+
+class SnsTopicGroupTriggerConsumer<TMessage extends object> extends AbstractSnsSqsConsumer<
+  TMessage,
+  TriggerExecutionContext<TMessage>
+> {
+  constructor(
+    dependencies: SNSSQSConsumerDependencies,
+    options: SNSSQSConsumerOptions<TMessage, TriggerExecutionContext<TMessage>, undefined>,
+    context: TriggerExecutionContext<TMessage>,
+  ) {
+    super(dependencies, options, context)
+  }
+}
+
+export class SqsGroupInvalidationTrigger<TMessage extends object> implements InvalidationTrigger {
+  private readonly params: SqsGroupInvalidationTriggerParams<TMessage>
+  private readonly channel: string
+  private internalConsumer?: InternalConsumer
+
+  constructor(params: SqsGroupInvalidationTriggerParams<TMessage>) {
+    this.params = params
+    this.channel = params.channel ?? deriveChannelName(params)
+  }
+
+  async start(): Promise<void> {
+    if (this.internalConsumer) return
+    this.internalConsumer = this.buildConsumer()
+    await this.internalConsumer.init()
+    await this.internalConsumer.start()
+  }
+
+  async stop(): Promise<void> {
+    const consumer = this.internalConsumer
+    if (!consumer) return
+    this.internalConsumer = undefined
+    await consumer.close()
+  }
+
+  private buildConsumer(): InternalConsumer {
+    const handler = async (message: TMessage, ctx: TriggerExecutionContext<TMessage>) => {
+      try {
+        await runGroupPipeline(message, ctx.resolver, ctx.publisher)
+        return { result: 'success' as const }
+      } catch (err) {
+        ctx.errorHandler?.(err as Error, ctx.channel)
+        throw err
+      }
+    }
+
+    const handlers = new MessageHandlerConfigBuilder<TMessage, TriggerExecutionContext<TMessage>>()
+      .addConfig(this.params.messageSchema, handler, { messageType: GROUP_TRIGGER_MESSAGE_TYPE })
+      .build()
+
+    const context: TriggerExecutionContext<TMessage> = {
+      resolver: this.params.resolver,
+      publisher: this.params.publisher,
+      channel: this.channel,
+      errorHandler: this.params.errorHandler,
+    }
+
+    if (this.params.sourceType === 'sqs-queue') {
+      const options: SQSConsumerOptions<TMessage, TriggerExecutionContext<TMessage>, undefined> = {
+        handlers,
+        messageTypeResolver: { literal: GROUP_TRIGGER_MESSAGE_TYPE },
+        ...(this.params.creationConfig
+          ? { creationConfig: this.params.creationConfig }
+          : { locatorConfig: this.params.locatorConfig }),
+      }
+      return new SqsQueueGroupTriggerConsumer(this.params.dependencies, options, context)
+    }
+
+    const options = {
+      handlers,
+      messageTypeResolver: { literal: GROUP_TRIGGER_MESSAGE_TYPE },
+      subscriptionConfig: this.params.subscriptionConfig ?? { updateAttributesIfExists: false },
+      ...(this.params.creationConfig
+        ? { creationConfig: this.params.creationConfig }
+        : { locatorConfig: this.params.locatorConfig }),
+    } as SNSSQSConsumerOptions<TMessage, TriggerExecutionContext<TMessage>, undefined>
+    return new SnsTopicGroupTriggerConsumer(this.params.dependencies, options, context)
+  }
+}
+
+function deriveChannelName<TMessage extends object>(
+  params: SqsGroupInvalidationTriggerParams<TMessage>,
+): string {
+  if (params.sourceType === 'sqs-queue') {
+    if (params.creationConfig?.queue?.QueueName) return params.creationConfig.queue.QueueName
+    if (params.locatorConfig?.queueName) return params.locatorConfig.queueName
+    if (params.locatorConfig?.queueUrl) return params.locatorConfig.queueUrl
+    return 'sqs-group-invalidation-trigger'
+  }
+  if (params.creationConfig?.topic?.Name) return params.creationConfig.topic.Name
+  if (params.locatorConfig?.topicName) return params.locatorConfig.topicName
+  if (params.locatorConfig?.topicArn) return params.locatorConfig.topicArn
+  if (params.locatorConfig?.queueUrl) return params.locatorConfig.queueUrl
+  return 'sns-group-invalidation-trigger'
+}

--- a/packages/sqs/lib/triggers/SqsGroupInvalidationTrigger.ts
+++ b/packages/sqs/lib/triggers/SqsGroupInvalidationTrigger.ts
@@ -1,58 +1,21 @@
-import { MessageHandlerConfigBuilder } from '@message-queue-toolkit/core'
-import {
-  AbstractSnsSqsConsumer,
-  type SNSSQSConsumerDependencies,
-  type SNSSQSConsumerOptions,
-  type SNSSQSCreationConfig,
-  type SNSSQSQueueLocatorType,
-} from '@message-queue-toolkit/sns'
-import {
-  AbstractSqsConsumer,
-  type SQSConsumerDependencies,
-  type SQSConsumerOptions,
-  type SQSCreationConfig,
-  type SQSQueueLocatorType,
-} from '@message-queue-toolkit/sqs'
+import { type MessageHandlerConfig, MessageHandlerConfigBuilder } from '@message-queue-toolkit/core'
 import type { GroupNotificationPublisher } from 'layered-loader'
 import type { ZodSchema } from 'zod'
+import {
+  AbstractSqsTrigger,
+  deriveTriggerChannelName,
+  type SqsTriggerSource,
+} from './AbstractSqsTrigger.js'
 import { runGroupPipeline } from './dispatch.js'
-import type { TriggerSubscriptionOptions } from './SqsInvalidationTrigger.js'
 import type {
   GroupInvalidationAction,
   InvalidationResolver,
-  InvalidationTrigger,
   TriggerErrorHandler,
 } from './types.js'
 
 const GROUP_TRIGGER_MESSAGE_TYPE = 'layered-loader.group-invalidation-trigger'
 
-export type SqsGroupTriggerSourceConfig =
-  | {
-      sourceType: 'sqs-queue'
-      dependencies: SQSConsumerDependencies
-      creationConfig: SQSCreationConfig
-      locatorConfig?: never
-    }
-  | {
-      sourceType: 'sqs-queue'
-      dependencies: SQSConsumerDependencies
-      creationConfig?: never
-      locatorConfig: SQSQueueLocatorType
-    }
-  | {
-      sourceType: 'sns-topic'
-      dependencies: SNSSQSConsumerDependencies
-      creationConfig: SNSSQSCreationConfig
-      locatorConfig?: never
-      subscriptionConfig?: TriggerSubscriptionOptions
-    }
-  | {
-      sourceType: 'sns-topic'
-      dependencies: SNSSQSConsumerDependencies
-      creationConfig?: never
-      locatorConfig: SNSSQSQueueLocatorType
-      subscriptionConfig?: TriggerSubscriptionOptions
-    }
+export type SqsGroupTriggerSourceConfig = SqsTriggerSource
 
 export type SqsGroupInvalidationTriggerParams<TMessage extends object> = {
   messageSchema: ZodSchema<TMessage>
@@ -69,126 +32,65 @@ export type SqsGroupInvalidationTriggerParams<TMessage extends object> = {
   channel?: string
 } & SqsGroupTriggerSourceConfig
 
-interface InternalConsumer {
-  init(): Promise<void>
-  start(): Promise<void>
-  close(abort?: boolean): Promise<void>
-}
-
-type TriggerExecutionContext<TMessage> = {
+type GroupTriggerContext<TMessage> = {
   resolver: InvalidationResolver<TMessage, GroupInvalidationAction>
   publisher: GroupNotificationPublisher<unknown>
   channel: string
   errorHandler: TriggerErrorHandler | undefined
 }
 
-class SqsQueueGroupTriggerConsumer<TMessage extends object> extends AbstractSqsConsumer<
+export class SqsGroupInvalidationTrigger<TMessage extends object> extends AbstractSqsTrigger<
   TMessage,
-  TriggerExecutionContext<TMessage>
+  GroupTriggerContext<TMessage>
 > {
-  constructor(
-    dependencies: SQSConsumerDependencies,
-    options: SQSConsumerOptions<TMessage, TriggerExecutionContext<TMessage>, undefined>,
-    context: TriggerExecutionContext<TMessage>,
-  ) {
-    super(dependencies, options, context)
-  }
-}
+  protected readonly source: SqsTriggerSource
+  protected readonly messageType = GROUP_TRIGGER_MESSAGE_TYPE
+  protected readonly channel: string
 
-class SnsTopicGroupTriggerConsumer<TMessage extends object> extends AbstractSnsSqsConsumer<
-  TMessage,
-  TriggerExecutionContext<TMessage>
-> {
-  constructor(
-    dependencies: SNSSQSConsumerDependencies,
-    options: SNSSQSConsumerOptions<TMessage, TriggerExecutionContext<TMessage>, undefined>,
-    context: TriggerExecutionContext<TMessage>,
-  ) {
-    super(dependencies, options, context)
-  }
-}
-
-export class SqsGroupInvalidationTrigger<TMessage extends object> implements InvalidationTrigger {
-  private readonly params: SqsGroupInvalidationTriggerParams<TMessage>
-  private readonly channel: string
-  private internalConsumer?: InternalConsumer
+  private readonly messageSchema: ZodSchema<TMessage>
+  private readonly resolver: InvalidationResolver<TMessage, GroupInvalidationAction>
+  private readonly publisher: GroupNotificationPublisher<unknown>
+  private readonly errorHandler: TriggerErrorHandler | undefined
 
   constructor(params: SqsGroupInvalidationTriggerParams<TMessage>) {
-    this.params = params
-    this.channel = params.channel ?? deriveChannelName(params)
+    super()
+    const { messageSchema, resolver, publisher, errorHandler, channel, ...source } = params
+    this.source = source as SqsTriggerSource
+    this.messageSchema = messageSchema
+    this.resolver = resolver
+    this.publisher = publisher
+    this.errorHandler = errorHandler
+    this.channel = channel ?? deriveTriggerChannelName(this.source)
   }
 
-  async start(): Promise<void> {
-    if (this.internalConsumer) return
-    this.internalConsumer = this.buildConsumer()
-    await this.internalConsumer.init()
-    await this.internalConsumer.start()
-  }
-
-  async stop(): Promise<void> {
-    const consumer = this.internalConsumer
-    if (!consumer) return
-    this.internalConsumer = undefined
-    await consumer.close()
-  }
-
-  private buildConsumer(): InternalConsumer {
-    const handler = async (message: TMessage, ctx: TriggerExecutionContext<TMessage>) => {
-      try {
-        await runGroupPipeline(message, ctx.resolver, ctx.publisher)
-        return { result: 'success' as const }
-      } catch (err) {
-        ctx.errorHandler?.(err as Error, ctx.channel)
-        throw err
-      }
-    }
-
-    const handlers = new MessageHandlerConfigBuilder<TMessage, TriggerExecutionContext<TMessage>>()
-      .addConfig(this.params.messageSchema, handler, { messageType: GROUP_TRIGGER_MESSAGE_TYPE })
-      .build()
-
-    const context: TriggerExecutionContext<TMessage> = {
-      resolver: this.params.resolver,
-      publisher: this.params.publisher,
+  protected buildContext(): GroupTriggerContext<TMessage> {
+    return {
+      resolver: this.resolver,
+      publisher: this.publisher,
       channel: this.channel,
-      errorHandler: this.params.errorHandler,
+      errorHandler: this.errorHandler,
     }
-
-    if (this.params.sourceType === 'sqs-queue') {
-      const options: SQSConsumerOptions<TMessage, TriggerExecutionContext<TMessage>, undefined> = {
-        handlers,
-        messageTypeResolver: { literal: GROUP_TRIGGER_MESSAGE_TYPE },
-        ...(this.params.creationConfig
-          ? { creationConfig: this.params.creationConfig }
-          : { locatorConfig: this.params.locatorConfig }),
-      }
-      return new SqsQueueGroupTriggerConsumer(this.params.dependencies, options, context)
-    }
-
-    const options = {
-      handlers,
-      messageTypeResolver: { literal: GROUP_TRIGGER_MESSAGE_TYPE },
-      subscriptionConfig: this.params.subscriptionConfig ?? { updateAttributesIfExists: false },
-      ...(this.params.creationConfig
-        ? { creationConfig: this.params.creationConfig }
-        : { locatorConfig: this.params.locatorConfig }),
-    } as SNSSQSConsumerOptions<TMessage, TriggerExecutionContext<TMessage>, undefined>
-    return new SnsTopicGroupTriggerConsumer(this.params.dependencies, options, context)
   }
-}
 
-function deriveChannelName<TMessage extends object>(
-  params: SqsGroupInvalidationTriggerParams<TMessage>,
-): string {
-  if (params.sourceType === 'sqs-queue') {
-    if (params.creationConfig?.queue?.QueueName) return params.creationConfig.queue.QueueName
-    if (params.locatorConfig?.queueName) return params.locatorConfig.queueName
-    if (params.locatorConfig?.queueUrl) return params.locatorConfig.queueUrl
-    return 'sqs-group-invalidation-trigger'
+  protected buildHandlers(): MessageHandlerConfig<
+    TMessage,
+    GroupTriggerContext<TMessage>,
+    undefined
+  >[] {
+    return new MessageHandlerConfigBuilder<TMessage, GroupTriggerContext<TMessage>>()
+      .addConfig(
+        this.messageSchema,
+        async (message, ctx) => {
+          try {
+            await runGroupPipeline(message, ctx.resolver, ctx.publisher)
+            return { result: 'success' as const }
+          } catch (err) {
+            ctx.errorHandler?.(err as Error, ctx.channel)
+            throw err
+          }
+        },
+        { messageType: GROUP_TRIGGER_MESSAGE_TYPE },
+      )
+      .build()
   }
-  if (params.creationConfig?.topic?.Name) return params.creationConfig.topic.Name
-  if (params.locatorConfig?.topicName) return params.locatorConfig.topicName
-  if (params.locatorConfig?.topicArn) return params.locatorConfig.topicArn
-  if (params.locatorConfig?.queueUrl) return params.locatorConfig.queueUrl
-  return 'sns-group-invalidation-trigger'
 }

--- a/packages/sqs/lib/triggers/SqsInvalidationTrigger.ts
+++ b/packages/sqs/lib/triggers/SqsInvalidationTrigger.ts
@@ -1,0 +1,220 @@
+import type { SubscribeCommandInput } from '@aws-sdk/client-sns'
+import { MessageHandlerConfigBuilder } from '@message-queue-toolkit/core'
+import {
+  AbstractSnsSqsConsumer,
+  type SNSSQSConsumerDependencies,
+  type SNSSQSConsumerOptions,
+  type SNSSQSCreationConfig,
+  type SNSSQSQueueLocatorType,
+} from '@message-queue-toolkit/sns'
+import {
+  AbstractSqsConsumer,
+  type SQSConsumerDependencies,
+  type SQSConsumerOptions,
+  type SQSCreationConfig,
+  type SQSQueueLocatorType,
+} from '@message-queue-toolkit/sqs'
+import type { NotificationPublisher } from 'layered-loader'
+import type { ZodSchema } from 'zod'
+import { runFlatPipeline } from './dispatch.js'
+import type {
+  InvalidationAction,
+  InvalidationResolver,
+  InvalidationTrigger,
+  TriggerErrorHandler,
+} from './types.js'
+
+const TRIGGER_MESSAGE_TYPE = 'layered-loader.invalidation-trigger'
+
+/** Mirror of `SNSSubscriptionOptions` (not re-exported by the upstream package). */
+export type TriggerSubscriptionOptions = Omit<
+  SubscribeCommandInput,
+  'TopicArn' | 'Endpoint' | 'Protocol' | 'ReturnSubscriptionArn'
+> & {
+  updateAttributesIfExists: boolean
+}
+
+export type SqsTriggerSourceConfig =
+  | {
+      sourceType: 'sqs-queue'
+      dependencies: SQSConsumerDependencies
+      creationConfig: SQSCreationConfig
+      locatorConfig?: never
+    }
+  | {
+      sourceType: 'sqs-queue'
+      dependencies: SQSConsumerDependencies
+      creationConfig?: never
+      locatorConfig: SQSQueueLocatorType
+    }
+  | {
+      sourceType: 'sns-topic'
+      dependencies: SNSSQSConsumerDependencies
+      creationConfig: SNSSQSCreationConfig
+      locatorConfig?: never
+      subscriptionConfig?: TriggerSubscriptionOptions
+    }
+  | {
+      sourceType: 'sns-topic'
+      dependencies: SNSSQSConsumerDependencies
+      creationConfig?: never
+      locatorConfig: SNSSQSQueueLocatorType
+      subscriptionConfig?: TriggerSubscriptionOptions
+    }
+
+export type SqsInvalidationTriggerParams<TMessage extends object> = {
+  /**
+   * Schema validating each message body delivered by the upstream transport.
+   * The resolver receives the validated `TMessage`. Use `z.unknown()` (or a
+   * permissive object schema) to accept arbitrary payloads.
+   */
+  messageSchema: ZodSchema<TMessage>
+  resolver: InvalidationResolver<TMessage, InvalidationAction>
+  /**
+   * The notification publisher that propagates invalidation across the cache
+   * cluster.
+   *
+   * **Important**: a trigger publishes invalidations on behalf of an external
+   * domain event, not on behalf of any local Loader. Pass a publisher that has
+   * its own server UUID (distinct from any Loader's notification pair),
+   * otherwise the local pair's consumer will treat the trigger's messages as
+   * self-emitted and drop them — leaving the local in-memory cache stale.
+   *
+   * Construct one with:
+   * ```
+   * const triggerPublisher = new SqsNotificationPublisher({
+   *   serverUuid: randomUUID(),
+   *   dependencies, locatorConfig: { topicName: 'app-invalidations' },
+   * })
+   * ```
+   */
+  publisher: NotificationPublisher<unknown>
+  errorHandler?: TriggerErrorHandler
+  /** Logical channel name passed to {@link errorHandler}. Defaults to a derived value. */
+  channel?: string
+} & SqsTriggerSourceConfig
+
+interface InternalConsumer {
+  init(): Promise<void>
+  start(): Promise<void>
+  close(abort?: boolean): Promise<void>
+}
+
+class SqsQueueTriggerConsumer<TMessage extends object> extends AbstractSqsConsumer<
+  TMessage,
+  TriggerExecutionContext<TMessage>
+> {
+  constructor(
+    dependencies: SQSConsumerDependencies,
+    options: SQSConsumerOptions<TMessage, TriggerExecutionContext<TMessage>, undefined>,
+    context: TriggerExecutionContext<TMessage>,
+  ) {
+    super(dependencies, options, context)
+  }
+}
+
+class SnsTopicTriggerConsumer<TMessage extends object> extends AbstractSnsSqsConsumer<
+  TMessage,
+  TriggerExecutionContext<TMessage>
+> {
+  constructor(
+    dependencies: SNSSQSConsumerDependencies,
+    options: SNSSQSConsumerOptions<TMessage, TriggerExecutionContext<TMessage>, undefined>,
+    context: TriggerExecutionContext<TMessage>,
+  ) {
+    super(dependencies, options, context)
+  }
+}
+
+type TriggerExecutionContext<TMessage> = {
+  resolver: InvalidationResolver<TMessage, InvalidationAction>
+  publisher: NotificationPublisher<unknown>
+  channel: string
+  errorHandler: TriggerErrorHandler | undefined
+}
+
+export class SqsInvalidationTrigger<TMessage extends object> implements InvalidationTrigger {
+  private readonly params: SqsInvalidationTriggerParams<TMessage>
+  private readonly channel: string
+  private internalConsumer?: InternalConsumer
+
+  constructor(params: SqsInvalidationTriggerParams<TMessage>) {
+    this.params = params
+    this.channel = params.channel ?? deriveChannelName(params)
+  }
+
+  async start(): Promise<void> {
+    if (this.internalConsumer) return
+    this.internalConsumer = this.buildConsumer()
+    await this.internalConsumer.init()
+    await this.internalConsumer.start()
+  }
+
+  async stop(): Promise<void> {
+    const consumer = this.internalConsumer
+    if (!consumer) return
+    this.internalConsumer = undefined
+    await consumer.close()
+  }
+
+  private buildConsumer(): InternalConsumer {
+    const handler = async (message: TMessage, ctx: TriggerExecutionContext<TMessage>) => {
+      try {
+        await runFlatPipeline(message, ctx.resolver, ctx.publisher)
+        return { result: 'success' as const }
+      } catch (err) {
+        ctx.errorHandler?.(err as Error, ctx.channel)
+        // Re-throw so message-queue-toolkit's standard retry/DLQ flow takes over.
+        throw err
+      }
+    }
+
+    const handlers = new MessageHandlerConfigBuilder<TMessage, TriggerExecutionContext<TMessage>>()
+      .addConfig(this.params.messageSchema, handler, { messageType: TRIGGER_MESSAGE_TYPE })
+      .build()
+
+    const context: TriggerExecutionContext<TMessage> = {
+      resolver: this.params.resolver,
+      publisher: this.params.publisher,
+      channel: this.channel,
+      errorHandler: this.params.errorHandler,
+    }
+
+    if (this.params.sourceType === 'sqs-queue') {
+      const options: SQSConsumerOptions<TMessage, TriggerExecutionContext<TMessage>, undefined> = {
+        handlers,
+        messageTypeResolver: { literal: TRIGGER_MESSAGE_TYPE },
+        ...(this.params.creationConfig
+          ? { creationConfig: this.params.creationConfig }
+          : { locatorConfig: this.params.locatorConfig }),
+      }
+      return new SqsQueueTriggerConsumer(this.params.dependencies, options, context)
+    }
+
+    const options = {
+      handlers,
+      messageTypeResolver: { literal: TRIGGER_MESSAGE_TYPE },
+      subscriptionConfig: this.params.subscriptionConfig ?? { updateAttributesIfExists: false },
+      ...(this.params.creationConfig
+        ? { creationConfig: this.params.creationConfig }
+        : { locatorConfig: this.params.locatorConfig }),
+    } as SNSSQSConsumerOptions<TMessage, TriggerExecutionContext<TMessage>, undefined>
+    return new SnsTopicTriggerConsumer(this.params.dependencies, options, context)
+  }
+}
+
+function deriveChannelName<TMessage extends object>(
+  params: SqsInvalidationTriggerParams<TMessage>,
+): string {
+  if (params.sourceType === 'sqs-queue') {
+    if (params.creationConfig?.queue?.QueueName) return params.creationConfig.queue.QueueName
+    if (params.locatorConfig?.queueName) return params.locatorConfig.queueName
+    if (params.locatorConfig?.queueUrl) return params.locatorConfig.queueUrl
+    return 'sqs-invalidation-trigger'
+  }
+  if (params.creationConfig?.topic?.Name) return params.creationConfig.topic.Name
+  if (params.locatorConfig?.topicName) return params.locatorConfig.topicName
+  if (params.locatorConfig?.topicArn) return params.locatorConfig.topicArn
+  if (params.locatorConfig?.queueUrl) return params.locatorConfig.queueUrl
+  return 'sns-invalidation-trigger'
+}

--- a/packages/sqs/lib/triggers/SqsInvalidationTrigger.ts
+++ b/packages/sqs/lib/triggers/SqsInvalidationTrigger.ts
@@ -1,66 +1,21 @@
-import type { SubscribeCommandInput } from '@aws-sdk/client-sns'
-import { MessageHandlerConfigBuilder } from '@message-queue-toolkit/core'
-import {
-  AbstractSnsSqsConsumer,
-  type SNSSQSConsumerDependencies,
-  type SNSSQSConsumerOptions,
-  type SNSSQSCreationConfig,
-  type SNSSQSQueueLocatorType,
-} from '@message-queue-toolkit/sns'
-import {
-  AbstractSqsConsumer,
-  type SQSConsumerDependencies,
-  type SQSConsumerOptions,
-  type SQSCreationConfig,
-  type SQSQueueLocatorType,
-} from '@message-queue-toolkit/sqs'
+import { type MessageHandlerConfig, MessageHandlerConfigBuilder } from '@message-queue-toolkit/core'
 import type { NotificationPublisher } from 'layered-loader'
 import type { ZodSchema } from 'zod'
+import {
+  AbstractSqsTrigger,
+  deriveTriggerChannelName,
+  type SqsTriggerSource,
+} from './AbstractSqsTrigger.js'
 import { runFlatPipeline } from './dispatch.js'
 import type {
   InvalidationAction,
   InvalidationResolver,
-  InvalidationTrigger,
   TriggerErrorHandler,
 } from './types.js'
 
 const TRIGGER_MESSAGE_TYPE = 'layered-loader.invalidation-trigger'
 
-/** Mirror of `SNSSubscriptionOptions` (not re-exported by the upstream package). */
-export type TriggerSubscriptionOptions = Omit<
-  SubscribeCommandInput,
-  'TopicArn' | 'Endpoint' | 'Protocol' | 'ReturnSubscriptionArn'
-> & {
-  updateAttributesIfExists: boolean
-}
-
-export type SqsTriggerSourceConfig =
-  | {
-      sourceType: 'sqs-queue'
-      dependencies: SQSConsumerDependencies
-      creationConfig: SQSCreationConfig
-      locatorConfig?: never
-    }
-  | {
-      sourceType: 'sqs-queue'
-      dependencies: SQSConsumerDependencies
-      creationConfig?: never
-      locatorConfig: SQSQueueLocatorType
-    }
-  | {
-      sourceType: 'sns-topic'
-      dependencies: SNSSQSConsumerDependencies
-      creationConfig: SNSSQSCreationConfig
-      locatorConfig?: never
-      subscriptionConfig?: TriggerSubscriptionOptions
-    }
-  | {
-      sourceType: 'sns-topic'
-      dependencies: SNSSQSConsumerDependencies
-      creationConfig?: never
-      locatorConfig: SNSSQSQueueLocatorType
-      subscriptionConfig?: TriggerSubscriptionOptions
-    }
+export type SqsTriggerSourceConfig = SqsTriggerSource
 
 export type SqsInvalidationTriggerParams<TMessage extends object> = {
   /**
@@ -94,127 +49,66 @@ export type SqsInvalidationTriggerParams<TMessage extends object> = {
   channel?: string
 } & SqsTriggerSourceConfig
 
-interface InternalConsumer {
-  init(): Promise<void>
-  start(): Promise<void>
-  close(abort?: boolean): Promise<void>
-}
-
-class SqsQueueTriggerConsumer<TMessage extends object> extends AbstractSqsConsumer<
-  TMessage,
-  TriggerExecutionContext<TMessage>
-> {
-  constructor(
-    dependencies: SQSConsumerDependencies,
-    options: SQSConsumerOptions<TMessage, TriggerExecutionContext<TMessage>, undefined>,
-    context: TriggerExecutionContext<TMessage>,
-  ) {
-    super(dependencies, options, context)
-  }
-}
-
-class SnsTopicTriggerConsumer<TMessage extends object> extends AbstractSnsSqsConsumer<
-  TMessage,
-  TriggerExecutionContext<TMessage>
-> {
-  constructor(
-    dependencies: SNSSQSConsumerDependencies,
-    options: SNSSQSConsumerOptions<TMessage, TriggerExecutionContext<TMessage>, undefined>,
-    context: TriggerExecutionContext<TMessage>,
-  ) {
-    super(dependencies, options, context)
-  }
-}
-
-type TriggerExecutionContext<TMessage> = {
+type FlatTriggerContext<TMessage> = {
   resolver: InvalidationResolver<TMessage, InvalidationAction>
   publisher: NotificationPublisher<unknown>
   channel: string
   errorHandler: TriggerErrorHandler | undefined
 }
 
-export class SqsInvalidationTrigger<TMessage extends object> implements InvalidationTrigger {
-  private readonly params: SqsInvalidationTriggerParams<TMessage>
-  private readonly channel: string
-  private internalConsumer?: InternalConsumer
+export class SqsInvalidationTrigger<TMessage extends object> extends AbstractSqsTrigger<
+  TMessage,
+  FlatTriggerContext<TMessage>
+> {
+  protected readonly source: SqsTriggerSource
+  protected readonly messageType = TRIGGER_MESSAGE_TYPE
+  protected readonly channel: string
+
+  private readonly messageSchema: ZodSchema<TMessage>
+  private readonly resolver: InvalidationResolver<TMessage, InvalidationAction>
+  private readonly publisher: NotificationPublisher<unknown>
+  private readonly errorHandler: TriggerErrorHandler | undefined
 
   constructor(params: SqsInvalidationTriggerParams<TMessage>) {
-    this.params = params
-    this.channel = params.channel ?? deriveChannelName(params)
+    super()
+    const { messageSchema, resolver, publisher, errorHandler, channel, ...source } = params
+    this.source = source as SqsTriggerSource
+    this.messageSchema = messageSchema
+    this.resolver = resolver
+    this.publisher = publisher
+    this.errorHandler = errorHandler
+    this.channel = channel ?? deriveTriggerChannelName(this.source)
   }
 
-  async start(): Promise<void> {
-    if (this.internalConsumer) return
-    this.internalConsumer = this.buildConsumer()
-    await this.internalConsumer.init()
-    await this.internalConsumer.start()
-  }
-
-  async stop(): Promise<void> {
-    const consumer = this.internalConsumer
-    if (!consumer) return
-    this.internalConsumer = undefined
-    await consumer.close()
-  }
-
-  private buildConsumer(): InternalConsumer {
-    const handler = async (message: TMessage, ctx: TriggerExecutionContext<TMessage>) => {
-      try {
-        await runFlatPipeline(message, ctx.resolver, ctx.publisher)
-        return { result: 'success' as const }
-      } catch (err) {
-        ctx.errorHandler?.(err as Error, ctx.channel)
-        // Re-throw so message-queue-toolkit's standard retry/DLQ flow takes over.
-        throw err
-      }
-    }
-
-    const handlers = new MessageHandlerConfigBuilder<TMessage, TriggerExecutionContext<TMessage>>()
-      .addConfig(this.params.messageSchema, handler, { messageType: TRIGGER_MESSAGE_TYPE })
-      .build()
-
-    const context: TriggerExecutionContext<TMessage> = {
-      resolver: this.params.resolver,
-      publisher: this.params.publisher,
+  protected buildContext(): FlatTriggerContext<TMessage> {
+    return {
+      resolver: this.resolver,
+      publisher: this.publisher,
       channel: this.channel,
-      errorHandler: this.params.errorHandler,
+      errorHandler: this.errorHandler,
     }
-
-    if (this.params.sourceType === 'sqs-queue') {
-      const options: SQSConsumerOptions<TMessage, TriggerExecutionContext<TMessage>, undefined> = {
-        handlers,
-        messageTypeResolver: { literal: TRIGGER_MESSAGE_TYPE },
-        ...(this.params.creationConfig
-          ? { creationConfig: this.params.creationConfig }
-          : { locatorConfig: this.params.locatorConfig }),
-      }
-      return new SqsQueueTriggerConsumer(this.params.dependencies, options, context)
-    }
-
-    const options = {
-      handlers,
-      messageTypeResolver: { literal: TRIGGER_MESSAGE_TYPE },
-      subscriptionConfig: this.params.subscriptionConfig ?? { updateAttributesIfExists: false },
-      ...(this.params.creationConfig
-        ? { creationConfig: this.params.creationConfig }
-        : { locatorConfig: this.params.locatorConfig }),
-    } as SNSSQSConsumerOptions<TMessage, TriggerExecutionContext<TMessage>, undefined>
-    return new SnsTopicTriggerConsumer(this.params.dependencies, options, context)
   }
-}
 
-function deriveChannelName<TMessage extends object>(
-  params: SqsInvalidationTriggerParams<TMessage>,
-): string {
-  if (params.sourceType === 'sqs-queue') {
-    if (params.creationConfig?.queue?.QueueName) return params.creationConfig.queue.QueueName
-    if (params.locatorConfig?.queueName) return params.locatorConfig.queueName
-    if (params.locatorConfig?.queueUrl) return params.locatorConfig.queueUrl
-    return 'sqs-invalidation-trigger'
+  protected buildHandlers(): MessageHandlerConfig<
+    TMessage,
+    FlatTriggerContext<TMessage>,
+    undefined
+  >[] {
+    return new MessageHandlerConfigBuilder<TMessage, FlatTriggerContext<TMessage>>()
+      .addConfig(
+        this.messageSchema,
+        async (message, ctx) => {
+          try {
+            await runFlatPipeline(message, ctx.resolver, ctx.publisher)
+            return { result: 'success' as const }
+          } catch (err) {
+            ctx.errorHandler?.(err as Error, ctx.channel)
+            // Re-throw so message-queue-toolkit's standard retry/DLQ flow takes over.
+            throw err
+          }
+        },
+        { messageType: TRIGGER_MESSAGE_TYPE },
+      )
+      .build()
   }
-  if (params.creationConfig?.topic?.Name) return params.creationConfig.topic.Name
-  if (params.locatorConfig?.topicName) return params.locatorConfig.topicName
-  if (params.locatorConfig?.topicArn) return params.locatorConfig.topicArn
-  if (params.locatorConfig?.queueUrl) return params.locatorConfig.queueUrl
-  return 'sns-invalidation-trigger'
 }

--- a/packages/sqs/lib/triggers/dispatch.ts
+++ b/packages/sqs/lib/triggers/dispatch.ts
@@ -13,6 +13,10 @@ function toArray<T>(output: ResolverOutput<T>): readonly T[] {
   return Array.isArray(output) ? output : ([output] as readonly T[])
 }
 
+function assertNever(value: never, label: string): never {
+  throw new Error(`Unhandled ${label} kind: ${JSON.stringify(value)}`)
+}
+
 /**
  * Apply a resolved {@link InvalidationAction} to a flat
  * {@link NotificationPublisher}.
@@ -34,6 +38,8 @@ export async function applyFlatAction(
     case 'clear':
       await publisher.clear()
       return
+    default:
+      assertNever(action, 'InvalidationAction')
   }
 }
 
@@ -55,6 +61,8 @@ export async function applyGroupAction(
     case 'clear':
       await publisher.clear()
       return
+    default:
+      assertNever(action, 'GroupInvalidationAction')
   }
 }
 

--- a/packages/sqs/lib/triggers/dispatch.ts
+++ b/packages/sqs/lib/triggers/dispatch.ts
@@ -7,8 +7,10 @@ import type {
 } from './types.js'
 
 function toArray<T>(output: ResolverOutput<T>): readonly T[] {
-  if (output === undefined || output === null) return []
-  return Array.isArray(output) ? output : [output as T]
+  if (output == null) return []
+  // T is a discriminated-union object type, never an array, so narrowing via
+  // Array.isArray is safe — but TS can't prove that for an arbitrary T.
+  return Array.isArray(output) ? output : ([output] as readonly T[])
 }
 
 /**

--- a/packages/sqs/lib/triggers/dispatch.ts
+++ b/packages/sqs/lib/triggers/dispatch.ts
@@ -1,0 +1,84 @@
+import type { GroupNotificationPublisher, NotificationPublisher } from 'layered-loader'
+import type {
+  GroupInvalidationAction,
+  InvalidationAction,
+  InvalidationResolver,
+  ResolverOutput,
+} from './types.js'
+
+function toArray<T>(output: ResolverOutput<T>): readonly T[] {
+  if (output === undefined || output === null) return []
+  return Array.isArray(output) ? output : [output as T]
+}
+
+/**
+ * Apply a resolved {@link InvalidationAction} to a flat
+ * {@link NotificationPublisher}.
+ */
+export async function applyFlatAction(
+  action: InvalidationAction,
+  publisher: NotificationPublisher<unknown>,
+): Promise<void> {
+  switch (action.kind) {
+    case 'delete':
+      await publisher.delete(action.key)
+      return
+    case 'deleteMany':
+      await publisher.deleteMany([...action.keys])
+      return
+    case 'set':
+      await publisher.set(action.key, action.value)
+      return
+    case 'clear':
+      await publisher.clear()
+      return
+  }
+}
+
+/**
+ * Apply a resolved {@link GroupInvalidationAction} to a
+ * {@link GroupNotificationPublisher}.
+ */
+export async function applyGroupAction(
+  action: GroupInvalidationAction,
+  publisher: GroupNotificationPublisher<unknown>,
+): Promise<void> {
+  switch (action.kind) {
+    case 'deleteFromGroup':
+      await publisher.deleteFromGroup(action.key, action.group)
+      return
+    case 'deleteGroup':
+      await publisher.deleteGroup(action.group)
+      return
+    case 'clear':
+      await publisher.clear()
+      return
+  }
+}
+
+/**
+ * Run the resolver and apply each emitted action sequentially. Errors
+ * propagate to the caller, allowing the transport adapter to decide whether
+ * to retry the source message.
+ */
+export async function runFlatPipeline<TMessage>(
+  message: TMessage,
+  resolver: InvalidationResolver<TMessage, InvalidationAction>,
+  publisher: NotificationPublisher<unknown>,
+): Promise<void> {
+  const result = await resolver(message)
+  for (const action of toArray(result)) {
+    await applyFlatAction(action, publisher)
+  }
+}
+
+export async function runGroupPipeline<TMessage>(
+  message: TMessage,
+  resolver: InvalidationResolver<TMessage, GroupInvalidationAction>,
+  publisher: GroupNotificationPublisher<unknown>,
+): Promise<void> {
+  const result = await resolver(message)
+  for (const action of toArray(result)) {
+    await applyGroupAction(action, publisher)
+  }
+}

--- a/packages/sqs/lib/triggers/types.ts
+++ b/packages/sqs/lib/triggers/types.ts
@@ -1,0 +1,53 @@
+/**
+ * Transport-agnostic primitives for building invalidation triggers.
+ *
+ * A trigger consumes domain events from an arbitrary upstream messaging system
+ * (SNS topic, SQS queue, RabbitMQ exchange, Kafka topic, ...) that has no
+ * knowledge of the caching layer. A {@link InvalidationResolver} maps each
+ * incoming message to one or more {@link InvalidationAction}s, which the
+ * trigger then dispatches via a configured layered-loader notification
+ * publisher to fan out across the cache cluster.
+ */
+
+/** Invalidation operations supported by `NotificationPublisher`. */
+export type InvalidationAction =
+  | { kind: 'delete'; key: string }
+  | { kind: 'deleteMany'; keys: readonly string[] }
+  | { kind: 'set'; key: string; value: unknown }
+  | { kind: 'clear' }
+
+/** Invalidation operations supported by `GroupNotificationPublisher`. */
+export type GroupInvalidationAction =
+  | { kind: 'deleteFromGroup'; key: string; group: string }
+  | { kind: 'deleteGroup'; group: string }
+  | { kind: 'clear' }
+
+export type ResolverOutput<TAction> =
+  | TAction
+  | readonly TAction[]
+  | null
+  | undefined
+  | void
+
+/**
+ * Pure function turning a parsed upstream message into invalidation
+ * action(s). Return `undefined`/`null` to skip the message.
+ */
+export type InvalidationResolver<TMessage, TAction> = (
+  message: TMessage,
+) => ResolverOutput<TAction> | Promise<ResolverOutput<TAction>>
+
+/** Lifecycle contract every trigger implementation honours. */
+export interface InvalidationTrigger {
+  /** Begin consuming messages from the upstream source. */
+  start(): Promise<void>
+  /** Stop consuming and release resources. Idempotent. */
+  stop(): Promise<void>
+}
+
+/**
+ * Invoked when the trigger pipeline (resolver + publish) fails for a single
+ * message. The transport may re-deliver the message regardless; this hook is
+ * for observability only.
+ */
+export type TriggerErrorHandler = (err: Error, channel: string) => void

--- a/packages/sqs/lib/triggers/types.ts
+++ b/packages/sqs/lib/triggers/types.ts
@@ -22,12 +22,7 @@ export type GroupInvalidationAction =
   | { kind: 'deleteGroup'; group: string }
   | { kind: 'clear' }
 
-export type ResolverOutput<TAction> =
-  | TAction
-  | readonly TAction[]
-  | null
-  | undefined
-  | void
+export type ResolverOutput<TAction> = TAction | readonly TAction[] | null | undefined
 
 /**
  * Pure function turning a parsed upstream message into invalidation
@@ -39,7 +34,7 @@ export type InvalidationResolver<TMessage, TAction> = (
 
 /** Lifecycle contract every trigger implementation honours. */
 export interface InvalidationTrigger {
-  /** Begin consuming messages from the upstream source. */
+  /** Begin consuming messages from the upstream source. Idempotent. */
   start(): Promise<void>
   /** Stop consuming and release resources. Idempotent. */
   stop(): Promise<void>

--- a/packages/sqs/package.json
+++ b/packages/sqs/package.json
@@ -47,7 +47,7 @@
     "@message-queue-toolkit/sns": ">=24.0.0",
     "@message-queue-toolkit/sqs": ">=23.0.0",
     "layered-loader": "workspace:^",
-    "zod": ">=3.25.76 <5.0.0"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@aws-sdk/client-sns": "^3.926.0",

--- a/packages/sqs/package.json
+++ b/packages/sqs/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@layered-loader/sqs",
+  "version": "0.1.0",
+  "description": "SNS/SQS remote invalidation adapter for layered-loader",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "lint": "tsc --noEmit"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/kibertoad/layered-loader.git",
+    "directory": "packages/sqs"
+  },
+  "files": ["dist/*", "README.md", "LICENSE"],
+  "keywords": [
+    "layered-loader",
+    "sqs",
+    "sns",
+    "aws",
+    "cache",
+    "invalidation",
+    "notification",
+    "pub-sub"
+  ],
+  "peerDependencies": {
+    "@aws-sdk/client-sns": "^3.632.0",
+    "@aws-sdk/client-sqs": "^3.632.0",
+    "@aws-sdk/client-sts": "^3.632.0",
+    "@lokalise/node-core": "^14.0.0",
+    "@message-queue-toolkit/core": ">=24.0.0",
+    "@message-queue-toolkit/sns": ">=24.0.0",
+    "@message-queue-toolkit/sqs": ">=23.0.0",
+    "layered-loader": "workspace:^",
+    "zod": ">=3.25.76 <5.0.0"
+  },
+  "devDependencies": {
+    "@aws-sdk/client-sns": "^3.926.0",
+    "@aws-sdk/client-sqs": "^3.926.0",
+    "@aws-sdk/client-sts": "^3.926.0",
+    "@lokalise/node-core": "^14.8.1",
+    "@message-queue-toolkit/core": "^25.4.0",
+    "@message-queue-toolkit/sns": "^24.6.1",
+    "@message-queue-toolkit/sqs": "^24.2.1",
+    "@types/node": "^22.19.15",
+    "@vitest/coverage-v8": "^4.1.0",
+    "fauxqs": "^2.5.0",
+    "layered-loader": "workspace:^",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.0",
+    "zod": "^4.4.3"
+  }
+}

--- a/packages/sqs/test/SqsGroupInvalidationTrigger.spec.ts
+++ b/packages/sqs/test/SqsGroupInvalidationTrigger.spec.ts
@@ -8,46 +8,9 @@ import { SqsGroupNotificationPublisher } from '../lib/SqsGroupNotificationPublis
 import { SqsGroupInvalidationTrigger } from '../lib/triggers/SqsGroupInvalidationTrigger.js'
 import { type AwsClientBundle, buildAwsClients } from './fakes/awsClients.js'
 import { buildConsumerDeps, buildPublisherDeps } from './fakes/dependencies.js'
+import { StubGroupedAsyncCache, waitFor } from './utils/testHelpers.js'
 
 const IN_MEMORY_CACHE_CONFIG = { ttlInMsecs: 99999 } satisfies InMemoryCacheConfiguration
-
-class StubGroupedAsyncCache {
-  public name = 'StubGroupedAsyncCache'
-  constructor(private readonly value: string) {}
-  getFromGroup() {
-    return Promise.resolve(this.value)
-  }
-  getManyFromGroup(keys: string[]) {
-    return Promise.resolve({ resolvedValues: keys.map(() => this.value), unresolvedKeys: [] })
-  }
-  setForGroup(): Promise<void> {
-    return Promise.resolve()
-  }
-  deleteFromGroup(): Promise<void> {
-    return Promise.resolve()
-  }
-  deleteGroup(): Promise<void> {
-    return Promise.resolve()
-  }
-  clear(): Promise<void> {
-    return Promise.resolve()
-  }
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-  getExpirationTimeFromGroup() {
-    return Promise.resolve(undefined)
-  }
-}
-
-async function waitFor(predicate: () => boolean, timeoutMs = 5000, intervalMs = 50): Promise<void> {
-  const start = Date.now()
-  while (Date.now() - start < timeoutMs) {
-    if (predicate()) return
-    await new Promise((resolve) => setTimeout(resolve, intervalMs))
-  }
-  throw new Error('Timed out waiting for predicate')
-}
 
 const TENANT_EVENT_SCHEMA = z.object({
   type: z.enum(['tenant.user.updated', 'tenant.purged']),

--- a/packages/sqs/test/SqsGroupInvalidationTrigger.spec.ts
+++ b/packages/sqs/test/SqsGroupInvalidationTrigger.spec.ts
@@ -1,0 +1,174 @@
+import { randomUUID } from 'node:crypto'
+import { CreateTopicCommand, PublishCommand } from '@aws-sdk/client-sns'
+import { GroupLoader, type InMemoryCacheConfiguration } from 'layered-loader'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { createGroupNotificationPair } from '../lib/SqsGroupNotificationFactory.js'
+import { SqsGroupNotificationPublisher } from '../lib/SqsGroupNotificationPublisher.js'
+import { SqsGroupInvalidationTrigger } from '../lib/triggers/SqsGroupInvalidationTrigger.js'
+import { type AwsClientBundle, buildAwsClients } from './fakes/awsClients.js'
+import { buildConsumerDeps, buildPublisherDeps } from './fakes/dependencies.js'
+
+const IN_MEMORY_CACHE_CONFIG = { ttlInMsecs: 99999 } satisfies InMemoryCacheConfiguration
+
+class StubGroupedAsyncCache {
+  public name = 'StubGroupedAsyncCache'
+  constructor(private readonly value: string) {}
+  getFromGroup() {
+    return Promise.resolve(this.value)
+  }
+  getManyFromGroup(keys: string[]) {
+    return Promise.resolve({ resolvedValues: keys.map(() => this.value), unresolvedKeys: [] })
+  }
+  setForGroup(): Promise<void> {
+    return Promise.resolve()
+  }
+  deleteFromGroup(): Promise<void> {
+    return Promise.resolve()
+  }
+  deleteGroup(): Promise<void> {
+    return Promise.resolve()
+  }
+  clear(): Promise<void> {
+    return Promise.resolve()
+  }
+  close(): Promise<void> {
+    return Promise.resolve()
+  }
+  getExpirationTimeFromGroup() {
+    return Promise.resolve(undefined)
+  }
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 5000, intervalMs = 50): Promise<void> {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+  throw new Error('Timed out waiting for predicate')
+}
+
+const TENANT_EVENT_SCHEMA = z.object({
+  type: z.enum(['tenant.user.updated', 'tenant.purged']),
+  tenantId: z.string(),
+  userId: z.string().optional(),
+})
+type TenantEvent = z.infer<typeof TENANT_EVENT_SCHEMA>
+
+describe('SqsGroupInvalidationTrigger', () => {
+  let clients: AwsClientBundle
+
+  beforeAll(() => {
+    const endpoint = process.env.FAUXQS_ENDPOINT
+    if (!endpoint) throw new Error('FAUXQS_ENDPOINT is not set; globalSetup did not run')
+    clients = buildAwsClients(endpoint)
+  })
+
+  afterAll(() => {
+    clients.destroy()
+  })
+
+  it('translates tenant events into per-group invalidation across the cluster', async () => {
+    const suffix = Math.random().toString(36).slice(2, 8)
+    const invalidationTopic = `group-trigger-${suffix}`
+
+    const peer = createGroupNotificationPair<string>({
+      publisher: {
+        dependencies: buildPublisherDeps(clients),
+        creationConfig: { topic: { Name: invalidationTopic } },
+      },
+      consumer: {
+        dependencies: buildConsumerDeps(clients),
+        creationConfig: {
+          topic: { Name: invalidationTopic },
+          queue: { QueueName: `group-trigger-peer-q-${suffix}` },
+        },
+      },
+    })
+
+    const loader = new GroupLoader<string>({
+      inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+      asyncCache: new StubGroupedAsyncCache('value'),
+      notificationConsumer: peer.consumer,
+      notificationPublisher: peer.publisher,
+    })
+
+    const upstreamTopicName = `tenant-events-${suffix}`
+    const createTopic = await clients.snsClient.send(
+      new CreateTopicCommand({ Name: upstreamTopicName }),
+    )
+    const upstreamTopicArn = createTopic.TopicArn!
+
+    const triggerPublisher = new SqsGroupNotificationPublisher<string>({
+      serverUuid: randomUUID(),
+      dependencies: buildPublisherDeps(clients),
+      locatorConfig: { topicName: invalidationTopic },
+    })
+
+    const trigger = new SqsGroupInvalidationTrigger<TenantEvent>({
+      sourceType: 'sns-topic',
+      dependencies: buildConsumerDeps(clients),
+      creationConfig: {
+        topic: { Name: upstreamTopicName },
+        queue: { QueueName: `group-trigger-q-${suffix}` },
+      },
+      messageSchema: TENANT_EVENT_SCHEMA,
+      publisher: triggerPublisher,
+      resolver: (msg) => {
+        if (msg.type === 'tenant.purged') {
+          return { kind: 'deleteGroup', group: msg.tenantId }
+        }
+        if (msg.type === 'tenant.user.updated' && msg.userId) {
+          return { kind: 'deleteFromGroup', key: msg.userId, group: msg.tenantId }
+        }
+        return null
+      },
+    })
+
+    try {
+      await loader.init()
+      await trigger.start()
+
+      await loader.getAsyncOnly('user-1', 'tenant-A')
+      await loader.getAsyncOnly('user-2', 'tenant-A')
+      await loader.getAsyncOnly('user-1', 'tenant-B')
+      expect(loader.getInMemoryOnly('user-1', 'tenant-A')).toBe('value')
+
+      // single-key invalidation
+      await clients.snsClient.send(
+        new PublishCommand({
+          TopicArn: upstreamTopicArn,
+          Message: JSON.stringify({
+            type: 'tenant.user.updated',
+            tenantId: 'tenant-A',
+            userId: 'user-1',
+          }),
+        }),
+      )
+      await waitFor(() => loader.getInMemoryOnly('user-1', 'tenant-A') === undefined)
+      expect(loader.getInMemoryOnly('user-1', 'tenant-A')).toBeUndefined()
+      expect(loader.getInMemoryOnly('user-2', 'tenant-A')).toBe('value')
+      expect(loader.getInMemoryOnly('user-1', 'tenant-B')).toBe('value')
+
+      // whole-group invalidation
+      await clients.snsClient.send(
+        new PublishCommand({
+          TopicArn: upstreamTopicArn,
+          Message: JSON.stringify({ type: 'tenant.purged', tenantId: 'tenant-A' }),
+        }),
+      )
+      await waitFor(() => loader.getInMemoryOnly('user-2', 'tenant-A') === undefined)
+      expect(loader.getInMemoryOnly('user-2', 'tenant-A')).toBeUndefined()
+      // Sibling tenant unaffected
+      expect(loader.getInMemoryOnly('user-1', 'tenant-B')).toBe('value')
+    } finally {
+      await Promise.allSettled([
+        trigger.stop(),
+        triggerPublisher.close(),
+        peer.consumer.close(),
+        peer.publisher.close(),
+      ])
+    }
+  })
+})

--- a/packages/sqs/test/SqsGroupNotificationPublisher.spec.ts
+++ b/packages/sqs/test/SqsGroupNotificationPublisher.spec.ts
@@ -1,0 +1,271 @@
+import { GroupLoader, type InMemoryCacheConfiguration } from 'layered-loader'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { createGroupNotificationPair } from '../lib/SqsGroupNotificationFactory.js'
+import { type AwsClientBundle, buildAwsClients } from './fakes/awsClients.js'
+import { buildConsumerDeps, buildPublisherDeps } from './fakes/dependencies.js'
+
+const IN_MEMORY_CACHE_CONFIG = { ttlInMsecs: 99999 } satisfies InMemoryCacheConfiguration
+
+class StubGroupedAsyncCache {
+  public name = 'StubGroupedAsyncCache'
+  constructor(private readonly value: string) {}
+  getFromGroup() {
+    return Promise.resolve(this.value)
+  }
+  getManyFromGroup(keys: string[]) {
+    return Promise.resolve({ resolvedValues: keys.map(() => this.value), unresolvedKeys: [] })
+  }
+  setForGroup(): Promise<void> {
+    return Promise.resolve()
+  }
+  deleteFromGroup(): Promise<void> {
+    return Promise.resolve()
+  }
+  deleteGroup(): Promise<void> {
+    return Promise.resolve()
+  }
+  clear(): Promise<void> {
+    return Promise.resolve()
+  }
+  close(): Promise<void> {
+    return Promise.resolve()
+  }
+  getExpirationTimeFromGroup() {
+    return Promise.resolve(undefined)
+  }
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 5000, intervalMs = 50): Promise<void> {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+  throw new Error('Timed out waiting for predicate')
+}
+
+describe('SqsGroupNotificationPublisher', () => {
+  let clients: AwsClientBundle
+
+  beforeAll(() => {
+    const endpoint = process.env.FAUXQS_ENDPOINT
+    if (!endpoint) throw new Error('FAUXQS_ENDPOINT is not set; globalSetup did not run')
+    clients = buildAwsClients(endpoint)
+  })
+
+  afterAll(() => {
+    clients.destroy()
+  })
+
+  it('propagates a deleteFromGroup event to all remote consumers', async () => {
+    const suffix = Math.random().toString(36).slice(2, 8)
+    const topicName = `g-delete-from-${suffix}`
+
+    const pair1 = createGroupNotificationPair<string>({
+      publisher: {
+        dependencies: buildPublisherDeps(clients),
+        creationConfig: { topic: { Name: topicName } },
+      },
+      consumer: {
+        dependencies: buildConsumerDeps(clients),
+        creationConfig: {
+          topic: { Name: topicName },
+          queue: { QueueName: `g-delete-from-q1-${suffix}` },
+        },
+      },
+    })
+
+    const pair2 = createGroupNotificationPair<string>({
+      publisher: {
+        dependencies: buildPublisherDeps(clients),
+        creationConfig: { topic: { Name: topicName } },
+      },
+      consumer: {
+        dependencies: buildConsumerDeps(clients),
+        creationConfig: {
+          topic: { Name: topicName },
+          queue: { QueueName: `g-delete-from-q2-${suffix}` },
+        },
+      },
+    })
+
+    const loader1 = new GroupLoader<string>({
+      inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+      asyncCache: new StubGroupedAsyncCache('value'),
+      notificationConsumer: pair1.consumer,
+      notificationPublisher: pair1.publisher,
+    })
+    const loader2 = new GroupLoader<string>({
+      inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+      asyncCache: new StubGroupedAsyncCache('value'),
+      notificationConsumer: pair2.consumer,
+      notificationPublisher: pair2.publisher,
+    })
+
+    try {
+      await loader1.init()
+      await loader2.init()
+
+      await loader1.getAsyncOnly('key', 'group1')
+      await loader2.getAsyncOnly('key', 'group1')
+
+      expect(loader1.getInMemoryOnly('key', 'group1')).toBe('value')
+      expect(loader2.getInMemoryOnly('key', 'group1')).toBe('value')
+
+      await loader1.invalidateCacheFor('key', 'group1')
+
+      await waitFor(() => loader2.getInMemoryOnly('key', 'group1') === undefined)
+      expect(loader2.getInMemoryOnly('key', 'group1')).toBeUndefined()
+    } finally {
+      await Promise.allSettled([
+        pair1.consumer.close(),
+        pair2.consumer.close(),
+        pair1.publisher.close(),
+        pair2.publisher.close(),
+      ])
+    }
+  })
+
+  it('propagates a deleteGroup event to all remote consumers', async () => {
+    const suffix = Math.random().toString(36).slice(2, 8)
+    const topicName = `g-delete-${suffix}`
+
+    const pair1 = createGroupNotificationPair<string>({
+      publisher: {
+        dependencies: buildPublisherDeps(clients),
+        creationConfig: { topic: { Name: topicName } },
+      },
+      consumer: {
+        dependencies: buildConsumerDeps(clients),
+        creationConfig: {
+          topic: { Name: topicName },
+          queue: { QueueName: `g-delete-q1-${suffix}` },
+        },
+      },
+    })
+
+    const pair2 = createGroupNotificationPair<string>({
+      publisher: {
+        dependencies: buildPublisherDeps(clients),
+        creationConfig: { topic: { Name: topicName } },
+      },
+      consumer: {
+        dependencies: buildConsumerDeps(clients),
+        creationConfig: {
+          topic: { Name: topicName },
+          queue: { QueueName: `g-delete-q2-${suffix}` },
+        },
+      },
+    })
+
+    const loader1 = new GroupLoader<string>({
+      inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+      asyncCache: new StubGroupedAsyncCache('value'),
+      notificationConsumer: pair1.consumer,
+      notificationPublisher: pair1.publisher,
+    })
+    const loader2 = new GroupLoader<string>({
+      inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+      asyncCache: new StubGroupedAsyncCache('value'),
+      notificationConsumer: pair2.consumer,
+      notificationPublisher: pair2.publisher,
+    })
+
+    try {
+      await loader1.init()
+      await loader2.init()
+
+      await loader1.getAsyncOnly('keyA', 'group1')
+      await loader2.getAsyncOnly('keyA', 'group1')
+      await loader2.getAsyncOnly('keyB', 'group1')
+
+      await loader1.invalidateCacheForGroup('group1')
+
+      await waitFor(
+        () =>
+          loader2.getInMemoryOnly('keyA', 'group1') === undefined &&
+          loader2.getInMemoryOnly('keyB', 'group1') === undefined,
+      )
+      expect(loader2.getInMemoryOnly('keyA', 'group1')).toBeUndefined()
+      expect(loader2.getInMemoryOnly('keyB', 'group1')).toBeUndefined()
+    } finally {
+      await Promise.allSettled([
+        pair1.consumer.close(),
+        pair2.consumer.close(),
+        pair1.publisher.close(),
+        pair2.publisher.close(),
+      ])
+    }
+  })
+
+  it('propagates a clear event to all remote consumers', async () => {
+    const suffix = Math.random().toString(36).slice(2, 8)
+    const topicName = `g-clear-${suffix}`
+
+    const pair1 = createGroupNotificationPair<string>({
+      publisher: {
+        dependencies: buildPublisherDeps(clients),
+        creationConfig: { topic: { Name: topicName } },
+      },
+      consumer: {
+        dependencies: buildConsumerDeps(clients),
+        creationConfig: {
+          topic: { Name: topicName },
+          queue: { QueueName: `g-clear-q1-${suffix}` },
+        },
+      },
+    })
+
+    const pair2 = createGroupNotificationPair<string>({
+      publisher: {
+        dependencies: buildPublisherDeps(clients),
+        creationConfig: { topic: { Name: topicName } },
+      },
+      consumer: {
+        dependencies: buildConsumerDeps(clients),
+        creationConfig: {
+          topic: { Name: topicName },
+          queue: { QueueName: `g-clear-q2-${suffix}` },
+        },
+      },
+    })
+
+    const loader1 = new GroupLoader<string>({
+      inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+      asyncCache: new StubGroupedAsyncCache('value'),
+      notificationConsumer: pair1.consumer,
+      notificationPublisher: pair1.publisher,
+    })
+    const loader2 = new GroupLoader<string>({
+      inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+      asyncCache: new StubGroupedAsyncCache('value'),
+      notificationConsumer: pair2.consumer,
+      notificationPublisher: pair2.publisher,
+    })
+
+    try {
+      await loader1.init()
+      await loader2.init()
+
+      await loader2.getAsyncOnly('keyA', 'groupA')
+      await loader2.getAsyncOnly('keyB', 'groupB')
+
+      await loader1.invalidateCache()
+
+      await waitFor(
+        () =>
+          loader2.getInMemoryOnly('keyA', 'groupA') === undefined &&
+          loader2.getInMemoryOnly('keyB', 'groupB') === undefined,
+      )
+      expect(loader2.getInMemoryOnly('keyA', 'groupA')).toBeUndefined()
+      expect(loader2.getInMemoryOnly('keyB', 'groupB')).toBeUndefined()
+    } finally {
+      await Promise.allSettled([
+        pair1.consumer.close(),
+        pair2.consumer.close(),
+        pair1.publisher.close(),
+        pair2.publisher.close(),
+      ])
+    }
+  })
+})

--- a/packages/sqs/test/SqsGroupNotificationPublisher.spec.ts
+++ b/packages/sqs/test/SqsGroupNotificationPublisher.spec.ts
@@ -3,46 +3,9 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { createGroupNotificationPair } from '../lib/SqsGroupNotificationFactory.js'
 import { type AwsClientBundle, buildAwsClients } from './fakes/awsClients.js'
 import { buildConsumerDeps, buildPublisherDeps } from './fakes/dependencies.js'
+import { StubGroupedAsyncCache, waitFor } from './utils/testHelpers.js'
 
 const IN_MEMORY_CACHE_CONFIG = { ttlInMsecs: 99999 } satisfies InMemoryCacheConfiguration
-
-class StubGroupedAsyncCache {
-  public name = 'StubGroupedAsyncCache'
-  constructor(private readonly value: string) {}
-  getFromGroup() {
-    return Promise.resolve(this.value)
-  }
-  getManyFromGroup(keys: string[]) {
-    return Promise.resolve({ resolvedValues: keys.map(() => this.value), unresolvedKeys: [] })
-  }
-  setForGroup(): Promise<void> {
-    return Promise.resolve()
-  }
-  deleteFromGroup(): Promise<void> {
-    return Promise.resolve()
-  }
-  deleteGroup(): Promise<void> {
-    return Promise.resolve()
-  }
-  clear(): Promise<void> {
-    return Promise.resolve()
-  }
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-  getExpirationTimeFromGroup() {
-    return Promise.resolve(undefined)
-  }
-}
-
-async function waitFor(predicate: () => boolean, timeoutMs = 5000, intervalMs = 50): Promise<void> {
-  const start = Date.now()
-  while (Date.now() - start < timeoutMs) {
-    if (predicate()) return
-    await new Promise((resolve) => setTimeout(resolve, intervalMs))
-  }
-  throw new Error('Timed out waiting for predicate')
-}
 
 describe('SqsGroupNotificationPublisher', () => {
   let clients: AwsClientBundle

--- a/packages/sqs/test/SqsGroupNotificationPublisher.spec.ts
+++ b/packages/sqs/test/SqsGroupNotificationPublisher.spec.ts
@@ -231,4 +231,42 @@ describe('SqsGroupNotificationPublisher', () => {
       ])
     }
   })
+
+  it('retries subscribe after a previous init attempt failed', async () => {
+    const suffix = Math.random().toString(36).slice(2, 8)
+    const { publisher } = createGroupNotificationPair<string>({
+      publisher: {
+        dependencies: buildPublisherDeps(clients),
+        creationConfig: { topic: { Name: `g-retry-test-${suffix}` } },
+      },
+      consumer: {
+        dependencies: buildConsumerDeps(clients),
+        creationConfig: {
+          topic: { Name: 'irrelevant' },
+          queue: { QueueName: 'irrelevant-q' },
+        },
+      },
+    })
+
+    const inner = (publisher as unknown as { publisher: { init: () => Promise<unknown> } })
+      .publisher
+    const realInit = inner.init.bind(inner)
+    let calls = 0
+    inner.init = () => {
+      calls += 1
+      if (calls === 1) return Promise.reject(new Error('transient AWS error'))
+      return realInit()
+    }
+
+    try {
+      await expect(publisher.subscribe()).rejects.toThrow('transient AWS error')
+      expect(publisher.topicArn).toBeUndefined()
+
+      await publisher.subscribe()
+      expect(calls).toBe(2)
+      expect(publisher.topicArn).toBeTruthy()
+    } finally {
+      await publisher.close().catch(() => undefined)
+    }
+  })
 })

--- a/packages/sqs/test/SqsInvalidationTrigger.spec.ts
+++ b/packages/sqs/test/SqsInvalidationTrigger.spec.ts
@@ -1,0 +1,516 @@
+import { randomUUID } from 'node:crypto'
+import { CreateQueueCommand, GetQueueUrlCommand, SendMessageCommand } from '@aws-sdk/client-sqs'
+import { CreateTopicCommand, PublishCommand } from '@aws-sdk/client-sns'
+import { Loader, type InMemoryCacheConfiguration } from 'layered-loader'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { createNotificationPair } from '../lib/SqsNotificationFactory.js'
+import { SqsNotificationPublisher } from '../lib/SqsNotificationPublisher.js'
+import { SqsInvalidationTrigger } from '../lib/triggers/SqsInvalidationTrigger.js'
+import { type AwsClientBundle, buildAwsClients } from './fakes/awsClients.js'
+import { buildConsumerDeps, buildPublisherDeps } from './fakes/dependencies.js'
+
+const IN_MEMORY_CACHE_CONFIG = { ttlInMsecs: 99999 } satisfies InMemoryCacheConfiguration
+
+class StubAsyncCache {
+  public name = 'StubAsyncCache'
+  constructor(private readonly value: string) {}
+  get() {
+    return Promise.resolve(this.value)
+  }
+  getMany(keys: string[]) {
+    return Promise.resolve({ resolvedValues: keys.map(() => this.value), unresolvedKeys: [] })
+  }
+  set(): Promise<void> {
+    return Promise.resolve()
+  }
+  delete(): Promise<void> {
+    return Promise.resolve()
+  }
+  deleteMany(): Promise<void> {
+    return Promise.resolve()
+  }
+  clear(): Promise<void> {
+    return Promise.resolve()
+  }
+  close(): Promise<void> {
+    return Promise.resolve()
+  }
+  getExpirationTime() {
+    return Promise.resolve(undefined)
+  }
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 5000, intervalMs = 50): Promise<void> {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+  throw new Error('Timed out waiting for predicate')
+}
+
+const UPSTREAM_EVENT_SCHEMA = z.object({
+  eventType: z.enum(['user.updated', 'user.deleted', 'user.bulk-updated', 'cache.flush']),
+  userId: z.string().optional(),
+  userIds: z.array(z.string()).optional(),
+})
+type UpstreamEvent = z.infer<typeof UPSTREAM_EVENT_SCHEMA>
+
+describe('SqsInvalidationTrigger', () => {
+  let clients: AwsClientBundle
+
+  beforeAll(() => {
+    const endpoint = process.env.FAUXQS_ENDPOINT
+    if (!endpoint) throw new Error('FAUXQS_ENDPOINT is not set; globalSetup did not run')
+    clients = buildAwsClients(endpoint)
+  })
+
+  afterAll(() => {
+    clients.destroy()
+  })
+
+  describe('SNS topic source', () => {
+    it('translates upstream events to fan-out invalidations across the cluster', async () => {
+      const suffix = Math.random().toString(36).slice(2, 8)
+      // 1. The application's own invalidation channel (the one peer caches subscribe to)
+      const peerATopic = `app-invalidation-${suffix}`
+      const peerAQueue1 = `app-invalidation-q1-${suffix}`
+      const peerAQueue2 = `app-invalidation-q2-${suffix}`
+
+      const peerA = createNotificationPair<string>({
+        publisher: {
+          dependencies: buildPublisherDeps(clients),
+          creationConfig: { topic: { Name: peerATopic } },
+        },
+        consumer: {
+          dependencies: buildConsumerDeps(clients),
+          creationConfig: {
+            topic: { Name: peerATopic },
+            queue: { QueueName: peerAQueue1 },
+          },
+        },
+      })
+
+      const peerB = createNotificationPair<string>({
+        publisher: {
+          dependencies: buildPublisherDeps(clients),
+          creationConfig: { topic: { Name: peerATopic } },
+        },
+        consumer: {
+          dependencies: buildConsumerDeps(clients),
+          creationConfig: {
+            topic: { Name: peerATopic },
+            queue: { QueueName: peerAQueue2 },
+          },
+        },
+      })
+
+      const loaderA = new Loader<string>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        asyncCache: new StubAsyncCache('value'),
+        notificationConsumer: peerA.consumer,
+        notificationPublisher: peerA.publisher,
+      })
+      const loaderB = new Loader<string>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        asyncCache: new StubAsyncCache('value'),
+        notificationConsumer: peerB.consumer,
+        notificationPublisher: peerB.publisher,
+      })
+
+      // 2. The upstream domain-event topic owned by some other service.
+      const upstreamTopicName = `domain-events-${suffix}`
+      const createTopic = await clients.snsClient.send(
+        new CreateTopicCommand({ Name: upstreamTopicName }),
+      )
+      const upstreamTopicArn = createTopic.TopicArn!
+
+      // The trigger needs its own publisher with a distinct serverUuid so that
+      // every peer consumer — including the one running in this process —
+      // treats trigger-emitted messages as foreign.
+      const triggerPublisher = new SqsNotificationPublisher<string>({
+        serverUuid: randomUUID(),
+        dependencies: buildPublisherDeps(clients),
+        locatorConfig: { topicName: peerATopic },
+      })
+
+      // 3. The trigger subscribes our fan-out queue to that upstream topic.
+      const trigger = new SqsInvalidationTrigger<UpstreamEvent>({
+        sourceType: 'sns-topic',
+        dependencies: buildConsumerDeps(clients),
+        creationConfig: {
+          topic: { Name: upstreamTopicName },
+          queue: { QueueName: `trigger-q-${suffix}` },
+        },
+        messageSchema: UPSTREAM_EVENT_SCHEMA,
+        publisher: triggerPublisher,
+        resolver: (msg) => {
+          switch (msg.eventType) {
+            case 'user.updated':
+            case 'user.deleted':
+              return msg.userId ? { kind: 'delete', key: msg.userId } : null
+            case 'user.bulk-updated':
+              return msg.userIds && msg.userIds.length > 0
+                ? { kind: 'deleteMany', keys: msg.userIds }
+                : null
+            case 'cache.flush':
+              return { kind: 'clear' }
+          }
+        },
+      })
+
+      try {
+        await loaderA.init()
+        await loaderB.init()
+        await trigger.start()
+
+        await loaderA.getAsyncOnly('user-1')
+        await loaderB.getAsyncOnly('user-1')
+        expect(loaderA.getInMemoryOnly('user-1')).toBe('value')
+        expect(loaderB.getInMemoryOnly('user-1')).toBe('value')
+
+        // 4. External system publishes a domain event.
+        await clients.snsClient.send(
+          new PublishCommand({
+            TopicArn: upstreamTopicArn,
+            Message: JSON.stringify({ eventType: 'user.updated', userId: 'user-1' }),
+          }),
+        )
+
+        await waitFor(
+          () =>
+            loaderA.getInMemoryOnly('user-1') === undefined &&
+            loaderB.getInMemoryOnly('user-1') === undefined,
+        )
+        expect(loaderA.getInMemoryOnly('user-1')).toBeUndefined()
+        expect(loaderB.getInMemoryOnly('user-1')).toBeUndefined()
+      } finally {
+        await Promise.allSettled([
+          trigger.stop(),
+          triggerPublisher.close(),
+          peerA.consumer.close(),
+          peerB.consumer.close(),
+          peerA.publisher.close(),
+          peerB.publisher.close(),
+        ])
+      }
+    })
+
+    it('handles bulk and clear actions', async () => {
+      const suffix = Math.random().toString(36).slice(2, 8)
+      const invalidationTopic = `bulk-clear-${suffix}`
+
+      const peer = createNotificationPair<string>({
+        publisher: {
+          dependencies: buildPublisherDeps(clients),
+          creationConfig: { topic: { Name: invalidationTopic } },
+        },
+        consumer: {
+          dependencies: buildConsumerDeps(clients),
+          creationConfig: {
+            topic: { Name: invalidationTopic },
+            queue: { QueueName: `bulk-clear-peer-q-${suffix}` },
+          },
+        },
+      })
+
+      const loader = new Loader<string>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        asyncCache: new StubAsyncCache('value'),
+        notificationConsumer: peer.consumer,
+        notificationPublisher: peer.publisher,
+      })
+
+      const upstreamTopicName = `domain-${suffix}`
+      const createTopic = await clients.snsClient.send(
+        new CreateTopicCommand({ Name: upstreamTopicName }),
+      )
+      const upstreamTopicArn = createTopic.TopicArn!
+
+      const triggerPublisher = new SqsNotificationPublisher<string>({
+        serverUuid: randomUUID(),
+        dependencies: buildPublisherDeps(clients),
+        locatorConfig: { topicName: invalidationTopic },
+      })
+
+      const trigger = new SqsInvalidationTrigger<UpstreamEvent>({
+        sourceType: 'sns-topic',
+        dependencies: buildConsumerDeps(clients),
+        creationConfig: {
+          topic: { Name: upstreamTopicName },
+          queue: { QueueName: `bulk-clear-trigger-q-${suffix}` },
+        },
+        messageSchema: UPSTREAM_EVENT_SCHEMA,
+        publisher: triggerPublisher,
+        resolver: (msg) => {
+          if (msg.eventType === 'user.bulk-updated' && msg.userIds) {
+            return { kind: 'deleteMany', keys: msg.userIds }
+          }
+          if (msg.eventType === 'cache.flush') {
+            return { kind: 'clear' }
+          }
+          return null
+        },
+      })
+
+      try {
+        await loader.init()
+        await trigger.start()
+
+        await loader.getAsyncOnly('a')
+        await loader.getAsyncOnly('b')
+        expect(loader.getInMemoryOnly('a')).toBe('value')
+        expect(loader.getInMemoryOnly('b')).toBe('value')
+
+        await clients.snsClient.send(
+          new PublishCommand({
+            TopicArn: upstreamTopicArn,
+            Message: JSON.stringify({ eventType: 'user.bulk-updated', userIds: ['a', 'b'] }),
+          }),
+        )
+
+        await waitFor(
+          () =>
+            loader.getInMemoryOnly('a') === undefined &&
+            loader.getInMemoryOnly('b') === undefined,
+        )
+
+        await loader.getAsyncOnly('c')
+        expect(loader.getInMemoryOnly('c')).toBe('value')
+
+        await clients.snsClient.send(
+          new PublishCommand({
+            TopicArn: upstreamTopicArn,
+            Message: JSON.stringify({ eventType: 'cache.flush' }),
+          }),
+        )
+
+        await waitFor(() => loader.getInMemoryOnly('c') === undefined)
+        expect(loader.getInMemoryOnly('c')).toBeUndefined()
+      } finally {
+        await Promise.allSettled([
+          trigger.stop(),
+          triggerPublisher.close(),
+          peer.consumer.close(),
+          peer.publisher.close(),
+        ])
+      }
+    })
+
+    it('skips messages for which the resolver returns null', async () => {
+      const suffix = Math.random().toString(36).slice(2, 8)
+      const invalidationTopic = `skip-${suffix}`
+
+      const peer = createNotificationPair<string>({
+        publisher: {
+          dependencies: buildPublisherDeps(clients),
+          creationConfig: { topic: { Name: invalidationTopic } },
+        },
+        consumer: {
+          dependencies: buildConsumerDeps(clients),
+          creationConfig: {
+            topic: { Name: invalidationTopic },
+            queue: { QueueName: `skip-peer-q-${suffix}` },
+          },
+        },
+      })
+
+      const loader = new Loader<string>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        asyncCache: new StubAsyncCache('value'),
+        notificationConsumer: peer.consumer,
+        notificationPublisher: peer.publisher,
+      })
+
+      const upstreamTopicName = `skip-domain-${suffix}`
+      const createTopic = await clients.snsClient.send(
+        new CreateTopicCommand({ Name: upstreamTopicName }),
+      )
+      const upstreamTopicArn = createTopic.TopicArn!
+
+      const triggerPublisher = new SqsNotificationPublisher<string>({
+        serverUuid: randomUUID(),
+        dependencies: buildPublisherDeps(clients),
+        locatorConfig: { topicName: invalidationTopic },
+      })
+
+      let resolverCalls = 0
+      const trigger = new SqsInvalidationTrigger<UpstreamEvent>({
+        sourceType: 'sns-topic',
+        dependencies: buildConsumerDeps(clients),
+        creationConfig: {
+          topic: { Name: upstreamTopicName },
+          queue: { QueueName: `skip-trigger-q-${suffix}` },
+        },
+        messageSchema: UPSTREAM_EVENT_SCHEMA,
+        publisher: triggerPublisher,
+        resolver: () => {
+          resolverCalls += 1
+          return null
+        },
+      })
+
+      try {
+        await loader.init()
+        await trigger.start()
+
+        await loader.getAsyncOnly('user-9')
+        expect(loader.getInMemoryOnly('user-9')).toBe('value')
+
+        await clients.snsClient.send(
+          new PublishCommand({
+            TopicArn: upstreamTopicArn,
+            Message: JSON.stringify({ eventType: 'user.updated', userId: 'user-9' }),
+          }),
+        )
+
+        await waitFor(() => resolverCalls > 0)
+        await new Promise((r) => setTimeout(r, 200))
+        expect(loader.getInMemoryOnly('user-9')).toBe('value')
+      } finally {
+        await Promise.allSettled([
+          trigger.stop(),
+          triggerPublisher.close(),
+          peer.consumer.close(),
+          peer.publisher.close(),
+        ])
+      }
+    })
+  })
+
+  describe('SQS queue source', () => {
+    it('processes messages dropped directly into a pre-existing SQS queue', async () => {
+      const suffix = Math.random().toString(36).slice(2, 8)
+      const invalidationTopic = `queue-src-${suffix}`
+
+      const peer = createNotificationPair<string>({
+        publisher: {
+          dependencies: buildPublisherDeps(clients),
+          creationConfig: { topic: { Name: invalidationTopic } },
+        },
+        consumer: {
+          dependencies: buildConsumerDeps(clients),
+          creationConfig: {
+            topic: { Name: invalidationTopic },
+            queue: { QueueName: `queue-src-peer-q-${suffix}` },
+          },
+        },
+      })
+
+      const loader = new Loader<string>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        asyncCache: new StubAsyncCache('value'),
+        notificationConsumer: peer.consumer,
+        notificationPublisher: peer.publisher,
+      })
+
+      // Pre-create the upstream queue without involving the trigger
+      const upstreamQueueName = `domain-events-q-${suffix}`
+      await clients.sqsClient.send(new CreateQueueCommand({ QueueName: upstreamQueueName }))
+      const queueUrl = (
+        await clients.sqsClient.send(new GetQueueUrlCommand({ QueueName: upstreamQueueName }))
+      ).QueueUrl!
+
+      const triggerPublisher = new SqsNotificationPublisher<string>({
+        serverUuid: randomUUID(),
+        dependencies: buildPublisherDeps(clients),
+        locatorConfig: { topicName: invalidationTopic },
+      })
+
+      const trigger = new SqsInvalidationTrigger<UpstreamEvent>({
+        sourceType: 'sqs-queue',
+        dependencies: buildConsumerDeps(clients),
+        locatorConfig: { queueUrl },
+        messageSchema: UPSTREAM_EVENT_SCHEMA,
+        publisher: triggerPublisher,
+        resolver: (msg) =>
+          msg.eventType === 'user.deleted' && msg.userId
+            ? { kind: 'delete', key: msg.userId }
+            : null,
+      })
+
+      try {
+        await loader.init()
+        await trigger.start()
+
+        await loader.getAsyncOnly('user-42')
+        expect(loader.getInMemoryOnly('user-42')).toBe('value')
+
+        await clients.sqsClient.send(
+          new SendMessageCommand({
+            QueueUrl: queueUrl,
+            MessageBody: JSON.stringify({ eventType: 'user.deleted', userId: 'user-42' }),
+          }),
+        )
+
+        await waitFor(() => loader.getInMemoryOnly('user-42') === undefined)
+        expect(loader.getInMemoryOnly('user-42')).toBeUndefined()
+      } finally {
+        await Promise.allSettled([
+          trigger.stop(),
+          triggerPublisher.close(),
+          peer.consumer.close(),
+          peer.publisher.close(),
+        ])
+      }
+    })
+  })
+
+  describe('error handling', () => {
+    it('invokes errorHandler when resolver throws', async () => {
+      const suffix = Math.random().toString(36).slice(2, 8)
+      const upstreamQueueName = `err-q-${suffix}`
+      await clients.sqsClient.send(new CreateQueueCommand({ QueueName: upstreamQueueName }))
+      const queueUrl = (
+        await clients.sqsClient.send(new GetQueueUrlCommand({ QueueName: upstreamQueueName }))
+      ).QueueUrl!
+
+      const peer = createNotificationPair<string>({
+        publisher: {
+          dependencies: buildPublisherDeps(clients),
+          creationConfig: { topic: { Name: `err-topic-${suffix}` } },
+        },
+        consumer: {
+          dependencies: buildConsumerDeps(clients),
+          creationConfig: {
+            topic: { Name: `err-topic-${suffix}` },
+            queue: { QueueName: `err-peer-q-${suffix}` },
+          },
+        },
+      })
+
+      const errors: Array<{ err: Error; channel: string }> = []
+      const trigger = new SqsInvalidationTrigger<UpstreamEvent>({
+        sourceType: 'sqs-queue',
+        dependencies: buildConsumerDeps(clients),
+        locatorConfig: { queueUrl },
+        messageSchema: UPSTREAM_EVENT_SCHEMA,
+        publisher: peer.publisher,
+        resolver: () => {
+          throw new Error('boom')
+        },
+        errorHandler: (err, channel) => {
+          errors.push({ err, channel })
+        },
+        channel: 'custom-trigger-channel',
+      })
+
+      try {
+        await trigger.start()
+        await clients.sqsClient.send(
+          new SendMessageCommand({
+            QueueUrl: queueUrl,
+            MessageBody: JSON.stringify({ eventType: 'user.updated', userId: 'x' }),
+          }),
+        )
+
+        await waitFor(() => errors.length > 0)
+        expect(errors[0]!.err.message).toBe('boom')
+        expect(errors[0]!.channel).toBe('custom-trigger-channel')
+      } finally {
+        await Promise.allSettled([trigger.stop(), peer.consumer.close(), peer.publisher.close()])
+      }
+    })
+  })
+})

--- a/packages/sqs/test/SqsInvalidationTrigger.spec.ts
+++ b/packages/sqs/test/SqsInvalidationTrigger.spec.ts
@@ -457,6 +457,65 @@ describe('SqsInvalidationTrigger', () => {
     })
   })
 
+  describe('lifecycle', () => {
+    it('start and stop are idempotent and safe to call concurrently', async () => {
+      const suffix = Math.random().toString(36).slice(2, 8)
+      const upstreamQueueName = `lifecycle-q-${suffix}`
+      await clients.sqsClient.send(new CreateQueueCommand({ QueueName: upstreamQueueName }))
+      const queueUrl = (
+        await clients.sqsClient.send(new GetQueueUrlCommand({ QueueName: upstreamQueueName }))
+      ).QueueUrl!
+
+      const peer = createNotificationPair<string>({
+        publisher: {
+          dependencies: buildPublisherDeps(clients),
+          creationConfig: { topic: { Name: `lifecycle-topic-${suffix}` } },
+        },
+        consumer: {
+          dependencies: buildConsumerDeps(clients),
+          creationConfig: {
+            topic: { Name: `lifecycle-topic-${suffix}` },
+            queue: { QueueName: `lifecycle-peer-q-${suffix}` },
+          },
+        },
+      })
+
+      const triggerPublisher = new SqsNotificationPublisher<string>({
+        serverUuid: randomUUID(),
+        dependencies: buildPublisherDeps(clients),
+        locatorConfig: { topicName: `lifecycle-topic-${suffix}` },
+      })
+
+      const trigger = new SqsInvalidationTrigger<UpstreamEvent>({
+        sourceType: 'sqs-queue',
+        dependencies: buildConsumerDeps(clients),
+        locatorConfig: { queueUrl },
+        messageSchema: UPSTREAM_EVENT_SCHEMA,
+        publisher: triggerPublisher,
+        resolver: () => null,
+      })
+
+      try {
+        // Concurrent starts must produce a single underlying consumer.
+        await Promise.all([trigger.start(), trigger.start(), trigger.start()])
+        // Repeated starts after success must be no-ops.
+        await trigger.start()
+        // Stop is idempotent.
+        await trigger.stop()
+        await trigger.stop()
+        // Restart is allowed.
+        await trigger.start()
+      } finally {
+        await Promise.allSettled([
+          trigger.stop(),
+          triggerPublisher.close(),
+          peer.consumer.close(),
+          peer.publisher.close(),
+        ])
+      }
+    })
+  })
+
   describe('error handling', () => {
     it('invokes errorHandler when resolver throws', async () => {
       const suffix = Math.random().toString(36).slice(2, 8)

--- a/packages/sqs/test/SqsInvalidationTrigger.spec.ts
+++ b/packages/sqs/test/SqsInvalidationTrigger.spec.ts
@@ -9,46 +9,9 @@ import { SqsNotificationPublisher } from '../lib/SqsNotificationPublisher.js'
 import { SqsInvalidationTrigger } from '../lib/triggers/SqsInvalidationTrigger.js'
 import { type AwsClientBundle, buildAwsClients } from './fakes/awsClients.js'
 import { buildConsumerDeps, buildPublisherDeps } from './fakes/dependencies.js'
+import { StubAsyncCache, waitFor } from './utils/testHelpers.js'
 
 const IN_MEMORY_CACHE_CONFIG = { ttlInMsecs: 99999 } satisfies InMemoryCacheConfiguration
-
-class StubAsyncCache {
-  public name = 'StubAsyncCache'
-  constructor(private readonly value: string) {}
-  get() {
-    return Promise.resolve(this.value)
-  }
-  getMany(keys: string[]) {
-    return Promise.resolve({ resolvedValues: keys.map(() => this.value), unresolvedKeys: [] })
-  }
-  set(): Promise<void> {
-    return Promise.resolve()
-  }
-  delete(): Promise<void> {
-    return Promise.resolve()
-  }
-  deleteMany(): Promise<void> {
-    return Promise.resolve()
-  }
-  clear(): Promise<void> {
-    return Promise.resolve()
-  }
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-  getExpirationTime() {
-    return Promise.resolve(undefined)
-  }
-}
-
-async function waitFor(predicate: () => boolean, timeoutMs = 5000, intervalMs = 50): Promise<void> {
-  const start = Date.now()
-  while (Date.now() - start < timeoutMs) {
-    if (predicate()) return
-    await new Promise((resolve) => setTimeout(resolve, intervalMs))
-  }
-  throw new Error('Timed out waiting for predicate')
-}
 
 const UPSTREAM_EVENT_SCHEMA = z.object({
   eventType: z.enum(['user.updated', 'user.deleted', 'user.bulk-updated', 'cache.flush']),

--- a/packages/sqs/test/SqsNotificationPublisher.spec.ts
+++ b/packages/sqs/test/SqsNotificationPublisher.spec.ts
@@ -3,46 +3,9 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { createNotificationPair } from '../lib/SqsNotificationFactory.js'
 import { type AwsClientBundle, buildAwsClients } from './fakes/awsClients.js'
 import { buildConsumerDeps, buildPublisherDeps } from './fakes/dependencies.js'
+import { StubAsyncCache, waitFor } from './utils/testHelpers.js'
 
 const IN_MEMORY_CACHE_CONFIG = { ttlInMsecs: 99999 } satisfies InMemoryCacheConfiguration
-
-class StubAsyncCache {
-  public name = 'StubAsyncCache'
-  constructor(private readonly value: string) {}
-  get() {
-    return Promise.resolve(this.value)
-  }
-  getMany(keys: string[]) {
-    return Promise.resolve({ resolvedValues: keys.map(() => this.value), unresolvedKeys: [] })
-  }
-  set(): Promise<void> {
-    return Promise.resolve()
-  }
-  delete(): Promise<void> {
-    return Promise.resolve()
-  }
-  deleteMany(): Promise<void> {
-    return Promise.resolve()
-  }
-  clear(): Promise<void> {
-    return Promise.resolve()
-  }
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-  getExpirationTime() {
-    return Promise.resolve(undefined)
-  }
-}
-
-async function waitFor(predicate: () => boolean, timeoutMs = 5000, intervalMs = 50): Promise<void> {
-  const start = Date.now()
-  while (Date.now() - start < timeoutMs) {
-    if (predicate()) return
-    await new Promise((resolve) => setTimeout(resolve, intervalMs))
-  }
-  throw new Error('Timed out waiting for predicate')
-}
 
 describe('SqsNotificationPublisher', () => {
   let clients: AwsClientBundle
@@ -285,8 +248,9 @@ describe('SqsNotificationPublisher', () => {
         },
       })
 
-      // Group consumer is normally bootstrapped via Loader.init which calls setTargetCache
-      // before subscribe. For provisioning we set a no-op cache to satisfy that contract.
+      // The flat (non-grouped) consumer is normally bootstrapped via Loader.init,
+      // which calls setTargetCache before subscribe. For one-off provisioning we
+      // set a no-op cache to satisfy that contract.
       provisioner.consumer.setTargetCache({
         get: () => undefined,
         getMany: () => ({ resolvedValues: [], unresolvedKeys: [] }),

--- a/packages/sqs/test/SqsNotificationPublisher.spec.ts
+++ b/packages/sqs/test/SqsNotificationPublisher.spec.ts
@@ -363,6 +363,46 @@ describe('SqsNotificationPublisher', () => {
       })
       expect(publisher.channel).toBe('derived-channel')
     })
+
+    it('retries subscribe after a previous init attempt failed', async () => {
+      const suffix = Math.random().toString(36).slice(2, 8)
+      const { publisher } = createNotificationPair<string>({
+        publisher: {
+          dependencies: buildPublisherDeps(clients),
+          creationConfig: { topic: { Name: `retry-test-${suffix}` } },
+        },
+        consumer: {
+          dependencies: buildConsumerDeps(clients),
+          creationConfig: {
+            topic: { Name: 'irrelevant' },
+            queue: { QueueName: 'irrelevant-q' },
+          },
+        },
+      })
+
+      // Reach into the private inner publisher to make the first init() reject,
+      // then fall through to the real implementation on retry.
+      const inner = (publisher as unknown as { publisher: { init: () => Promise<unknown> } })
+        .publisher
+      const realInit = inner.init.bind(inner)
+      let calls = 0
+      inner.init = () => {
+        calls += 1
+        if (calls === 1) return Promise.reject(new Error('transient AWS error'))
+        return realInit()
+      }
+
+      try {
+        await expect(publisher.subscribe()).rejects.toThrow('transient AWS error')
+        expect(publisher.topicArn).toBeUndefined()
+
+        await publisher.subscribe()
+        expect(calls).toBe(2)
+        expect(publisher.topicArn).toBeTruthy()
+      } finally {
+        await publisher.close().catch(() => undefined)
+      }
+    })
   })
 
   describe('serverUuid filtering', () => {

--- a/packages/sqs/test/SqsNotificationPublisher.spec.ts
+++ b/packages/sqs/test/SqsNotificationPublisher.spec.ts
@@ -1,0 +1,450 @@
+import { Loader, type InMemoryCacheConfiguration } from 'layered-loader'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { createNotificationPair } from '../lib/SqsNotificationFactory.js'
+import { type AwsClientBundle, buildAwsClients } from './fakes/awsClients.js'
+import { buildConsumerDeps, buildPublisherDeps } from './fakes/dependencies.js'
+
+const IN_MEMORY_CACHE_CONFIG = { ttlInMsecs: 99999 } satisfies InMemoryCacheConfiguration
+
+class StubAsyncCache {
+  public name = 'StubAsyncCache'
+  constructor(private readonly value: string) {}
+  get() {
+    return Promise.resolve(this.value)
+  }
+  getMany(keys: string[]) {
+    return Promise.resolve({ resolvedValues: keys.map(() => this.value), unresolvedKeys: [] })
+  }
+  set(): Promise<void> {
+    return Promise.resolve()
+  }
+  delete(): Promise<void> {
+    return Promise.resolve()
+  }
+  deleteMany(): Promise<void> {
+    return Promise.resolve()
+  }
+  clear(): Promise<void> {
+    return Promise.resolve()
+  }
+  close(): Promise<void> {
+    return Promise.resolve()
+  }
+  getExpirationTime() {
+    return Promise.resolve(undefined)
+  }
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 5000, intervalMs = 50): Promise<void> {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+  throw new Error('Timed out waiting for predicate')
+}
+
+describe('SqsNotificationPublisher', () => {
+  let clients: AwsClientBundle
+
+  beforeAll(() => {
+    const endpoint = process.env.FAUXQS_ENDPOINT
+    if (!endpoint) throw new Error('FAUXQS_ENDPOINT is not set; globalSetup did not run')
+    clients = buildAwsClients(endpoint)
+  })
+
+  afterAll(() => {
+    clients.destroy()
+  })
+
+  describe('with auto-created topic and queue', () => {
+    let suffix: string
+
+    beforeEach(() => {
+      suffix = Math.random().toString(36).slice(2, 8)
+    })
+
+    it('propagates a delete event to a remote consumer', async () => {
+      const { publisher: publisher1, consumer: consumer1 } = createNotificationPair<string>({
+        publisher: {
+          dependencies: buildPublisherDeps(clients),
+          creationConfig: { topic: { Name: `delete-test-${suffix}` } },
+        },
+        consumer: {
+          dependencies: buildConsumerDeps(clients),
+          creationConfig: {
+            topic: { Name: `delete-test-${suffix}` },
+            queue: { QueueName: `delete-test-q1-${suffix}` },
+          },
+        },
+      })
+
+      const { publisher: publisher2, consumer: consumer2 } = createNotificationPair<string>({
+        publisher: {
+          dependencies: buildPublisherDeps(clients),
+          creationConfig: { topic: { Name: `delete-test-${suffix}` } },
+        },
+        consumer: {
+          dependencies: buildConsumerDeps(clients),
+          creationConfig: {
+            topic: { Name: `delete-test-${suffix}` },
+            queue: { QueueName: `delete-test-q2-${suffix}` },
+          },
+        },
+      })
+
+      const loader1 = new Loader<string>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        asyncCache: new StubAsyncCache('value'),
+        notificationConsumer: consumer1,
+        notificationPublisher: publisher1,
+      })
+      const loader2 = new Loader<string>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        asyncCache: new StubAsyncCache('value'),
+        notificationConsumer: consumer2,
+        notificationPublisher: publisher2,
+      })
+
+      try {
+        await loader1.init()
+        await loader2.init()
+
+        await loader1.getAsyncOnly('key')
+        await loader2.getAsyncOnly('key')
+
+        expect(loader1.getInMemoryOnly('key')).toBe('value')
+        expect(loader2.getInMemoryOnly('key')).toBe('value')
+
+        await loader1.invalidateCacheFor('key')
+
+        await waitFor(() => loader2.getInMemoryOnly('key') === undefined)
+        expect(loader2.getInMemoryOnly('key')).toBeUndefined()
+      } finally {
+        await Promise.allSettled([
+          consumer1.close(),
+          consumer2.close(),
+          publisher1.close(),
+          publisher2.close(),
+        ])
+      }
+    })
+
+    it('propagates a clear event to all remote consumers', async () => {
+      const { publisher: publisher1, consumer: consumer1 } = createNotificationPair<string>({
+        publisher: {
+          dependencies: buildPublisherDeps(clients),
+          creationConfig: { topic: { Name: `clear-test-${suffix}` } },
+        },
+        consumer: {
+          dependencies: buildConsumerDeps(clients),
+          creationConfig: {
+            topic: { Name: `clear-test-${suffix}` },
+            queue: { QueueName: `clear-test-q1-${suffix}` },
+          },
+        },
+      })
+
+      const { publisher: publisher2, consumer: consumer2 } = createNotificationPair<string>({
+        publisher: {
+          dependencies: buildPublisherDeps(clients),
+          creationConfig: { topic: { Name: `clear-test-${suffix}` } },
+        },
+        consumer: {
+          dependencies: buildConsumerDeps(clients),
+          creationConfig: {
+            topic: { Name: `clear-test-${suffix}` },
+            queue: { QueueName: `clear-test-q2-${suffix}` },
+          },
+        },
+      })
+
+      const loader1 = new Loader<string>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        asyncCache: new StubAsyncCache('value'),
+        notificationConsumer: consumer1,
+        notificationPublisher: publisher1,
+      })
+      const loader2 = new Loader<string>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        asyncCache: new StubAsyncCache('value'),
+        notificationConsumer: consumer2,
+        notificationPublisher: publisher2,
+      })
+
+      try {
+        await loader1.init()
+        await loader2.init()
+
+        await loader1.getAsyncOnly('key')
+        await loader2.getAsyncOnly('key')
+
+        await loader1.invalidateCache()
+
+        await waitFor(() => loader2.getInMemoryOnly('key') === undefined)
+        expect(loader2.getInMemoryOnly('key')).toBeUndefined()
+      } finally {
+        await Promise.allSettled([
+          consumer1.close(),
+          consumer2.close(),
+          publisher1.close(),
+          publisher2.close(),
+        ])
+      }
+    })
+
+    it('propagates a deleteMany event to remote consumers', async () => {
+      const { publisher: publisher1, consumer: consumer1 } = createNotificationPair<string>({
+        publisher: {
+          dependencies: buildPublisherDeps(clients),
+          creationConfig: { topic: { Name: `delmany-test-${suffix}` } },
+        },
+        consumer: {
+          dependencies: buildConsumerDeps(clients),
+          creationConfig: {
+            topic: { Name: `delmany-test-${suffix}` },
+            queue: { QueueName: `delmany-test-q1-${suffix}` },
+          },
+        },
+      })
+
+      const { publisher: publisher2, consumer: consumer2 } = createNotificationPair<string>({
+        publisher: {
+          dependencies: buildPublisherDeps(clients),
+          creationConfig: { topic: { Name: `delmany-test-${suffix}` } },
+        },
+        consumer: {
+          dependencies: buildConsumerDeps(clients),
+          creationConfig: {
+            topic: { Name: `delmany-test-${suffix}` },
+            queue: { QueueName: `delmany-test-q2-${suffix}` },
+          },
+        },
+      })
+
+      const loader1 = new Loader<string>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        asyncCache: new StubAsyncCache('value'),
+        notificationConsumer: consumer1,
+        notificationPublisher: publisher1,
+      })
+      const loader2 = new Loader<string>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        asyncCache: new StubAsyncCache('value'),
+        notificationConsumer: consumer2,
+        notificationPublisher: publisher2,
+      })
+
+      try {
+        await loader1.init()
+        await loader2.init()
+
+        await loader1.getAsyncOnly('keyA')
+        await loader1.getAsyncOnly('keyB')
+        await loader2.getAsyncOnly('keyA')
+        await loader2.getAsyncOnly('keyB')
+
+        await loader1.invalidateCacheForMany(['keyA', 'keyB'])
+
+        await waitFor(
+          () =>
+            loader2.getInMemoryOnly('keyA') === undefined &&
+            loader2.getInMemoryOnly('keyB') === undefined,
+        )
+        expect(loader2.getInMemoryOnly('keyA')).toBeUndefined()
+        expect(loader2.getInMemoryOnly('keyB')).toBeUndefined()
+      } finally {
+        await Promise.allSettled([
+          consumer1.close(),
+          consumer2.close(),
+          publisher1.close(),
+          publisher2.close(),
+        ])
+      }
+    })
+  })
+
+  describe('with locatorConfig (existing topic/queue/subscription)', () => {
+    it('reuses already-provisioned topic, queue and subscription', async () => {
+      const suffix = Math.random().toString(36).slice(2, 8)
+      const topicName = `locator-topic-${suffix}`
+      const queueName = `locator-queue-${suffix}`
+
+      // Provision topic, queue and subscription via creationConfig and capture identifiers
+      const provisioner = createNotificationPair<string>({
+        publisher: {
+          dependencies: buildPublisherDeps(clients),
+          creationConfig: { topic: { Name: topicName } },
+        },
+        consumer: {
+          dependencies: buildConsumerDeps(clients),
+          creationConfig: {
+            topic: { Name: topicName },
+            queue: { QueueName: queueName },
+          },
+        },
+      })
+
+      // Group consumer is normally bootstrapped via Loader.init which calls setTargetCache
+      // before subscribe. For provisioning we set a no-op cache to satisfy that contract.
+      provisioner.consumer.setTargetCache({
+        get: () => undefined,
+        getMany: () => ({ resolvedValues: [], unresolvedKeys: [] }),
+        set: () => undefined,
+        delete: () => undefined,
+        deleteMany: () => undefined,
+        clear: () => undefined,
+        getExpirationTime: () => undefined,
+      })
+      await provisioner.publisher.subscribe()
+      await provisioner.consumer.subscribe()
+      const topicArn = provisioner.publisher.topicArn
+      const subscriptionArn = provisioner.consumer.subscriptionArn
+      const queueUrl = provisioner.consumer.queueUrl
+      await provisioner.publisher.close()
+      await provisioner.consumer.close()
+
+      expect(topicArn).toBeTruthy()
+      expect(subscriptionArn).toBeTruthy()
+      expect(queueUrl).toBeTruthy()
+
+      const { publisher, consumer } = createNotificationPair<string>({
+        publisher: {
+          dependencies: buildPublisherDeps(clients),
+          locatorConfig: { topicArn },
+        },
+        consumer: {
+          dependencies: buildConsumerDeps(clients),
+          locatorConfig: { topicArn, queueUrl, subscriptionArn },
+        },
+      })
+
+      const loader = new Loader<string>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        asyncCache: new StubAsyncCache('value'),
+        notificationConsumer: consumer,
+        notificationPublisher: publisher,
+      })
+
+      try {
+        await loader.init()
+
+        await loader.getAsyncOnly('key')
+        expect(loader.getInMemoryOnly('key')).toBe('value')
+
+        await loader.invalidateCacheFor('key')
+        await new Promise((r) => setTimeout(r, 200))
+        expect(loader.getInMemoryOnly('key')).toBeUndefined()
+      } finally {
+        await Promise.allSettled([consumer.close(), publisher.close()])
+      }
+    })
+  })
+
+  describe('error handling', () => {
+    it('rejects publish when topic does not exist and no creationConfig is given', async () => {
+      const { publisher } = createNotificationPair<string>({
+        publisher: {
+          dependencies: buildPublisherDeps(clients),
+          locatorConfig: { topicName: 'definitely-does-not-exist-xyz' },
+        },
+        consumer: {
+          dependencies: buildConsumerDeps(clients),
+          creationConfig: {
+            topic: { Name: 'unrelated' },
+            queue: { QueueName: 'unrelated-q' },
+          },
+        },
+      })
+
+      try {
+        await expect(publisher.delete('key')).rejects.toBeDefined()
+      } finally {
+        await publisher.close().catch(() => undefined)
+      }
+    })
+
+    it('exposes channel name derived from creation config', () => {
+      const { publisher, consumer } = createNotificationPair<string>({
+        channel: 'custom-channel',
+        publisher: {
+          dependencies: buildPublisherDeps(clients),
+          creationConfig: { topic: { Name: 'irrelevant' } },
+        },
+        consumer: {
+          dependencies: buildConsumerDeps(clients),
+          creationConfig: {
+            topic: { Name: 'irrelevant' },
+            queue: { QueueName: 'irrelevant-q' },
+          },
+        },
+      })
+      expect(publisher.channel).toBe('custom-channel')
+      expect(consumer.serverUuid).toBeTruthy()
+    })
+
+    it('falls back to topic name when channel is not provided', () => {
+      const { publisher } = createNotificationPair<string>({
+        publisher: {
+          dependencies: buildPublisherDeps(clients),
+          creationConfig: { topic: { Name: 'derived-channel' } },
+        },
+        consumer: {
+          dependencies: buildConsumerDeps(clients),
+          creationConfig: {
+            topic: { Name: 'derived-channel' },
+            queue: { QueueName: 'derived-q' },
+          },
+        },
+      })
+      expect(publisher.channel).toBe('derived-channel')
+    })
+  })
+
+  describe('serverUuid filtering', () => {
+    it('skips messages emitted by the same process', async () => {
+      const suffix = Math.random().toString(36).slice(2, 8)
+      const { publisher, consumer } = createNotificationPair<string>({
+        publisher: {
+          dependencies: buildPublisherDeps(clients),
+          creationConfig: { topic: { Name: `self-test-${suffix}` } },
+        },
+        consumer: {
+          dependencies: buildConsumerDeps(clients),
+          creationConfig: {
+            topic: { Name: `self-test-${suffix}` },
+            queue: { QueueName: `self-test-q-${suffix}` },
+          },
+        },
+      })
+
+      const loader = new Loader<string>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        asyncCache: new StubAsyncCache('value'),
+        notificationConsumer: consumer,
+        notificationPublisher: publisher,
+      })
+
+      try {
+        await loader.init()
+
+        await loader.getAsyncOnly('key')
+        expect(loader.getInMemoryOnly('key')).toBe('value')
+
+        await loader.invalidateCacheFor('key')
+
+        // Self-publish means the cache stays cleared locally (cleared synchronously by Loader),
+        // and the message bouncing back via SQS must not re-affect the cache.
+        await new Promise((r) => setTimeout(r, 200))
+        expect(loader.getInMemoryOnly('key')).toBeUndefined()
+
+        // Re-populate; the consumer must not undo this with a stale self-message.
+        await loader.getAsyncOnly('key')
+        await new Promise((r) => setTimeout(r, 200))
+        expect(loader.getInMemoryOnly('key')).toBe('value')
+      } finally {
+        await Promise.allSettled([consumer.close(), publisher.close()])
+      }
+    })
+  })
+})

--- a/packages/sqs/test/fakes/awsClients.ts
+++ b/packages/sqs/test/fakes/awsClients.ts
@@ -1,0 +1,32 @@
+import { SNSClient } from '@aws-sdk/client-sns'
+import { SQSClient } from '@aws-sdk/client-sqs'
+import { STSClient } from '@aws-sdk/client-sts'
+
+export type AwsClientBundle = {
+  endpoint: string
+  snsClient: SNSClient
+  sqsClient: SQSClient
+  stsClient: STSClient
+  destroy: () => void
+}
+
+export function buildAwsClients(endpoint: string): AwsClientBundle {
+  const credentials = { accessKeyId: 'test', secretAccessKey: 'test' }
+  const region = 'us-east-1'
+
+  const snsClient = new SNSClient({ endpoint, region, credentials })
+  const sqsClient = new SQSClient({ endpoint, region, credentials })
+  const stsClient = new STSClient({ endpoint, region, credentials })
+
+  return {
+    endpoint,
+    snsClient,
+    sqsClient,
+    stsClient,
+    destroy: () => {
+      snsClient.destroy()
+      sqsClient.destroy()
+      stsClient.destroy()
+    },
+  }
+}

--- a/packages/sqs/test/fakes/dependencies.ts
+++ b/packages/sqs/test/fakes/dependencies.ts
@@ -1,0 +1,41 @@
+import { globalLogger } from '@lokalise/node-core'
+import {
+  NoopObservabilityManager,
+  type ErrorReporter,
+  type TransactionObservabilityManager,
+} from '@lokalise/node-core'
+import {
+  type SNSDependencies,
+  SnsConsumerErrorResolver,
+} from '@message-queue-toolkit/sns'
+import type { SNSSQSConsumerDependencies } from '@message-queue-toolkit/sns'
+import type { AwsClientBundle } from './awsClients.js'
+
+const noopErrorReporter: ErrorReporter = {
+  report: () => {
+    /* noop */
+  },
+}
+
+export function buildPublisherDeps(clients: AwsClientBundle): SNSDependencies {
+  return {
+    snsClient: clients.snsClient,
+    stsClient: clients.stsClient,
+    logger: globalLogger,
+    errorReporter: noopErrorReporter,
+  }
+}
+
+export function buildConsumerDeps(clients: AwsClientBundle): SNSSQSConsumerDependencies {
+  const observability: TransactionObservabilityManager = new NoopObservabilityManager()
+
+  return {
+    sqsClient: clients.sqsClient,
+    snsClient: clients.snsClient,
+    stsClient: clients.stsClient,
+    logger: globalLogger,
+    errorReporter: noopErrorReporter,
+    consumerErrorResolver: new SnsConsumerErrorResolver(),
+    transactionObservabilityManager: observability,
+  }
+}

--- a/packages/sqs/test/globalSetup.ts
+++ b/packages/sqs/test/globalSetup.ts
@@ -1,12 +1,32 @@
 import { type FauxqsServer, startFauxqs } from 'fauxqs'
 
+/**
+ * Global setup for the @layered-loader/sqs test suite.
+ *
+ * Runs an in-process fauxqs server on a random port and exports its address
+ * via `process.env.FAUXQS_ENDPOINT`. In-process fauxqs is preferred over
+ * docker for CI: no daemon required, sub-second startup, fully isolated per
+ * test process. The docker-compose.yml at the repository root still provides
+ * a fauxqs service for *local app smoke testing* against a fixed endpoint.
+ *
+ * Allowing `FAUXQS_ENDPOINT` to be supplied externally lets contributors run
+ * the suite against their own server (e.g. a docker-compose-managed one) by
+ * exporting the variable before invoking vitest.
+ */
+
 let server: FauxqsServer | undefined
 
 export async function setup() {
+  if (process.env.FAUXQS_ENDPOINT) return
   server = await startFauxqs({ port: 0, logger: false })
   process.env.FAUXQS_ENDPOINT = server.address
 }
 
 export async function teardown() {
-  await server?.stop()
+  const currentServer = server
+  server = undefined
+  delete process.env.FAUXQS_ENDPOINT
+  if (currentServer) {
+    await currentServer.stop()
+  }
 }

--- a/packages/sqs/test/globalSetup.ts
+++ b/packages/sqs/test/globalSetup.ts
@@ -1,0 +1,12 @@
+import { type FauxqsServer, startFauxqs } from 'fauxqs'
+
+let server: FauxqsServer | undefined
+
+export async function setup() {
+  server = await startFauxqs({ port: 0, logger: false })
+  process.env.FAUXQS_ENDPOINT = server.address
+}
+
+export async function teardown() {
+  await server?.stop()
+}

--- a/packages/sqs/test/utils/testHelpers.ts
+++ b/packages/sqs/test/utils/testHelpers.ts
@@ -1,0 +1,84 @@
+/** Shared utilities for the @layered-loader/sqs test suite. */
+
+/** Stub flat async cache that returns a fixed value for any key. */
+export class StubAsyncCache {
+  public name = 'StubAsyncCache'
+  constructor(private readonly value: string) {}
+  get() {
+    return Promise.resolve(this.value)
+  }
+  getMany(keys: string[]) {
+    return Promise.resolve({ resolvedValues: keys.map(() => this.value), unresolvedKeys: [] })
+  }
+  set(): Promise<void> {
+    return Promise.resolve()
+  }
+  delete(): Promise<void> {
+    return Promise.resolve()
+  }
+  deleteMany(): Promise<void> {
+    return Promise.resolve()
+  }
+  clear(): Promise<void> {
+    return Promise.resolve()
+  }
+  close(): Promise<void> {
+    return Promise.resolve()
+  }
+  getExpirationTime() {
+    return Promise.resolve(undefined)
+  }
+}
+
+/** Stub group async cache that returns a fixed value for any (key, group). */
+export class StubGroupedAsyncCache {
+  public name = 'StubGroupedAsyncCache'
+  constructor(private readonly value: string) {}
+  getFromGroup() {
+    return Promise.resolve(this.value)
+  }
+  getManyFromGroup(keys: string[]) {
+    return Promise.resolve({ resolvedValues: keys.map(() => this.value), unresolvedKeys: [] })
+  }
+  setForGroup(): Promise<void> {
+    return Promise.resolve()
+  }
+  deleteFromGroup(): Promise<void> {
+    return Promise.resolve()
+  }
+  deleteGroup(): Promise<void> {
+    return Promise.resolve()
+  }
+  clear(): Promise<void> {
+    return Promise.resolve()
+  }
+  close(): Promise<void> {
+    return Promise.resolve()
+  }
+  getExpirationTimeFromGroup() {
+    return Promise.resolve(undefined)
+  }
+}
+
+/**
+ * Polls `predicate` every `intervalMs` until it returns truthy or the timeout
+ * is reached. Throws on timeout. Use for assertions about events that happen
+ * asynchronously after a publish.
+ */
+export async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 5000,
+  intervalMs = 50,
+): Promise<void> {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+  throw new Error('Timed out waiting for predicate')
+}
+
+/** Random short suffix for unique resource names within a single test. */
+export function uniqueSuffix(): string {
+  return Math.random().toString(36).slice(2, 8)
+}

--- a/packages/sqs/tsconfig.json
+++ b/packages/sqs/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "compilerOptions": {
     "outDir": "dist",
-    "module": "CommonJS",
+    "rootDir": ".",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "target": "ES2022",
     "lib": ["ES2022"],
     "sourceMap": true,
@@ -10,7 +12,6 @@
     "types": ["node"],
     "strict": true,
     "skipLibCheck": true,
-    "moduleResolution": "node",
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
@@ -18,13 +19,11 @@
     "noImplicitAny": true,
     "noImplicitThis": true,
     "strictNullChecks": true,
-    "importHelpers": false,
-    "baseUrl": ".",
+    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "esModuleInterop": false,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
   },
-  "exclude": ["node_modules", "dist", "test", "packages",
-    "vitest.config.mts"
-  ]
+  "include": ["index.ts", "lib/**/*.ts"],
+  "exclude": ["node_modules", "dist", "test", "vitest.config.mts"]
 }

--- a/packages/sqs/vitest.config.mts
+++ b/packages/sqs/vitest.config.mts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    watch: false,
+    maxWorkers: 1,
+    isolate: false,
+    environment: 'node',
+    fileParallelism: false,
+    reporters: ['verbose'],
+    testTimeout: 30000,
+    hookTimeout: 30000,
+    globalSetup: ['./test/globalSetup.ts'],
+    exclude: ['**/node_modules/**', '**/dist/**'],
+    coverage: {
+      include: ['lib/**/*.ts', 'index.ts'],
+      reporter: ['lcov', 'text'],
+      all: true,
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,97 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 10.33.0
+        version: 10.33.0
+      pnpm:
+        specifier: 10.33.0
+        version: 10.33.0
+
+packages:
+
+  '@pnpm/exe@10.33.0':
+    resolution: {integrity: sha512-sGsjztJBelzVMd0RhceDJ3p8Hk7eBcpu4G/TF6REzIvNdkKyxDT0czc1BWyo8Kbg+U0OBtK/TAGXN7Art4rTdg==}
+    hasBin: true
+
+  '@pnpm/linux-arm64@10.33.0':
+    resolution: {integrity: sha512-oYb5NxEyImqaTkLVX/7jL59m9Vfmd07iLWzr4Pg2LIk4XEtAllNcnksNHcp5Uf+lFk/BggtpOdvC84TG3VnbFw==}
+    cpu: [arm64]
+    os: [linux]
+    hasBin: true
+
+  '@pnpm/linux-x64@10.33.0':
+    resolution: {integrity: sha512-JYD2GXDF2roKpvTg5s032lYcUcT9lMedYlzxoqitWTjKlkMhl2gXRYpiDHdi2mWC5nFOJYlgYbUuy6jh3rXhng==}
+    cpu: [x64]
+    os: [linux]
+    hasBin: true
+
+  '@pnpm/macos-arm64@10.33.0':
+    resolution: {integrity: sha512-3w9Pqpw0swnAbnEdAKumMuKj+TPaGratnqC49bC41vjR1pNs0UMwVdOxiIROUMQy5OHKPx0IH/wOOP0hkhJd+g==}
+    cpu: [arm64]
+    os: [darwin]
+    hasBin: true
+
+  '@pnpm/macos-x64@10.33.0':
+    resolution: {integrity: sha512-SBeiLjU/9ORMIXAMsD6+Ltaaesniwh49FeFcG6kA64Zxr30U9SyzeZDnNOyWCGFjHeCmGfzCnSpNEN4VNo827g==}
+    cpu: [x64]
+    os: [darwin]
+    hasBin: true
+
+  '@pnpm/win-arm64@10.33.0':
+    resolution: {integrity: sha512-8X3NQqmfNVZ+dCu+EfD7ZkAgDgIKKdAgBBKcvhvMoMJq/nWHOfqDLxewE9TQ7qzVLuUKG/9b/xBVRVjdtDOm0w==}
+    cpu: [arm64]
+    os: [win32]
+    hasBin: true
+
+  '@pnpm/win-x64@10.33.0':
+    resolution: {integrity: sha512-wiPVvxmTuB6FFn+rZ4FfSk1WTn+cxiQ7MTJEEz1k9VZLN/yZujGrv/WLYH2JcwzVTgObfmQuBKeNgEUavEL0Qg==}
+    cpu: [x64]
+    os: [win32]
+    hasBin: true
+
+  pnpm@10.33.0:
+    resolution: {integrity: sha512-EFaLtKavtYyes2MNqQzJUWQXq+vT+rvmc58K55VyjaFJHp21pUTHatjrdXD1xLs9bGN7LLQb/c20f6gjyGSTGQ==}
+    engines: {node: '>=18.12'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe@10.33.0':
+    optionalDependencies:
+      '@pnpm/linux-arm64': 10.33.0
+      '@pnpm/linux-x64': 10.33.0
+      '@pnpm/macos-arm64': 10.33.0
+      '@pnpm/macos-x64': 10.33.0
+      '@pnpm/win-arm64': 10.33.0
+      '@pnpm/win-x64': 10.33.0
+
+  '@pnpm/linux-arm64@10.33.0':
+    optional: true
+
+  '@pnpm/linux-x64@10.33.0':
+    optional: true
+
+  '@pnpm/macos-arm64@10.33.0':
+    optional: true
+
+  '@pnpm/macos-x64@10.33.0':
+    optional: true
+
+  '@pnpm/win-arm64@10.33.0':
+    optional: true
+
+  '@pnpm/win-x64@10.33.0':
+    optional: true
+
+  pnpm@10.33.0: {}
+
+---
 lockfileVersion: '9.0'
 
 settings:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,227 @@ importers:
         specifier: ^4.1.0
         version: 4.1.5(@types/node@22.19.18)(@vitest/coverage-v8@4.1.5)(vite@8.0.11(@types/node@22.19.18))
 
+  packages/sqs:
+    devDependencies:
+      '@aws-sdk/client-sns':
+        specifier: ^3.926.0
+        version: 3.1045.0
+      '@aws-sdk/client-sqs':
+        specifier: ^3.926.0
+        version: 3.1045.0
+      '@aws-sdk/client-sts':
+        specifier: ^3.926.0
+        version: 3.1045.0
+      '@lokalise/node-core':
+        specifier: ^14.8.1
+        version: 14.8.1(zod@4.4.3)
+      '@message-queue-toolkit/core':
+        specifier: ^25.4.0
+        version: 25.4.0(zod@4.4.3)
+      '@message-queue-toolkit/sns':
+        specifier: ^24.6.1
+        version: 24.6.1(@aws-sdk/client-sns@3.1045.0)(@aws-sdk/client-sqs@3.1045.0)(@aws-sdk/client-sts@3.1045.0)(@message-queue-toolkit/core@25.4.0(zod@4.4.3))(@message-queue-toolkit/schemas@7.1.0(zod@4.4.3))(@message-queue-toolkit/sqs@24.2.1(@aws-sdk/client-sqs@3.1045.0)(@message-queue-toolkit/core@25.4.0(zod@4.4.3))(zod@4.4.3))(zod@4.4.3)
+      '@message-queue-toolkit/sqs':
+        specifier: ^24.2.1
+        version: 24.2.1(@aws-sdk/client-sqs@3.1045.0)(@message-queue-toolkit/core@25.4.0(zod@4.4.3))(zod@4.4.3)
+      '@types/node':
+        specifier: ^22.19.15
+        version: 22.19.18
+      '@vitest/coverage-v8':
+        specifier: ^4.1.0
+        version: 4.1.5(vitest@4.1.5)
+      fauxqs:
+        specifier: ^2.5.0
+        version: 2.5.0(typescript@5.9.3)
+      layered-loader:
+        specifier: workspace:^
+        version: link:../..
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.5(@types/node@22.19.18)(@vitest/coverage-v8@4.1.5)(vite@8.0.11(@types/node@22.19.18))
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+
 packages:
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/crc32c@5.2.0':
+    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-s3@3.1045.0':
+    resolution: {integrity: sha512-fsuO3Y6t+3Ro9Bsg41DKj4Sfy53CGSrhnMldNplWmG8Tx0UbYk+YDa4RD1hVlJpERw4JBmPkl0+J9qlxMh1pcA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-sns@3.1045.0':
+    resolution: {integrity: sha512-w/iwPYVAXx62dD2E5nBQaUOntlYWCjaIPXGZpdC6+WWF/idTPjN3qu5Q0KgcrP6zQDGCgtAVaLlLVaK36/5x7A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-sqs@3.1045.0':
+    resolution: {integrity: sha512-reWeEE53mgCv8uUFSicvVf0A6BoWGImdC4y5x5clkeEmfIikahIBtons6u0d32kwI4NczpcretpUkOCE/nvWAA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-sts@3.1045.0':
+    resolution: {integrity: sha512-oDJJ7rM1osvfBdfZuhQ5DM6lHD9iuypL9m2LsEiA/lB8xuE5uPYsftNDcS0J9VRXFSvYTqC14K7Y5vMMKMg0vw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.8':
+    resolution: {integrity: sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/crc64-nvme@3.972.7':
+    resolution: {integrity: sha512-QUagVVBbC8gODCF6e1aV0mE2TXWB9Opz4k8EJFdNrujUVQm5R4AjJa1mpOqzwOuROBzqJU9zawzig7M96L8Ejg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.34':
+    resolution: {integrity: sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.36':
+    resolution: {integrity: sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.38':
+    resolution: {integrity: sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.38':
+    resolution: {integrity: sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.39':
+    resolution: {integrity: sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.34':
+    resolution: {integrity: sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.38':
+    resolution: {integrity: sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.38':
+    resolution: {integrity: sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.10':
+    resolution: {integrity: sha512-Vbc2frZH7wXlMNd+ZZSXUEs/l1Sv8Jj4zUnIfwrYF5lwaLdXHZ9xx4U3rjUcaye3HRhFVc+E5DbBxpRAbB16BA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-expect-continue@3.972.10':
+    resolution: {integrity: sha512-2Yn0f1Qiq/DjxYR3wfI3LokXnjOhFM7Ssn4LTdFDIxRMCE6I32MAsVnhPX1cUZsuVA9tiZtwwhlSLAtFGxAZlQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.16':
+    resolution: {integrity: sha512-6ru8doI0/XzszqLIPXf0E/V7HhAw1Pu94010XCKYtBUfD0LxF0BuOzrUf8OQGR6j2o6wgKTHUniOmndQycHwCA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-host-header@3.972.10':
+    resolution: {integrity: sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-location-constraint@3.972.10':
+    resolution: {integrity: sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-logger@3.972.10':
+    resolution: {integrity: sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.972.11':
+    resolution: {integrity: sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.37':
+    resolution: {integrity: sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-sqs@3.972.22':
+    resolution: {integrity: sha512-DtR3mEiOUJcnEX/QuXmvbJto6xvQzp2ftnHb29c0aQYdmmzbKf0gsu9ovx1i/yy4ZR6m0rttTucS0iiP32dlGA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-ssec@3.972.10':
+    resolution: {integrity: sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-user-agent@3.972.38':
+    resolution: {integrity: sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.6':
+    resolution: {integrity: sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.972.13':
+    resolution: {integrity: sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.25':
+    resolution: {integrity: sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1041.0':
+    resolution: {integrity: sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.8':
+    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    resolution: {integrity: sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.996.8':
+    resolution: {integrity: sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-user-agent-browser@3.972.10':
+    resolution: {integrity: sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==}
+
+  '@aws-sdk/util-user-agent-node@3.973.24':
+    resolution: {integrity: sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
+  '@aws-sdk/xml-builder@3.972.22':
+    resolution: {integrity: sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -126,6 +346,27 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@fastify/ajv-compiler@4.0.5':
+    resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
+
+  '@fastify/cors@11.2.0':
+    resolution: {integrity: sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==}
+
+  '@fastify/error@4.2.0':
+    resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    resolution: {integrity: sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==}
+
+  '@fastify/forwarded@3.0.1':
+    resolution: {integrity: sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==}
+
+  '@fastify/merge-json-schemas@0.2.1':
+    resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
+
+  '@fastify/proxy-addr@5.1.0':
+    resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
+
   '@ioredis/commands@1.5.1':
     resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
 
@@ -139,11 +380,50 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@lokalise/node-core@14.8.1':
+    resolution: {integrity: sha512-Oaf1CqtcyV2pkdNXH//umnWcsyj8SFASQxsNV0h5QVOdq/N8PIETg6H/qp5Ovi2+Vh+YmK2t/Lg8tn5C8EeXsw==}
+    peerDependencies:
+      zod: '>=3.25.76 <5.0.0'
+
+  '@lokalise/universal-ts-utils@4.10.0':
+    resolution: {integrity: sha512-+k99TEjNikAqIEZCZZ6ltQ9lJveeHMNYzJmSClS4iBz+RLf67+8m2HDrPZ3J7MMWCGync2UGx7m8tjCNPJP3Aw==}
+
+  '@message-queue-toolkit/core@25.4.0':
+    resolution: {integrity: sha512-vQ88ClXDL0N/hA+MoOIcxcMxYmDftBt3bd5LlieaZIV2rK4+KQkOir0/nNk6zS63rXVkrM6uTyV8mIyezu2KQQ==}
+    peerDependencies:
+      zod: '>=3.25.76 <5.0.0'
+
+  '@message-queue-toolkit/schemas@7.1.0':
+    resolution: {integrity: sha512-JAzSQAHouympK/cEDBxsfEuS2Ifu1pv0a/NRvhNWfFlgW0TmsWT7SkYNERA7x89OK7PGk9PyDN88cV9l0gZ22Q==}
+    peerDependencies:
+      zod: '>=3.25.76 <5.0.0'
+
+  '@message-queue-toolkit/sns@24.6.1':
+    resolution: {integrity: sha512-QBBHdpjJV2nouLDJdHHpeU1aNFfyof32q/vmvmIBNnK1UHvOxkRQZctzmkBh2C1hqYccE84U860YTeR5Kc3l8g==}
+    peerDependencies:
+      '@aws-sdk/client-sns': ^3.632.0
+      '@aws-sdk/client-sqs': ^3.632.0
+      '@aws-sdk/client-sts': ^3.632.0
+      '@message-queue-toolkit/core': '>=24.0.0'
+      '@message-queue-toolkit/schemas': '>=7.0.0'
+      '@message-queue-toolkit/sqs': '>=23.0.0'
+      zod: '>=3.25.76 <5.0.0'
+
+  '@message-queue-toolkit/sqs@24.2.1':
+    resolution: {integrity: sha512-R3+XSzvBUStsjbjKWtTIb64PD/4+cUM0CrqiATuPj4XUK0WTzCYhHF42okk+6k1Nv5H3U7P1gGXgeotBGRKadg==}
+    peerDependencies:
+      '@aws-sdk/client-sqs': ^3.632.0
+      '@message-queue-toolkit/core': '>=25.0.0'
+      zod: '>=3.25.76 <5.0.0'
+
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -159,6 +439,9 @@ packages:
 
   '@oxc-project/types@0.128.0':
     resolution: {integrity: sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==}
+
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.18':
     resolution: {integrity: sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==}
@@ -262,6 +545,178 @@ packages:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
+  '@smithy/config-resolver@4.5.0':
+    resolution: {integrity: sha512-m5PNfr7xKdIegNG8DlLz+Gf/DlAhHWFGmFbe0DZo9pnvBwuZ3P/9OMtQU0UyWMYy8zjl+HDFVS7rdD9p2xEFjQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/core@3.24.0':
+    resolution: {integrity: sha512-rZ5YfycIXX6puoGjthnDiMpUgtKNOq3c7CndQYkCNYQTv26AiCrZQOJPy7ANSfZ6Okk3UvCRnmO1OYWlLnYZgg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.3.0':
+    resolution: {integrity: sha512-5gi+28FH+RurB2+tcRH1CK7KiLJ0dVnabjWLY3DgeFLiU45dbyrsq7NOYvMUcHgu9LVZH5F7G+Qk1GdXF0y6jg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-browser@4.3.0':
+    resolution: {integrity: sha512-JlY17/ZwBJ2O7FK/bKt8PZR+HBkyFwvgssgT6LiB0xYtz5/E5XG/HeKr5q2NMaVm8u8xjFfGk/6DVlbBe1qNkA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-config-resolver@4.4.0':
+    resolution: {integrity: sha512-1Pg7aqxIdMilTbGJKCHTx0toIkKSrHdO6VHCh9oCncWJG+1wkJa90O/xb9mmRPuoOFCg2DLZAqnRyuBiUQnNIA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-node@4.3.0':
+    resolution: {integrity: sha512-Xte1Td6CQpc/D0WnPZ2k98CvF7y1GopylMoGY/r26a9wbRHV5xusRbT6O9vouSeZlvtxoVb4ON/1fLRofO7m4Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.4.0':
+    resolution: {integrity: sha512-yxurumLvHfgYgM0FVtjOVIyBSJXfno4xKKOgD43wOk9Qh+2lTKfP9Qhu4JHU7IUwrqVPa888byUzomHMgvKVMg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-blob-browser@4.3.0':
+    resolution: {integrity: sha512-xOQ7w5hSzTe8IAwQ6BAbX+1d9s9SRwWUbU8cYYh5DHgkYOi131Q5+B9Blelg9u0zoPfM4VYOuuBRAmregPkzpQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-node@4.3.0':
+    resolution: {integrity: sha512-4a+KoVqr1SZtw7cZvY24XU1S5OL+c23MdDQ3jFmMCQ5s9diBFdMG/UIgp5dNqlwvDrWA0U5KO+z3Gzq1ize+LA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-stream-node@4.3.0':
+    resolution: {integrity: sha512-DPDT0UyOREMPwipO7BzSJfD8z2YYp/x1FMpHqEppBF+gmGr7FoqUUFlXfK+YPOfHhlr8HDJRQpmShNb9C9po5Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/invalid-dependency@4.3.0':
+    resolution: {integrity: sha512-TaoGtqi2ZNdGzxUgYcLczjW8rb/h5DQ8vlCMYDSdZ4LRzGQrrEYgUjlZVM9dAagTsLK5gZx1f7+44sFTjz5vuQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/is-array-buffer@4.3.0':
+    resolution: {integrity: sha512-V9ZCT5mHNteWOKtu3LkGHTheEyBWzTU3XydeSOHrqG6znEoCARjxFZ0XP9JJyKV9jxEMx7hNbzGlQaXtKkmvSQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/md5-js@4.3.0':
+    resolution: {integrity: sha512-bODwWrXILREpCL7XZq1/QxiMqFxdWadw3noiKGjNKsPl1/nvWtLVFInNjK6pmHjM4BUOgfgZkrl9+V56ez2FNA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-content-length@4.3.0':
+    resolution: {integrity: sha512-IbSiS/3nOxsimCthzElEoBrjQo+Na4bsQ63qyC8qSI8lkMjOv9+VlosDQd8gfNolAD9XmC5tLqYTI0bJGJsscg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-endpoint@4.5.0':
+    resolution: {integrity: sha512-ux8LgN/m/X7ET2ISRc8G4aKFI1QhINZtkKpoayNPTrhwpsCVxb47mlpYFuWceTlesc0Wmb0S9y6DP195ReQoXA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-retry@4.6.0':
+    resolution: {integrity: sha512-8CtxY9aHT4f3UvZUbU2O0bccRckqTDfTKk3t1DawUZa5DWRZdV2AMABLsdMTdj7KE1uumhzEaT0X7/jTcOtoBw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-serde@4.3.0':
+    resolution: {integrity: sha512-c+V02hZlIStscI4ie2VllJjM4DLxdI2SymIBvXmqCqicrNb0NAbgDXDTBiwcMiruaBOqEFYxpKXbz6JjsNEN3Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-stack@4.3.0':
+    resolution: {integrity: sha512-KtYcs+sJn7AiT0YdM53/6MT0dKsaW2MSAr9MpprRVSfwN9qyKQf2dBIuCXt18/nEZaWerol/bGaQ63G949aovw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-config-provider@4.4.0':
+    resolution: {integrity: sha512-5RutFJsYoqK4tWYZOjGQrPLowGf2Ku8rbNuVeGkNJ5axIDO4LV/fydBojPtwcDz2zf87YNCOXfNyuEyAwYgI7A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.7.0':
+    resolution: {integrity: sha512-PxF57Jr3dPm+RgZWekOL+o96FPdaT62xZUyDfi47uMRFi5rHpwO/ewFbrztrASQ/7H8moNi1sspIHihHpfoKsQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/property-provider@4.3.0':
+    resolution: {integrity: sha512-/YBWtO2SdvPSAUk/Ke1Xpdg1E1lfaNGblla7mnIVGtaGkSQ5bK7KBZqpuj5IokHlU9UcLDvt2QwTLV7oRzBUTA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/protocol-http@5.4.0':
+    resolution: {integrity: sha512-WG0LgSZg+WbvWYD04uwIYVyMEpyd0cPx1lkqx61JxunxiFti+wGoFiDKr6wswun1r25Z2f8yUoMQWyxjMnnXtw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/shared-ini-file-loader@4.5.0':
+    resolution: {integrity: sha512-xATpw6gcurFztdsUrMNaKb2ugqk3545Whhqg7ZD4sxTg+zI27THjg3IY+InXsVWturOWdCdV+UHQx11g9Sp5Kw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.4.0':
+    resolution: {integrity: sha512-nkdB9T8JS6iD5PukE5TB8KqcvMEPVPHVUY7J0odYJgyIM40Du2msUhBdoPNRqRArDDcGQqVQcbzu0CZA7b+Nkw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.13.0':
+    resolution: {integrity: sha512-lysfoRCr7PdD9CsPp9VQuJYRGI5mWYb8FRkbdBSQttxpQmW7tZsFgmpBNKVcgvBsAgBCkYX/UQs0NmznuBcZQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.1':
+    resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/url-parser@4.3.0':
+    resolution: {integrity: sha512-I5tCWs/ndLrJrbvlnsN1cOt8PVAbQEqg0nNeQqebD5ynQcbhgch9uA7KmpX9vfq/vEudq0iVYAOxt+4aBkUlWA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-base64@4.4.0':
+    resolution: {integrity: sha512-puJITyefgQ9a5F+wKylCLkf0VCwesWbaN4O3YCEalRin4N0CTPQu/XA3kz/QsMOTgd3knhd0BQwGCBm/tv0Y1A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-browser@4.3.0':
+    resolution: {integrity: sha512-83U8xa8EmdExGzFuqBzgXvtmbLQIYcCuCNm5no4rlPqpGdOPGUufzMvLdlw+sPTb01qHIsDDNwOecm4s8ROOPw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-node@4.3.0':
+    resolution: {integrity: sha512-Ok2v9zPFfd6uOJMTIIJ8HFdCpARD77q4OHYhwhG9y5X1Y9oeQ0CHUQVJD6LhT6l8FUkFYisqcUaZSg7SArFUTA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-config-provider@4.3.0':
+    resolution: {integrity: sha512-kAC6/UB9qW9r2xQAOko2iDxAXmRD2VGMZjnXSEacAhQySdJs58CwvoOE0tHWdtc/lWF4g78X6Z9ucLanJnuVUw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-browser@4.4.0':
+    resolution: {integrity: sha512-jKezW5Taa+N2gbkB02UVijH1rFlEJC+cskZzwasFqFJMBBi/bcVgHqcYOX0WOnUk6MDZfHf0gEsr5Br4XMHiAg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-node@4.3.0':
+    resolution: {integrity: sha512-xYRuNHHIztu5AzruMJ8kTyA1JsBL/yZKvX5z/A7OHUxsf+rkEESZFZWJDcAj5dDWSu6brWFe5KH6qJNTVztX/w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-endpoints@3.5.0':
+    resolution: {integrity: sha512-pcvTCp9Wch/9UnWWfRGoG5GJogDXFPjevE+CqALxtPFGA4GqFQRD6eUtgJhHN+NPtohcozI12u1skF2/iubGrQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-hex-encoding@4.3.0':
+    resolution: {integrity: sha512-ZkAHu0SAsXPkVpaP6dhzu+DO/i4mlAMmwa4tejbGv9shozy/m4a2vIAk6HjPy7fKuGpANE1tZczGfCSLgyw5jA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-middleware@4.3.0':
+    resolution: {integrity: sha512-X/DNQxgUCbjjs3HosLmt5Yi1NocxjRFiiOgHml4tVV3w4mIbqZxPR8kq7apGPEMnhIpyxeTgFyypMrfxfn2DlQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-retry@4.4.0':
+    resolution: {integrity: sha512-pV/Kq4jUuP9raOqwSPeBiut2IWmwbc9vM+nE3ly4YUkzPHbBZvfhikwMOyudER+KHPjakuc8r4TecEPMsI7nVg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.6.0':
+    resolution: {integrity: sha512-BlWg46UASokl3O5YqWmbLpINE5stmAxynXlyOe1nE4dx+tvwgqtT4ug/rPcRg0xVcBnj68XlcOqbXeaGGcH0DA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@4.3.0':
+    resolution: {integrity: sha512-5hrmCc+dTgZkiFhX72Q16LemYPkvZ1M4pFMOhk0X9tQnLY7dn7zC1+C+aAJn0dw6CXldbqY/KMbMYCwm8yw14g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-waiter@4.4.0':
+    resolution: {integrity: sha512-7kAlrB3n7/BHyw+uLq83d5jdadPUcDkdMOUSGxvpXjrJ++G0hTedTnoNChjybIxhZ/Gk7sCrfIOLkMAB0LhRBA==}
+    engines: {node: '>=18.0.0'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -318,12 +773,36 @@ packages:
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
+  abstract-logging@2.0.1:
+    resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
+
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
+  avvio@9.2.0:
+    resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -337,8 +816,18 @@ packages:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
     engines: {node: '>=0.10.0'}
 
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
+  dateformat@4.6.3:
+    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -362,9 +851,24 @@ packages:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dot-prop@10.1.0:
+    resolution: {integrity: sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==}
+    engines: {node: '>=20'}
+
+  dot-prop@6.0.1:
+    resolution: {integrity: sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==}
+    engines: {node: '>=10'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
@@ -376,12 +880,55 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  fast-copy@4.0.3:
+    resolution: {integrity: sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==}
+
+  fast-decode-uri-component@1.0.1:
+    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-equals@6.0.0:
+    resolution: {integrity: sha512-PFhhIGgdM79r5Uztdj9Zb6Tt1zKafqVfdMGwVca1z5z6fbX7DmsySSuJd8HiP6I1j505DCS83cLxo5rmSNeVEA==}
+    engines: {node: '>=6.0.0'}
+
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
+  fast-json-stringify@6.4.0:
+    resolution: {integrity: sha512-ibRCQ0GZKJIQ+P3Et1h0LhPgp3PMTYk0MH8O+kW3lNYsvmaQww5Nn3f1jf73Q0jR1Yz3a1CDP4/NZD3vOajWJQ==}
+
+  fast-querystring@1.1.2:
+    resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.7.2:
+    resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
+    hasBin: true
+
+  fastify-plugin@5.1.0:
+    resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
+
+  fastify@5.8.5:
+    resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fauxqs@2.5.0:
+    resolution: {integrity: sha512-p7M2i2vo+Ywm7qrsvWbhqAPMCX+T1hxvAzwslOPVIKEEFoPpXzQItAIngbK3rxXpDIPEwPkh3UKNFR6trdTa3g==}
+    engines: {node: '>=22.5.0'}
+    hasBin: true
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -395,6 +942,10 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  find-my-way@9.6.0:
+    resolution: {integrity: sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==}
+    engines: {node: '>=20'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -413,6 +964,9 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  help-me@5.0.0:
+    resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -423,6 +977,10 @@ packages:
   ioredis@5.10.1:
     resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
     engines: {node: '>=12.22.0'}
+
+  ipaddr.js@2.4.0:
+    resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
+    engines: {node: '>= 10'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -435,6 +993,10 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-obj@2.0.0:
+    resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
+    engines: {node: '>=8'}
 
   is-path-cwd@3.0.0:
     resolution: {integrity: sha512-kyiNFFLU0Ampr6SDZitD/DwUo4Zs1nSdnygUBqsu3LooL00Qvb5j+UnvApUn/TTj1J3OuE6BTdQ5rudKmU2ZaA==}
@@ -456,8 +1018,25 @@ packages:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
+  json-schema-ref-resolver@3.0.0:
+    resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-stream-stringify@3.1.6:
+    resolution: {integrity: sha512-x7fpwxOkbhFCaJDJ8vb1fBY3DdSa4AlITaz+HHILQJzdPMnHEFjxPwVUi1ALIbcIxDE0PNe/0i7frnY8QnBQog==}
+    engines: {node: '>=7.10.1'}
+
+  light-my-request@6.6.0:
+    resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -561,6 +1140,9 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -572,9 +1154,20 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
   p-map@7.0.4:
     resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
     engines: {node: '>=18'}
+
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
 
   path-type@6.0.0:
     resolution: {integrity: sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==}
@@ -594,6 +1187,20 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-pretty@13.1.3:
+    resolution: {integrity: sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==}
+    hasBin: true
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
+
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -602,8 +1209,24 @@ packages:
     resolution: {integrity: sha512-E6rsNU1QNJgB3sjj7OANinGncFKuK+164sLXw1/CqBjj/EkXSoSdHCtWQGBNlREIGLnL7IEUEGa08YFVUbrhVg==}
     engines: {node: '>=16'}
 
+  process-warning@4.0.1:
+    resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
+
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
 
   redis-errors@1.2.0:
     resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
@@ -612,6 +1235,14 @@ packages:
   redis-parser@3.0.0:
     resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  ret@0.5.0:
+    resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
+    engines: {node: '>=10'}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -628,10 +1259,24 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  safe-regex2@5.1.1:
+    resolution: {integrity: sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==}
+    hasBin: true
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
+  secure-json-parse@4.1.0:
+    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
+
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -640,9 +1285,22 @@ packages:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
     engines: {node: '>=14.16'}
 
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
+  sqs-consumer@14.2.8:
+    resolution: {integrity: sha512-Iq3AdASfsxY2s3KL88aPRGgvST3gviZphL5teTKxUqDZzXRIB8s6SWATft+v7YaGMspCs8BwrOKo9vD6ltcJmw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-sqs': ^3.1018.0
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -653,9 +1311,24 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  strip-json-comments@5.0.3:
+    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
+    engines: {node: '>=14.16'}
+
+  strnum@2.3.0:
+    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
+  thread-stream@4.0.0:
+    resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
+    engines: {node: '>=20'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -672,6 +1345,10 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tmp@0.2.5:
+    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+    engines: {node: '>=14.14'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -682,6 +1359,10 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  type-fest@5.6.0:
+    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+    engines: {node: '>=20'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -694,6 +1375,14 @@ packages:
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
+
+  valibot@1.4.0:
+    resolution: {integrity: sha512-iC/x7fVcSyOwlm/VSt7RlHnzNGLGvR9GnxdifUeWoCJo0q4ZZvrVkIHC6faTlkxG47I2Y4UrFquPuVHCrOnrLg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   vite@8.0.11:
     resolution: {integrity: sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==}
@@ -784,7 +1473,608 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
 snapshots:
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/crc32c@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1045.0':
+    dependencies:
+      '@aws-crypto/sha1-browser': 5.2.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-node': 3.972.39
+      '@aws-sdk/middleware-bucket-endpoint': 3.972.10
+      '@aws-sdk/middleware-expect-continue': 3.972.10
+      '@aws-sdk/middleware-flexible-checksums': 3.974.16
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-location-constraint': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-sdk-s3': 3.972.37
+      '@aws-sdk/middleware-ssec': 3.972.10
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.25
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.24
+      '@smithy/config-resolver': 4.5.0
+      '@smithy/core': 3.24.0
+      '@smithy/eventstream-serde-browser': 4.3.0
+      '@smithy/eventstream-serde-config-resolver': 4.4.0
+      '@smithy/eventstream-serde-node': 4.3.0
+      '@smithy/fetch-http-handler': 5.4.0
+      '@smithy/hash-blob-browser': 4.3.0
+      '@smithy/hash-node': 4.3.0
+      '@smithy/hash-stream-node': 4.3.0
+      '@smithy/invalid-dependency': 4.3.0
+      '@smithy/md5-js': 4.3.0
+      '@smithy/middleware-content-length': 4.3.0
+      '@smithy/middleware-endpoint': 4.5.0
+      '@smithy/middleware-retry': 4.6.0
+      '@smithy/middleware-serde': 4.3.0
+      '@smithy/middleware-stack': 4.3.0
+      '@smithy/node-config-provider': 4.4.0
+      '@smithy/node-http-handler': 4.7.0
+      '@smithy/protocol-http': 5.4.0
+      '@smithy/smithy-client': 4.13.0
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.3.0
+      '@smithy/util-base64': 4.4.0
+      '@smithy/util-body-length-browser': 4.3.0
+      '@smithy/util-body-length-node': 4.3.0
+      '@smithy/util-defaults-mode-browser': 4.4.0
+      '@smithy/util-defaults-mode-node': 4.3.0
+      '@smithy/util-endpoints': 3.5.0
+      '@smithy/util-middleware': 4.3.0
+      '@smithy/util-retry': 4.4.0
+      '@smithy/util-stream': 4.6.0
+      '@smithy/util-utf8': 4.3.0
+      '@smithy/util-waiter': 4.4.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-sns@3.1045.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-node': 3.972.39
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.24
+      '@smithy/config-resolver': 4.5.0
+      '@smithy/core': 3.24.0
+      '@smithy/fetch-http-handler': 5.4.0
+      '@smithy/hash-node': 4.3.0
+      '@smithy/invalid-dependency': 4.3.0
+      '@smithy/middleware-content-length': 4.3.0
+      '@smithy/middleware-endpoint': 4.5.0
+      '@smithy/middleware-retry': 4.6.0
+      '@smithy/middleware-serde': 4.3.0
+      '@smithy/middleware-stack': 4.3.0
+      '@smithy/node-config-provider': 4.4.0
+      '@smithy/node-http-handler': 4.7.0
+      '@smithy/protocol-http': 5.4.0
+      '@smithy/smithy-client': 4.13.0
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.3.0
+      '@smithy/util-base64': 4.4.0
+      '@smithy/util-body-length-browser': 4.3.0
+      '@smithy/util-body-length-node': 4.3.0
+      '@smithy/util-defaults-mode-browser': 4.4.0
+      '@smithy/util-defaults-mode-node': 4.3.0
+      '@smithy/util-endpoints': 3.5.0
+      '@smithy/util-middleware': 4.3.0
+      '@smithy/util-retry': 4.4.0
+      '@smithy/util-utf8': 4.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-sqs@3.1045.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-node': 3.972.39
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-sdk-sqs': 3.972.22
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.24
+      '@smithy/config-resolver': 4.5.0
+      '@smithy/core': 3.24.0
+      '@smithy/fetch-http-handler': 5.4.0
+      '@smithy/hash-node': 4.3.0
+      '@smithy/invalid-dependency': 4.3.0
+      '@smithy/md5-js': 4.3.0
+      '@smithy/middleware-content-length': 4.3.0
+      '@smithy/middleware-endpoint': 4.5.0
+      '@smithy/middleware-retry': 4.6.0
+      '@smithy/middleware-serde': 4.3.0
+      '@smithy/middleware-stack': 4.3.0
+      '@smithy/node-config-provider': 4.4.0
+      '@smithy/node-http-handler': 4.7.0
+      '@smithy/protocol-http': 5.4.0
+      '@smithy/smithy-client': 4.13.0
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.3.0
+      '@smithy/util-base64': 4.4.0
+      '@smithy/util-body-length-browser': 4.3.0
+      '@smithy/util-body-length-node': 4.3.0
+      '@smithy/util-defaults-mode-browser': 4.4.0
+      '@smithy/util-defaults-mode-node': 4.3.0
+      '@smithy/util-endpoints': 3.5.0
+      '@smithy/util-middleware': 4.3.0
+      '@smithy/util-retry': 4.4.0
+      '@smithy/util-utf8': 4.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-sts@3.1045.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-node': 3.972.39
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.25
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.24
+      '@smithy/config-resolver': 4.5.0
+      '@smithy/core': 3.24.0
+      '@smithy/fetch-http-handler': 5.4.0
+      '@smithy/hash-node': 4.3.0
+      '@smithy/invalid-dependency': 4.3.0
+      '@smithy/middleware-content-length': 4.3.0
+      '@smithy/middleware-endpoint': 4.5.0
+      '@smithy/middleware-retry': 4.6.0
+      '@smithy/middleware-serde': 4.3.0
+      '@smithy/middleware-stack': 4.3.0
+      '@smithy/node-config-provider': 4.4.0
+      '@smithy/node-http-handler': 4.7.0
+      '@smithy/protocol-http': 5.4.0
+      '@smithy/smithy-client': 4.13.0
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.3.0
+      '@smithy/util-base64': 4.4.0
+      '@smithy/util-body-length-browser': 4.3.0
+      '@smithy/util-body-length-node': 4.3.0
+      '@smithy/util-defaults-mode-browser': 4.4.0
+      '@smithy/util-defaults-mode-node': 4.3.0
+      '@smithy/util-endpoints': 3.5.0
+      '@smithy/util-middleware': 4.3.0
+      '@smithy/util-retry': 4.4.0
+      '@smithy/util-utf8': 4.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/core@3.974.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/xml-builder': 3.972.22
+      '@smithy/core': 3.24.0
+      '@smithy/node-config-provider': 4.4.0
+      '@smithy/property-provider': 4.3.0
+      '@smithy/protocol-http': 5.4.0
+      '@smithy/signature-v4': 5.4.0
+      '@smithy/smithy-client': 4.13.0
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.4.0
+      '@smithy/util-middleware': 4.3.0
+      '@smithy/util-retry': 4.4.0
+      '@smithy/util-utf8': 4.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/crc64-nvme@3.972.7':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.34':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.3.0
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.36':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@smithy/fetch-http-handler': 5.4.0
+      '@smithy/node-http-handler': 4.7.0
+      '@smithy/property-provider': 4.3.0
+      '@smithy/protocol-http': 5.4.0
+      '@smithy/smithy-client': 4.13.0
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.6.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-env': 3.972.34
+      '@aws-sdk/credential-provider-http': 3.972.36
+      '@aws-sdk/credential-provider-login': 3.972.38
+      '@aws-sdk/credential-provider-process': 3.972.34
+      '@aws-sdk/credential-provider-sso': 3.972.38
+      '@aws-sdk/credential-provider-web-identity': 3.972.38
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.3.0
+      '@smithy/property-provider': 4.3.0
+      '@smithy/shared-ini-file-loader': 4.5.0
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.3.0
+      '@smithy/protocol-http': 5.4.0
+      '@smithy/shared-ini-file-loader': 4.5.0
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-node@3.972.39':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.34
+      '@aws-sdk/credential-provider-http': 3.972.36
+      '@aws-sdk/credential-provider-ini': 3.972.38
+      '@aws-sdk/credential-provider-process': 3.972.34
+      '@aws-sdk/credential-provider-sso': 3.972.38
+      '@aws-sdk/credential-provider-web-identity': 3.972.38
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.3.0
+      '@smithy/property-provider': 4.3.0
+      '@smithy/shared-ini-file-loader': 4.5.0
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-process@3.972.34':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.3.0
+      '@smithy/shared-ini-file-loader': 4.5.0
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/token-providers': 3.1041.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.3.0
+      '@smithy/shared-ini-file-loader': 4.5.0
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.3.0
+      '@smithy/shared-ini-file-loader': 4.5.0
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/node-config-provider': 4.4.0
+      '@smithy/protocol-http': 5.4.0
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-expect-continue@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.4.0
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.16':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@aws-crypto/crc32c': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/crc64-nvme': 3.972.7
+      '@aws-sdk/types': 3.973.8
+      '@smithy/is-array-buffer': 4.3.0
+      '@smithy/node-config-provider': 4.4.0
+      '@smithy/protocol-http': 5.4.0
+      '@smithy/types': 4.14.1
+      '@smithy/util-middleware': 4.3.0
+      '@smithy/util-stream': 4.6.0
+      '@smithy/util-utf8': 4.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-host-header@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.4.0
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-location-constraint@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-logger@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-recursion-detection@3.972.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/protocol-http': 5.4.0
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.37':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/core': 3.24.0
+      '@smithy/node-config-provider': 4.4.0
+      '@smithy/protocol-http': 5.4.0
+      '@smithy/signature-v4': 5.4.0
+      '@smithy/smithy-client': 4.13.0
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.3.0
+      '@smithy/util-middleware': 4.3.0
+      '@smithy/util-stream': 4.6.0
+      '@smithy/util-utf8': 4.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-sqs@3.972.22':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/smithy-client': 4.13.0
+      '@smithy/types': 4.14.1
+      '@smithy/util-hex-encoding': 4.3.0
+      '@smithy/util-utf8': 4.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-ssec@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@smithy/core': 3.24.0
+      '@smithy/protocol-http': 5.4.0
+      '@smithy/types': 4.14.1
+      '@smithy/util-retry': 4.4.0
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.6':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.25
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.24
+      '@smithy/config-resolver': 4.5.0
+      '@smithy/core': 3.24.0
+      '@smithy/fetch-http-handler': 5.4.0
+      '@smithy/hash-node': 4.3.0
+      '@smithy/invalid-dependency': 4.3.0
+      '@smithy/middleware-content-length': 4.3.0
+      '@smithy/middleware-endpoint': 4.5.0
+      '@smithy/middleware-retry': 4.6.0
+      '@smithy/middleware-serde': 4.3.0
+      '@smithy/middleware-stack': 4.3.0
+      '@smithy/node-config-provider': 4.4.0
+      '@smithy/node-http-handler': 4.7.0
+      '@smithy/protocol-http': 5.4.0
+      '@smithy/smithy-client': 4.13.0
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.3.0
+      '@smithy/util-base64': 4.4.0
+      '@smithy/util-body-length-browser': 4.3.0
+      '@smithy/util-body-length-node': 4.3.0
+      '@smithy/util-defaults-mode-browser': 4.4.0
+      '@smithy/util-defaults-mode-node': 4.3.0
+      '@smithy/util-endpoints': 3.5.0
+      '@smithy/util-middleware': 4.3.0
+      '@smithy/util-retry': 4.4.0
+      '@smithy/util-utf8': 4.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/region-config-resolver@3.972.13':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/config-resolver': 4.5.0
+      '@smithy/node-config-provider': 4.4.0
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.25':
+    dependencies:
+      '@aws-sdk/middleware-sdk-s3': 3.972.37
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.4.0
+      '@smithy/signature-v4': 5.4.0
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1041.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.3.0
+      '@smithy/shared-ini-file-loader': 4.5.0
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/types@3.973.8':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.996.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.3.0
+      '@smithy/util-endpoints': 3.5.0
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-browser@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-node@3.973.24':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/types': 3.973.8
+      '@smithy/node-config-provider': 4.4.0
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.22':
+    dependencies:
+      '@nodable/entities': 2.1.0
+      '@smithy/types': 4.14.1
+      fast-xml-parser: 5.7.2
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -852,6 +2142,34 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@fastify/ajv-compiler@4.0.5':
+    dependencies:
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      fast-uri: 3.1.2
+
+  '@fastify/cors@11.2.0':
+    dependencies:
+      fastify-plugin: 5.1.0
+      toad-cache: 3.7.0
+
+  '@fastify/error@4.2.0': {}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    dependencies:
+      fast-json-stringify: 6.4.0
+
+  '@fastify/forwarded@3.0.1': {}
+
+  '@fastify/merge-json-schemas@0.2.1':
+    dependencies:
+      dequal: 2.0.3
+
+  '@fastify/proxy-addr@5.1.0':
+    dependencies:
+      '@fastify/forwarded': 3.0.1
+      ipaddr.js: 2.4.0
+
   '@ioredis/commands@1.5.1': {}
 
   '@jridgewell/resolve-uri@3.1.2': {}
@@ -863,12 +2181,64 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@lokalise/node-core@14.8.1(zod@4.4.3)':
+    dependencies:
+      dot-prop: 6.0.1
+      pino: 10.3.1
+      pino-pretty: 13.1.3
+      tslib: 2.8.1
+      zod: 4.4.3
+
+  '@lokalise/universal-ts-utils@4.10.0': {}
+
+  '@message-queue-toolkit/core@25.4.0(zod@4.4.3)':
+    dependencies:
+      '@lokalise/node-core': 14.8.1(zod@4.4.3)
+      '@lokalise/universal-ts-utils': 4.10.0
+      '@message-queue-toolkit/schemas': 7.1.0(zod@4.4.3)
+      dot-prop: 10.1.0
+      fast-equals: 6.0.0
+      json-stream-stringify: 3.1.6
+      tmp: 0.2.5
+      toad-cache: 3.7.0
+      zod: 4.4.3
+
+  '@message-queue-toolkit/schemas@7.1.0(zod@4.4.3)':
+    dependencies:
+      zod: 4.4.3
+
+  '@message-queue-toolkit/sns@24.6.1(@aws-sdk/client-sns@3.1045.0)(@aws-sdk/client-sqs@3.1045.0)(@aws-sdk/client-sts@3.1045.0)(@message-queue-toolkit/core@25.4.0(zod@4.4.3))(@message-queue-toolkit/schemas@7.1.0(zod@4.4.3))(@message-queue-toolkit/sqs@24.2.1(@aws-sdk/client-sqs@3.1045.0)(@message-queue-toolkit/core@25.4.0(zod@4.4.3))(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@aws-sdk/client-sns': 3.1045.0
+      '@aws-sdk/client-sqs': 3.1045.0
+      '@aws-sdk/client-sts': 3.1045.0
+      '@lokalise/node-core': 14.8.1(zod@4.4.3)
+      '@message-queue-toolkit/core': 25.4.0(zod@4.4.3)
+      '@message-queue-toolkit/schemas': 7.1.0(zod@4.4.3)
+      '@message-queue-toolkit/sqs': 24.2.1(@aws-sdk/client-sqs@3.1045.0)(@message-queue-toolkit/core@25.4.0(zod@4.4.3))(zod@4.4.3)
+      sqs-consumer: 14.2.8(@aws-sdk/client-sqs@3.1045.0)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@message-queue-toolkit/sqs@24.2.1(@aws-sdk/client-sqs@3.1045.0)(@message-queue-toolkit/core@25.4.0(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@aws-sdk/client-sqs': 3.1045.0
+      '@lokalise/node-core': 14.8.1(zod@4.4.3)
+      '@message-queue-toolkit/core': 25.4.0(zod@4.4.3)
+      sqs-consumer: 14.2.8(@aws-sdk/client-sqs@3.1045.0)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.2
     optional: true
+
+  '@nodable/entities@2.1.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -883,6 +2253,8 @@ snapshots:
       fastq: 1.20.1
 
   '@oxc-project/types@0.128.0': {}
+
+  '@pinojs/redact@0.4.0': {}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.18':
     optional: true
@@ -936,6 +2308,225 @@ snapshots:
   '@rolldown/pluginutils@1.0.0-rc.18': {}
 
   '@sindresorhus/merge-streams@2.3.0': {}
+
+  '@smithy/config-resolver@4.5.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/core@3.24.0':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.3.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-browser@4.3.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-config-resolver@4.4.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-node@4.3.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.4.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/hash-blob-browser@4.3.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/hash-node@4.3.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/hash-stream-node@4.3.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/invalid-dependency@4.3.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@4.3.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/md5-js@4.3.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-content-length@4.3.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-endpoint@4.5.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-retry@4.6.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-serde@4.3.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-stack@4.3.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@4.4.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.7.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/property-provider@4.3.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/protocol-http@5.4.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/shared-ini-file-loader@4.5.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.4.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@4.13.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/url-parser@4.3.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/util-base64@4.4.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-browser@4.3.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-node@4.3.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-config-provider@4.3.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-browser@4.4.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-node@4.3.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/util-endpoints@3.5.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/util-hex-encoding@4.3.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/util-middleware@4.3.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/util-retry@4.4.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/util-stream@4.6.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@4.3.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
+
+  '@smithy/util-waiter@4.4.0':
+    dependencies:
+      '@smithy/core': 3.24.0
+      tslib: 2.8.1
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -1012,6 +2603,19 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  abstract-logging@2.0.1: {}
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   assertion-error@2.0.1: {}
 
   ast-v8-to-istanbul@1.0.0:
@@ -1019,6 +2623,15 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
       js-tokens: 10.0.0
+
+  atomic-sleep@1.0.0: {}
+
+  avvio@9.2.0:
+    dependencies:
+      '@fastify/error': 4.2.0
+      fastq: 1.20.1
+
+  bowser@2.14.1: {}
 
   braces@3.0.3:
     dependencies:
@@ -1028,7 +2641,13 @@ snapshots:
 
   cluster-key-slot@1.1.2: {}
 
+  colorette@2.0.20: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
+
+  dateformat@4.6.3: {}
 
   debug@4.4.3:
     dependencies:
@@ -1052,7 +2671,21 @@ snapshots:
 
   denque@2.1.0: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
+
+  dot-prop@10.1.0:
+    dependencies:
+      type-fest: 5.6.0
+
+  dot-prop@6.0.1:
+    dependencies:
+      is-obj: 2.0.0
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   es-module-lexer@2.1.0: {}
 
@@ -1062,6 +2695,14 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  fast-copy@4.0.3: {}
+
+  fast-decode-uri-component@1.0.1: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-equals@6.0.0: {}
+
   fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -1070,9 +2711,72 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-json-stringify@6.4.0:
+    dependencies:
+      '@fastify/merge-json-schemas': 0.2.1
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      fast-uri: 3.1.2
+      json-schema-ref-resolver: 3.0.0
+      rfdc: 1.4.1
+
+  fast-querystring@1.1.2:
+    dependencies:
+      fast-decode-uri-component: 1.0.1
+
+  fast-safe-stringify@2.1.1: {}
+
+  fast-uri@3.1.2: {}
+
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.7.2:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.3.0
+
+  fastify-plugin@5.1.0: {}
+
+  fastify@5.8.5:
+    dependencies:
+      '@fastify/ajv-compiler': 4.0.5
+      '@fastify/error': 4.2.0
+      '@fastify/fast-json-stringify-compiler': 5.0.3
+      '@fastify/proxy-addr': 5.1.0
+      abstract-logging: 2.0.1
+      avvio: 9.2.0
+      fast-json-stringify: 6.4.0
+      find-my-way: 9.6.0
+      light-my-request: 6.6.0
+      pino: 10.3.1
+      process-warning: 5.0.0
+      rfdc: 1.4.1
+      secure-json-parse: 4.1.0
+      semver: 7.7.4
+      toad-cache: 3.7.0
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
+
+  fauxqs@2.5.0(typescript@5.9.3):
+    dependencies:
+      '@aws-sdk/client-s3': 3.1045.0
+      '@aws-sdk/client-sns': 3.1045.0
+      '@aws-sdk/client-sqs': 3.1045.0
+      '@fastify/cors': 11.2.0
+      '@smithy/node-http-handler': 4.7.0
+      fastify: 5.8.5
+      toad-cache: 3.7.0
+      valibot: 1.4.0(typescript@5.9.3)
+    transitivePeerDependencies:
+      - aws-crt
+      - typescript
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -1081,6 +2785,12 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  find-my-way@9.6.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-querystring: 1.1.2
+      safe-regex2: 5.1.1
 
   fsevents@2.3.3:
     optional: true
@@ -1100,6 +2810,8 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  help-me@5.0.0: {}
+
   html-escaper@2.0.2: {}
 
   ignore@7.0.5: {}
@@ -1118,6 +2830,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  ipaddr.js@2.4.0: {}
+
   is-extglob@2.1.1: {}
 
   is-glob@4.0.3:
@@ -1125,6 +2839,8 @@ snapshots:
       is-extglob: 2.1.1
 
   is-number@7.0.0: {}
+
+  is-obj@2.0.0: {}
 
   is-path-cwd@3.0.0: {}
 
@@ -1143,7 +2859,23 @@ snapshots:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
+  joycon@3.1.1: {}
+
   js-tokens@10.0.0: {}
+
+  json-schema-ref-resolver@3.0.0:
+    dependencies:
+      dequal: 2.0.3
+
+  json-schema-traverse@1.0.0: {}
+
+  json-stream-stringify@3.1.6: {}
+
+  light-my-request@6.6.0:
+    dependencies:
+      cookie: 1.1.1
+      process-warning: 4.0.1
+      set-cookie-parser: 2.7.2
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -1221,13 +2953,23 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  minimist@1.2.8: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.12: {}
 
   obug@2.1.1: {}
 
+  on-exit-leak-free@2.1.2: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
   p-map@7.0.4: {}
+
+  path-expression-matcher@1.5.0: {}
 
   path-type@6.0.0: {}
 
@@ -1239,6 +2981,42 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-pretty@13.1.3:
+    dependencies:
+      colorette: 2.0.20
+      dateformat: 4.6.3
+      fast-copy: 4.0.3
+      fast-safe-stringify: 2.1.1
+      help-me: 5.0.0
+      joycon: 3.1.1
+      minimist: 1.2.8
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pump: 3.0.4
+      secure-json-parse: 4.1.0
+      sonic-boom: 4.2.1
+      strip-json-comments: 5.0.3
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.3.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.0.0
+
   postcss@8.5.14:
     dependencies:
       nanoid: 3.3.12
@@ -1247,13 +3025,30 @@ snapshots:
 
   presentable-error@0.0.1: {}
 
+  process-warning@4.0.1: {}
+
+  process-warning@5.0.0: {}
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   queue-microtask@1.2.3: {}
+
+  quick-format-unescaped@4.0.4: {}
+
+  real-require@0.2.0: {}
 
   redis-errors@1.2.0: {}
 
   redis-parser@3.0.0:
     dependencies:
       redis-errors: 1.2.0
+
+  require-from-string@2.0.2: {}
+
+  ret@0.5.0: {}
 
   reusify@1.1.0: {}
 
@@ -1284,13 +3079,36 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-regex2@5.1.1:
+    dependencies:
+      ret: 0.5.0
+
+  safe-stable-stringify@2.5.0: {}
+
+  secure-json-parse@4.1.0: {}
+
   semver@7.7.4: {}
+
+  set-cookie-parser@2.7.2: {}
 
   siginfo@2.0.0: {}
 
   slash@5.1.0: {}
 
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   source-map-js@1.2.1: {}
+
+  split2@4.2.0: {}
+
+  sqs-consumer@14.2.8(@aws-sdk/client-sqs@3.1045.0):
+    dependencies:
+      '@aws-sdk/client-sqs': 3.1045.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   stackback@0.0.2: {}
 
@@ -1298,9 +3116,19 @@ snapshots:
 
   std-env@4.1.0: {}
 
+  strip-json-comments@5.0.3: {}
+
+  strnum@2.3.0: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  tagged-tag@1.0.0: {}
+
+  thread-stream@4.0.0:
+    dependencies:
+      real-require: 0.2.0
 
   tinybench@2.9.0: {}
 
@@ -1313,20 +3141,29 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tmp@0.2.5: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
   toad-cache@3.7.0: {}
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
+
+  type-fest@5.6.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
 
   unicorn-magic@0.3.0: {}
+
+  valibot@1.4.0(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
 
   vite@8.0.11(@types/node@22.19.18):
     dependencies:
@@ -1371,3 +3208,9 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wrappy@1.0.2: {}
+
+  xml-naming@0.1.0: {}
+
+  zod@4.4.3: {}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -10,7 +10,7 @@ export default defineConfig({
     environment: 'node',
     fileParallelism: false,
     reporters: ['verbose'],
-    exclude: ['**/node_modules/**', '**/dist/**'],
+    exclude: ['**/node_modules/**', '**/dist/**', 'packages/**'],
     coverage: {
       include: ['lib/**/*.ts'],
       exclude: [


### PR DESCRIPTION
Introduces a workspace package providing a remote cache invalidation
adapter for the SNS/SQS ecosystem, mirroring the existing Redis pub/sub
adapter. Built on top of @message-queue-toolkit/sns and exposes the
familiar createNotificationPair / createGroupNotificationPair factories
returning publishers and consumers that plug into Loader/GroupLoader.

- Supports both creationConfig (auto-create topic/queue/subscription)
  and locatorConfig (reuse existing infrastructure).
- Filters self-emitted messages via originUuid so a process does not
  re-process its own invalidations.
- Tested end-to-end against the fauxqs in-process emulator.

Also implements support for flexible invalidation triggers, which consume external SNS topics in order to initiate invalidation (as opposed to internal invalidation based on cache operations inside one of the nodes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added @layered-loader/sqs package with SNS/SQS publishers, consumers, and group notification support.
  * New transport-agnostic invalidation trigger primitives and helper pipelines.
  * Expanded public type exports for notification and synchronous cache contracts.

* **Tests**
  * Extensive integration and unit tests for SQS publishers, consumers, triggers, and retry/error behaviors.

* **Chores**
  * CI updated to run build/lint/test across the workspace; multi-package publish workflow added.
  * Docs and local testing (fauxqs) tooling added; Docker compose updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->