### PR TITLE
ci: use official zizmor action with PR annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@a0ea98b2dc7d387a59324835f7421c1d5f8357b4 # v6.0.5
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
 
       - name: Setup Node ${{ matrix.node-version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,14 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
 
     strategy:
       matrix:
@@ -16,15 +21,16 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6.0.5
+        uses: pnpm/action-setup@a0ea98b2dc7d387a59324835f7421c1d5f8357b4 # v6.0.5
 
       - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           always-auth: false
           node-version: ${{ matrix.node-version }}
@@ -60,6 +66,6 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      - uses: fastify/github-action-merge-dependabot@v3
+      - uses: fastify/github-action-merge-dependabot@30c3f8f14a4f7b315ba38dbc1b793d27128fef82 # v3.12.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@a0ea98b2dc7d387a59324835f7421c1d5f8357b4 # v6.0.5
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
 
       - name: Setup Node ${{ matrix.node-version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,10 +7,15 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
     name: coverage
+
+    permissions:
+      contents: read
 
     strategy:
       matrix:
@@ -18,15 +23,16 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6.0.5
+        uses: pnpm/action-setup@a0ea98b2dc7d387a59324835f7421c1d5f8357b4 # v6.0.5
 
       - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           always-auth: false
           node-version: ${{ matrix.node-version }}
@@ -45,6 +51,6 @@ jobs:
         run: pnpm run docker:stop
 
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   publish:
     if: github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'patch') || contains(github.event.pull_request.labels.*.name, 'minor') || contains(github.event.pull_request.labels.*.name, 'major'))
@@ -18,19 +20,19 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Full history so we can diff between the PR's base SHA and the
           # merge commit SHA regardless of how the PR was merged
           # (merge commit / squash / rebase).
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6.0.5
+        uses: pnpm/action-setup@a0ea98b2dc7d387a59324835f7421c1d5f8357b4 # v6.0.5
 
       - name: Setup Node
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
@@ -43,13 +45,16 @@ jobs:
 
       - name: Determine version bump
         id: version
+        env:
+          IS_MAJOR: ${{ contains(github.event.pull_request.labels.*.name, 'major') }}
+          IS_MINOR: ${{ contains(github.event.pull_request.labels.*.name, 'minor') }}
         run: |
-          if ${{ contains(github.event.pull_request.labels.*.name, 'major') }}; then
-            echo "bump=major" >> $GITHUB_OUTPUT
-          elif ${{ contains(github.event.pull_request.labels.*.name, 'minor') }}; then
-            echo "bump=minor" >> $GITHUB_OUTPUT
+          if [ "$IS_MAJOR" = "true" ]; then
+            echo "bump=major" >> "$GITHUB_OUTPUT"
+          elif [ "$IS_MINOR" = "true" ]; then
+            echo "bump=minor" >> "$GITHUB_OUTPUT"
           else
-            echo "bump=patch" >> $GITHUB_OUTPUT
+            echo "bump=patch" >> "$GITHUB_OUTPUT"
           fi
 
       # Diff between the PR's base SHA and merge commit SHA to find which
@@ -111,12 +116,16 @@ jobs:
 
       - name: Bump root version
         if: steps.changes.outputs.root == 'true'
-        run: npm version ${{ steps.version.outputs.bump }} --no-git-tag-version
+        env:
+          BUMP: ${{ steps.version.outputs.bump }}
+        run: npm version "$BUMP" --no-git-tag-version
 
       - name: Bump @layered-loader/sqs version
         if: steps.changes.outputs.sqs == 'true'
         working-directory: packages/sqs
-        run: npm version ${{ steps.version.outputs.bump }} --no-git-tag-version
+        env:
+          BUMP: ${{ steps.version.outputs.bump }}
+        run: npm version "$BUMP" --no-git-tag-version
 
       - name: Fix formatting
         if: steps.changes.outputs.root == 'true' || steps.changes.outputs.sqs == 'true'
@@ -124,6 +133,10 @@ jobs:
 
       - name: Commit and tag releases
         if: steps.changes.outputs.root == 'true' || steps.changes.outputs.sqs == 'true'
+        env:
+          ROOT_CHANGED: ${{ steps.changes.outputs.root }}
+          SQS_CHANGED: ${{ steps.changes.outputs.sqs }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           git add .
@@ -131,12 +144,12 @@ jobs:
           message="chore: release"
           tags=()
 
-          if [ "${{ steps.changes.outputs.root }}" = "true" ]; then
+          if [ "$ROOT_CHANGED" = "true" ]; then
             v=$(node -p "require('./package.json').version")
             message="$message layered-loader@$v"
             tags+=("v$v")
           fi
-          if [ "${{ steps.changes.outputs.sqs }}" = "true" ]; then
+          if [ "$SQS_CHANGED" = "true" ]; then
             v=$(node -p "require('./packages/sqs/package.json').version")
             message="$message @layered-loader/sqs@$v"
             tags+=("@layered-loader/sqs@$v")
@@ -146,6 +159,10 @@ jobs:
           for t in "${tags[@]}"; do
             git tag "$t"
           done
+
+          # Auth for push: checkout used persist-credentials: false, so we
+          # configure the remote with the workflow token explicitly here.
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push
           git push --tags
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@a0ea98b2dc7d387a59324835f7421c1d5f8357b4 # v6.0.5
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -9,15 +9,15 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   zizmor:
     name: zizmor
     runs-on: ubuntu-latest
 
     permissions:
-      security-events: write
       contents: read
-      actions: read
 
     steps:
       - name: Checkout Repository
@@ -26,17 +26,8 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Setup uv
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
-
       - name: Run zizmor
-        run: uvx zizmor --format=sarif . > results.sarif
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload SARIF file
-        if: always()
-        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
         with:
-          sarif_file: results.sarif
-          category: zizmor
+          advanced-security: false
+          annotations: true


### PR DESCRIPTION
## Summary
- Switch the zizmor workflow from manual `uvx zizmor` + SARIF upload to the official [`zizmorcore/zizmor-action`](https://github.com/zizmorcore/zizmor-action) pinned to v0.5.6.
- Enable `annotations: true` so findings appear as inline GitHub annotations on PR diffs.
- Drop `security-events: write` and `actions: read` permissions (no longer needed without SARIF/Advanced Security upload); job now runs with `contents: read` only, and the workflow-level `permissions: {}` removes the default token scope for any future jobs.
- Build fails automatically when zizmor finds anything — the action preserves zizmor's non-zero exit code on findings.

## Test plan
- [ ] Confirm the `zizmor` check runs green on this PR (no current findings).
- [ ] Verify annotations show up inline in the Files Changed tab if/when findings are introduced (can be sanity-checked by temporarily adding a vulnerable pattern in a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)