### PR TITLE
chore: update dependencies to latest and add Node 26 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [20.x, 22.x, 24.x, 26.x]
 
     steps:
       - name: Checkout Repository

--- a/biome.json
+++ b/biome.json
@@ -1,8 +1,6 @@
 {
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
-  "organizeImports": {
-    "enabled": true
-  },
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "json": {
     "formatter": {
       "enabled": true,
@@ -27,14 +25,17 @@
     }
   },
   "files": {
-    "include": [
-      "./test/**/*.ts",
-      "./src/**/*.ts",
-      "./scripts/**/*.ts",
-      "./biome.json",
-      "./package.json"
-    ],
-    "ignore": ["./dist", "./coverage", "./node_modules", "./packages"]
+    "includes": [
+      "test/**/*.ts",
+      "src/**/*.ts",
+      "scripts/**/*.ts",
+      "biome.json",
+      "package.json",
+      "!dist",
+      "!coverage",
+      "!node_modules",
+      "!packages"
+    ]
   },
   "formatter": {
     "enabled": true,
@@ -56,7 +57,6 @@
         "useTemplate": "error",
         "useShorthandAssign": "error",
         "useShorthandFunctionType": "error",
-        "noVar": "off",
         "noUselessElse": "error",
         "noUnusedTemplateLiteral": "off",
         "useConst": "error",
@@ -71,7 +71,6 @@
         "noGlobalObjectCalls": "error",
         "noInnerDeclarations": "error",
         "noInvalidConstructorSuper": "error",
-        "noInvalidNewBuiltin": "error",
         "noSelfAssign": "error",
         "noSetterReturn": "error",
         "noUnreachable": "error",
@@ -81,18 +80,18 @@
         "noUnusedImports": "error",
         "noUnusedPrivateClassMembers": "error",
         "noUnreachableSuper": "error",
-        "noUndeclaredVariables": "error"
+        "noUndeclaredVariables": "error",
+        "noInvalidBuiltinInstantiation": "error",
+        "useValidTypeof": "error"
       },
       "suspicious": {
         "noGlobalIsNan": "off",
         "noAssignInExpressions": "error",
         "noCatchAssign": "error",
         "noClassAssign": "error",
-        "noConsoleLog": "error",
         "noDuplicateCase": "error",
         "noDuplicateClassMembers": "error",
         "noEmptyBlockStatements": "off",
-        "useValidTypeof": "error",
         "useIsArray": "error",
         "useGetterReturn": "error",
         "useAwait": "error",
@@ -106,7 +105,9 @@
         "noExplicitAny": "off",
         "noFocusedTests": "error",
         "noGlobalAssign": "error",
-        "noFunctionAssign": "error"
+        "noFunctionAssign": "error",
+        "noVar": "off",
+        "noConsole": { "level": "error", "options": { "allow": ["log"] } }
       },
       "complexity": {
         "noForEach": "error",
@@ -122,5 +123,17 @@
         "noBannedTypes": "off"
       }
     }
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["test/**/*.ts"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "useAwait": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "engines": {
     "node": ">=18"
   },
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.1.2",
   "repository": {
     "type": "git",
     "url": "git://github.com/kibertoad/layered-loader.git"
@@ -51,20 +51,26 @@
   ],
   "homepage": "https://github.com/kibertoad/layered-loader",
   "dependencies": {
-    "ioredis": "^5.10.0",
-    "toad-cache": "^3.7.0"
+    "ioredis": "^5.10.1",
+    "toad-cache": "^3.7.1"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.9.4",
-    "@types/node": "^22.19.15",
-    "@vitest/coverage-v8": "^4.1.0",
+    "@biomejs/biome": "^2.4.15",
+    "@types/node": "^25.8.0",
+    "@vitest/coverage-v8": "^4.1.6",
     "del-cli": "^7.0.0",
     "rfdc": "^1.4.1",
-    "vitest": "^4.1.0",
-    "typescript": "^5.9.3"
+    "vitest": "^4.1.6",
+    "typescript": "^6.0.3"
   },
-  "files": ["README.md", "LICENSE", "dist/*"],
+  "files": [
+    "README.md",
+    "LICENSE",
+    "dist/*"
+  ],
   "pnpm": {
-    "onlyBuiltDependencies": ["@biomejs/biome"]
+    "onlyBuiltDependencies": [
+      "@biomejs/biome"
+    ]
   }
 }

--- a/packages/sqs/package.json
+++ b/packages/sqs/package.json
@@ -54,19 +54,19 @@
     "zod": "^4.0.0"
   },
   "devDependencies": {
-    "@aws-sdk/client-sns": "^3.926.0",
-    "@aws-sdk/client-sqs": "^3.926.0",
-    "@aws-sdk/client-sts": "^3.926.0",
+    "@aws-sdk/client-sns": "^3.1048.0",
+    "@aws-sdk/client-sqs": "^3.1048.0",
+    "@aws-sdk/client-sts": "^3.1047.0",
     "@lokalise/node-core": "^14.8.1",
-    "@message-queue-toolkit/core": "^25.4.0",
+    "@message-queue-toolkit/core": "^25.5.0",
     "@message-queue-toolkit/sns": "^24.6.1",
     "@message-queue-toolkit/sqs": "^24.2.1",
-    "@types/node": "^22.19.15",
-    "@vitest/coverage-v8": "^4.1.0",
+    "@types/node": "^25.8.0",
+    "@vitest/coverage-v8": "^4.1.6",
     "fauxqs": "^2.5.0",
     "layered-loader": "workspace:^",
-    "typescript": "^5.9.3",
-    "vitest": "^4.1.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.6",
     "zod": "^4.4.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,21 +103,21 @@ importers:
   .:
     dependencies:
       ioredis:
-        specifier: ^5.10.0
+        specifier: ^5.10.1
         version: 5.10.1
       toad-cache:
-        specifier: ^3.7.0
-        version: 3.7.0
+        specifier: ^3.7.1
+        version: 3.7.1
     devDependencies:
       '@biomejs/biome':
-        specifier: ^1.9.4
-        version: 1.9.4
+        specifier: ^2.4.15
+        version: 2.4.15
       '@types/node':
-        specifier: ^22.19.15
-        version: 22.19.18
+        specifier: ^25.8.0
+        version: 25.8.0
       '@vitest/coverage-v8':
-        specifier: ^4.1.0
-        version: 4.1.5(vitest@4.1.5)
+        specifier: ^4.1.6
+        version: 4.1.6(vitest@4.1.6)
       del-cli:
         specifier: ^7.0.0
         version: 7.0.0
@@ -125,53 +125,53 @@ importers:
         specifier: ^1.4.1
         version: 1.4.1
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
-        specifier: ^4.1.0
-        version: 4.1.5(@types/node@22.19.18)(@vitest/coverage-v8@4.1.5)(vite@8.0.11(@types/node@22.19.18))
+        specifier: ^4.1.6
+        version: 4.1.6(@types/node@25.8.0)(@vitest/coverage-v8@4.1.6)(vite@8.0.11(@types/node@25.8.0))
 
   packages/sqs:
     devDependencies:
       '@aws-sdk/client-sns':
-        specifier: ^3.926.0
-        version: 3.1045.0
+        specifier: ^3.1048.0
+        version: 3.1048.0
       '@aws-sdk/client-sqs':
-        specifier: ^3.926.0
-        version: 3.1045.0
+        specifier: ^3.1048.0
+        version: 3.1048.0
       '@aws-sdk/client-sts':
-        specifier: ^3.926.0
-        version: 3.1045.0
+        specifier: ^3.1047.0
+        version: 3.1047.0
       '@lokalise/node-core':
         specifier: ^14.8.1
         version: 14.8.1(zod@4.4.3)
       '@message-queue-toolkit/core':
-        specifier: ^25.4.0
-        version: 25.4.0(zod@4.4.3)
+        specifier: ^25.5.0
+        version: 25.5.0(zod@4.4.3)
       '@message-queue-toolkit/sns':
         specifier: ^24.6.1
-        version: 24.6.1(@aws-sdk/client-sns@3.1045.0)(@aws-sdk/client-sqs@3.1045.0)(@aws-sdk/client-sts@3.1045.0)(@message-queue-toolkit/core@25.4.0(zod@4.4.3))(@message-queue-toolkit/schemas@7.1.0(zod@4.4.3))(@message-queue-toolkit/sqs@24.2.1(@aws-sdk/client-sqs@3.1045.0)(@message-queue-toolkit/core@25.4.0(zod@4.4.3))(zod@4.4.3))(zod@4.4.3)
+        version: 24.6.1(@aws-sdk/client-sns@3.1048.0)(@aws-sdk/client-sqs@3.1048.0)(@aws-sdk/client-sts@3.1047.0)(@message-queue-toolkit/core@25.5.0(zod@4.4.3))(@message-queue-toolkit/schemas@7.1.0(zod@4.4.3))(@message-queue-toolkit/sqs@24.2.1(@aws-sdk/client-sqs@3.1048.0)(@message-queue-toolkit/core@25.5.0(zod@4.4.3))(zod@4.4.3))(zod@4.4.3)
       '@message-queue-toolkit/sqs':
         specifier: ^24.2.1
-        version: 24.2.1(@aws-sdk/client-sqs@3.1045.0)(@message-queue-toolkit/core@25.4.0(zod@4.4.3))(zod@4.4.3)
+        version: 24.2.1(@aws-sdk/client-sqs@3.1048.0)(@message-queue-toolkit/core@25.5.0(zod@4.4.3))(zod@4.4.3)
       '@types/node':
-        specifier: ^22.19.15
-        version: 22.19.18
+        specifier: ^25.8.0
+        version: 25.8.0
       '@vitest/coverage-v8':
-        specifier: ^4.1.0
-        version: 4.1.5(vitest@4.1.5)
+        specifier: ^4.1.6
+        version: 4.1.6(vitest@4.1.6)
       fauxqs:
         specifier: ^2.5.0
-        version: 2.5.0(typescript@5.9.3)
+        version: 2.5.0(typescript@6.0.3)
       layered-loader:
         specifier: workspace:^
         version: link:../..
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
-        specifier: ^4.1.0
-        version: 4.1.5(@types/node@22.19.18)(@vitest/coverage-v8@4.1.5)(vite@8.0.11(@types/node@22.19.18))
+        specifier: ^4.1.6
+        version: 4.1.6(@types/node@25.8.0)(@vitest/coverage-v8@4.1.6)(vite@8.0.11(@types/node@25.8.0))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -209,12 +209,24 @@ packages:
     resolution: {integrity: sha512-w/iwPYVAXx62dD2E5nBQaUOntlYWCjaIPXGZpdC6+WWF/idTPjN3qu5Q0KgcrP6zQDGCgtAVaLlLVaK36/5x7A==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-sns@3.1048.0':
+    resolution: {integrity: sha512-IHecQQhboEb6tnBo77q95NyfBBWNb1xDKcsV5vnyeRPlWuC8uz+utaZEQcFBzhxDCS4/A9oynTVcrSE13mB4Vw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-sqs@3.1045.0':
     resolution: {integrity: sha512-reWeEE53mgCv8uUFSicvVf0A6BoWGImdC4y5x5clkeEmfIikahIBtons6u0d32kwI4NczpcretpUkOCE/nvWAA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/client-sts@3.1045.0':
-    resolution: {integrity: sha512-oDJJ7rM1osvfBdfZuhQ5DM6lHD9iuypL9m2LsEiA/lB8xuE5uPYsftNDcS0J9VRXFSvYTqC14K7Y5vMMKMg0vw==}
+  '@aws-sdk/client-sqs@3.1048.0':
+    resolution: {integrity: sha512-GGCSdU3rFc77KxgL7LmJeY169MEjsQmbLwHpnWpopavA1nxz2htJvLSPghuyGhTVpgqnp4HqwWiczlkjV3UADw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-sts@3.1047.0':
+    resolution: {integrity: sha512-LLeyHPEYlo16wfteaAkYKZx8BrvF+ZqSkYSWodLmtk8xxCAONLOkeHyAofOswQrSetz3BWiu+sd9WNXEvucoPg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.11':
+    resolution: {integrity: sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/core@3.974.8':
@@ -229,32 +241,64 @@ packages:
     resolution: {integrity: sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.37':
+    resolution: {integrity: sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.972.36':
     resolution: {integrity: sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.39':
+    resolution: {integrity: sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.38':
     resolution: {integrity: sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.972.41':
+    resolution: {integrity: sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.972.38':
     resolution: {integrity: sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.41':
+    resolution: {integrity: sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.39':
     resolution: {integrity: sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.42':
+    resolution: {integrity: sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.972.34':
     resolution: {integrity: sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.37':
+    resolution: {integrity: sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.972.38':
     resolution: {integrity: sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.972.41':
+    resolution: {integrity: sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.38':
     resolution: {integrity: sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.41':
+    resolution: {integrity: sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-bucket-endpoint@3.972.10':
@@ -273,6 +317,10 @@ packages:
     resolution: {integrity: sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-host-header@3.972.12':
+    resolution: {integrity: sha512-4QEreU2qPSu19Vsw/eQW8dq5wQEstoyR0nPvguprIa6U/wSA2/fMrisYO4ZZauD8zmYx53SoUodKLipHSi0ZYg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-location-constraint@3.972.10':
     resolution: {integrity: sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ==}
     engines: {node: '>=20.0.0'}
@@ -285,12 +333,20 @@ packages:
     resolution: {integrity: sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-recursion-detection@3.972.13':
+    resolution: {integrity: sha512-QZIpAIa6fDeVgJ8BEG1S6EHGKVul1DM6w6u24041Xl31FvgArh0slURCz5ij3oo0p249yjNHVRTw1GPJa7YUkQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-sdk-s3@3.972.37':
     resolution: {integrity: sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-sdk-sqs@3.972.22':
     resolution: {integrity: sha512-DtR3mEiOUJcnEX/QuXmvbJto6xvQzp2ftnHb29c0aQYdmmzbKf0gsu9ovx1i/yy4ZR6m0rttTucS0iiP32dlGA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-sqs@3.972.24':
+    resolution: {integrity: sha512-ej3vwWFzTP2B0FxlU2JelMaxplEncflFv2ARsoMQ9TXI/yfmsPEZw8zkOdsQp3rMEJ/vN7iKTYDYIcpeMmDRoQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-ssec@3.972.10':
@@ -301,20 +357,40 @@ packages:
     resolution: {integrity: sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-user-agent@3.972.41':
+    resolution: {integrity: sha512-HU2IGiA0aLlWgYpDlwnLn5wzyt7vYATi0JAyltrx7DE8AbO4w50E+Qzr2VSJWv4VXzhQYdfwevhHjOUuBTil1g==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/nested-clients@3.997.6':
     resolution: {integrity: sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.9':
+    resolution: {integrity: sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/region-config-resolver@3.972.13':
     resolution: {integrity: sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/region-config-resolver@3.972.15':
+    resolution: {integrity: sha512-RROpdNPC4L15h4WE0Zlzxd2n5yRd4VaIY/Pgw/+6YNgiGZo61qavXgMG9Zdb+OnPkBnwfpXIguTcEwhSrjEHGw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/signature-v4-multi-region@3.996.25':
     resolution: {integrity: sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/signature-v4-multi-region@3.996.27':
+    resolution: {integrity: sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/token-providers@3.1041.0':
     resolution: {integrity: sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1048.0':
+    resolution: {integrity: sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.8':
@@ -323,6 +399,10 @@ packages:
 
   '@aws-sdk/util-arn-parser@3.972.3':
     resolution: {integrity: sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.996.10':
+    resolution: {integrity: sha512-cdmvh+mmVWFKNhqFv/axpjJOYyaCgw+zta93IOv9sXKZPoL1m0XVhSI/Y7MGKLeVHUkG+ULVZy+q5AEAGivSDw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-endpoints@3.996.8':
@@ -336,6 +416,9 @@ packages:
   '@aws-sdk/util-user-agent-browser@3.972.10':
     resolution: {integrity: sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==}
 
+  '@aws-sdk/util-user-agent-browser@3.972.12':
+    resolution: {integrity: sha512-Glip9lOu73ttWJPO5OIbbWuivyCerLuCD/Rfk2BC/a23zpMeX3FGY9FMui5fh3YatGFZu1NVllVvA1sQy+PhJg==}
+
   '@aws-sdk/util-user-agent-node@3.973.24':
     resolution: {integrity: sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==}
     engines: {node: '>=20.0.0'}
@@ -345,8 +428,16 @@ packages:
       aws-crt:
         optional: true
 
+  '@aws-sdk/util-user-agent-node@3.973.27':
+    resolution: {integrity: sha512-om8FvUFQPVZECi08zIn6tuVomqbqNIlaMSXShKWWnGxOJ19TofiQtN7ZSlAIy/YvHNBm7oTK9dgT20G3YVH6qQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/xml-builder@3.972.22':
     resolution: {integrity: sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.24':
+    resolution: {integrity: sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
@@ -374,59 +465,59 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@biomejs/biome@1.9.4':
-    resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
+  '@biomejs/biome@2.4.15':
+    resolution: {integrity: sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@1.9.4':
-    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
+  '@biomejs/cli-darwin-arm64@2.4.15':
+    resolution: {integrity: sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@1.9.4':
-    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
+  '@biomejs/cli-darwin-x64@2.4.15':
+    resolution: {integrity: sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@1.9.4':
-    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
+  '@biomejs/cli-linux-arm64-musl@2.4.15':
+    resolution: {integrity: sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@1.9.4':
-    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
+  '@biomejs/cli-linux-arm64@2.4.15':
+    resolution: {integrity: sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@1.9.4':
-    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
+  '@biomejs/cli-linux-x64-musl@2.4.15':
+    resolution: {integrity: sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@1.9.4':
-    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
+  '@biomejs/cli-linux-x64@2.4.15':
+    resolution: {integrity: sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@1.9.4':
-    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
+  '@biomejs/cli-win32-arm64@2.4.15':
+    resolution: {integrity: sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@1.9.4':
-    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
+  '@biomejs/cli-win32-x64@2.4.15':
+    resolution: {integrity: sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -482,8 +573,8 @@ packages:
   '@lokalise/universal-ts-utils@4.10.0':
     resolution: {integrity: sha512-+k99TEjNikAqIEZCZZ6ltQ9lJveeHMNYzJmSClS4iBz+RLf67+8m2HDrPZ3J7MMWCGync2UGx7m8tjCNPJP3Aw==}
 
-  '@message-queue-toolkit/core@25.4.0':
-    resolution: {integrity: sha512-vQ88ClXDL0N/hA+MoOIcxcMxYmDftBt3bd5LlieaZIV2rK4+KQkOir0/nNk6zS63rXVkrM6uTyV8mIyezu2KQQ==}
+  '@message-queue-toolkit/core@25.5.0':
+    resolution: {integrity: sha512-QJHIktu1WOHtiys7LS/772IbhwyHoa61AZEAC4o5vZPaJ5jUPB9hXbbhwOgjYSFIGvx/meUszaA9lzTOL9R8lQ==}
     peerDependencies:
       zod: '>=3.25.76 <5.0.0'
 
@@ -647,8 +738,16 @@ packages:
     resolution: {integrity: sha512-rZ5YfycIXX6puoGjthnDiMpUgtKNOq3c7CndQYkCNYQTv26AiCrZQOJPy7ANSfZ6Okk3UvCRnmO1OYWlLnYZgg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.24.3':
+    resolution: {integrity: sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.3.0':
     resolution: {integrity: sha512-5gi+28FH+RurB2+tcRH1CK7KiLJ0dVnabjWLY3DgeFLiU45dbyrsq7NOYvMUcHgu9LVZH5F7G+Qk1GdXF0y6jg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.3.3':
+    resolution: {integrity: sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/eventstream-serde-browser@4.3.0':
@@ -665,6 +764,10 @@ packages:
 
   '@smithy/fetch-http-handler@5.4.0':
     resolution: {integrity: sha512-yxurumLvHfgYgM0FVtjOVIyBSJXfno4xKKOgD43wOk9Qh+2lTKfP9Qhu4JHU7IUwrqVPa888byUzomHMgvKVMg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.4.3':
+    resolution: {integrity: sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/hash-blob-browser@4.3.0':
@@ -723,6 +826,10 @@ packages:
     resolution: {integrity: sha512-PxF57Jr3dPm+RgZWekOL+o96FPdaT62xZUyDfi47uMRFi5rHpwO/ewFbrztrASQ/7H8moNi1sspIHihHpfoKsQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.7.3':
+    resolution: {integrity: sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/property-provider@4.3.0':
     resolution: {integrity: sha512-/YBWtO2SdvPSAUk/Ke1Xpdg1E1lfaNGblla7mnIVGtaGkSQ5bK7KBZqpuj5IokHlU9UcLDvt2QwTLV7oRzBUTA==}
     engines: {node: '>=18.0.0'}
@@ -739,12 +846,20 @@ packages:
     resolution: {integrity: sha512-nkdB9T8JS6iD5PukE5TB8KqcvMEPVPHVUY7J0odYJgyIM40Du2msUhBdoPNRqRArDDcGQqVQcbzu0CZA7b+Nkw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/signature-v4@5.4.3':
+    resolution: {integrity: sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/smithy-client@4.13.0':
     resolution: {integrity: sha512-lysfoRCr7PdD9CsPp9VQuJYRGI5mWYb8FRkbdBSQttxpQmW7tZsFgmpBNKVcgvBsAgBCkYX/UQs0NmznuBcZQQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.14.1':
     resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.2':
+    resolution: {integrity: sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/url-parser@4.3.0':
@@ -826,23 +941,23 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
-  '@types/node@22.19.18':
-    resolution: {integrity: sha512-9v00a+dn2yWVsYDEunWC4g/TcRKVq3r8N5FuZp7u0SGrPvdN9c2yXI9bBuf5Fl0hNCb+QTIePTn5pJs2pwBOQQ==}
+  '@types/node@25.8.0':
+    resolution: {integrity: sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==}
 
-  '@vitest/coverage-v8@4.1.5':
-    resolution: {integrity: sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==}
+  '@vitest/coverage-v8@4.1.6':
+    resolution: {integrity: sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==}
     peerDependencies:
-      '@vitest/browser': 4.1.5
-      vitest: 4.1.5
+      '@vitest/browser': 4.1.6
+      vitest: 4.1.6
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.1.5':
-    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+  '@vitest/expect@4.1.6':
+    resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
 
-  '@vitest/mocker@4.1.5':
-    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+  '@vitest/mocker@4.1.6':
+    resolution: {integrity: sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -852,20 +967,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.5':
-    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+  '@vitest/pretty-format@4.1.6':
+    resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
 
-  '@vitest/runner@4.1.5':
-    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+  '@vitest/runner@4.1.6':
+    resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
 
-  '@vitest/snapshot@4.1.5':
-    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+  '@vitest/snapshot@4.1.6':
+    resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
 
-  '@vitest/spy@4.1.5':
-    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+  '@vitest/spy@4.1.6':
+    resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
 
-  '@vitest/utils@4.1.5':
-    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+  '@vitest/utils@4.1.6':
+    resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
 
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
@@ -1008,6 +1123,10 @@ packages:
 
   fast-xml-parser@5.7.2:
     resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
+    hasBin: true
+
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
     hasBin: true
 
   fastify-plugin@5.1.0:
@@ -1451,6 +1570,10 @@ packages:
     resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
     engines: {node: '>=12'}
 
+  toad-cache@3.7.1:
+    resolution: {integrity: sha512-5DXWzE4Vz7xNHsv+xQ+MGfJYyC78Aok3tEr0MNwHoRf7vZnga1mQXZ4/Nsodld4VR6Wd+VhfmqnNrsRJyYPfrQ==}
+    engines: {node: '>=20'}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -1458,13 +1581,13 @@ packages:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
     engines: {node: '>=20'}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -1521,20 +1644,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.5:
-    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+  vitest@4.1.6:
+    resolution: {integrity: sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.5
-      '@vitest/browser-preview': 4.1.5
-      '@vitest/browser-webdriverio': 4.1.5
-      '@vitest/coverage-istanbul': 4.1.5
-      '@vitest/coverage-v8': 4.1.5
-      '@vitest/ui': 4.1.5
+      '@vitest/browser-playwright': 4.1.6
+      '@vitest/browser-preview': 4.1.6
+      '@vitest/browser-webdriverio': 4.1.6
+      '@vitest/coverage-istanbul': 4.1.6
+      '@vitest/coverage-v8': 4.1.6
+      '@vitest/ui': 4.1.6
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1730,6 +1853,19 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/client-sns@3.1048.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.11
+      '@aws-sdk/credential-provider-node': 3.972.42
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/client-sqs@3.1045.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -1776,50 +1912,52 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sts@3.1045.0':
+  '@aws-sdk/client-sqs@3.1048.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/credential-provider-node': 3.972.39
-      '@aws-sdk/middleware-host-header': 3.972.10
-      '@aws-sdk/middleware-logger': 3.972.10
-      '@aws-sdk/middleware-recursion-detection': 3.972.11
-      '@aws-sdk/middleware-user-agent': 3.972.38
-      '@aws-sdk/region-config-resolver': 3.972.13
-      '@aws-sdk/signature-v4-multi-region': 3.996.25
+      '@aws-sdk/core': 3.974.11
+      '@aws-sdk/credential-provider-node': 3.972.42
+      '@aws-sdk/middleware-sdk-sqs': 3.972.24
       '@aws-sdk/types': 3.973.8
-      '@aws-sdk/util-endpoints': 3.996.8
-      '@aws-sdk/util-user-agent-browser': 3.972.10
-      '@aws-sdk/util-user-agent-node': 3.973.24
-      '@smithy/config-resolver': 4.5.0
-      '@smithy/core': 3.24.0
-      '@smithy/fetch-http-handler': 5.4.0
-      '@smithy/hash-node': 4.3.0
-      '@smithy/invalid-dependency': 4.3.0
-      '@smithy/middleware-content-length': 4.3.0
-      '@smithy/middleware-endpoint': 4.5.0
-      '@smithy/middleware-retry': 4.6.0
-      '@smithy/middleware-serde': 4.3.0
-      '@smithy/middleware-stack': 4.3.0
-      '@smithy/node-config-provider': 4.4.0
-      '@smithy/node-http-handler': 4.7.0
-      '@smithy/protocol-http': 5.4.0
-      '@smithy/smithy-client': 4.13.0
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
       '@smithy/types': 4.14.1
-      '@smithy/url-parser': 4.3.0
-      '@smithy/util-base64': 4.4.0
-      '@smithy/util-body-length-browser': 4.3.0
-      '@smithy/util-body-length-node': 4.3.0
-      '@smithy/util-defaults-mode-browser': 4.4.0
-      '@smithy/util-defaults-mode-node': 4.3.0
-      '@smithy/util-endpoints': 3.5.0
-      '@smithy/util-middleware': 4.3.0
-      '@smithy/util-retry': 4.4.0
-      '@smithy/util-utf8': 4.3.0
       tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
+
+  '@aws-sdk/client-sts@3.1047.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.11
+      '@aws-sdk/credential-provider-node': 3.972.42
+      '@aws-sdk/middleware-host-header': 3.972.12
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.13
+      '@aws-sdk/middleware-user-agent': 3.972.41
+      '@aws-sdk/region-config-resolver': 3.972.15
+      '@aws-sdk/signature-v4-multi-region': 3.996.27
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.10
+      '@aws-sdk/util-user-agent-browser': 3.972.12
+      '@aws-sdk/util-user-agent-node': 3.973.27
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/xml-builder': 3.972.24
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.3
+      '@smithy/signature-v4': 5.4.3
+      '@smithy/types': 4.14.1
+      bowser: 2.14.1
+      tslib: 2.8.1
 
   '@aws-sdk/core@3.974.8':
     dependencies:
@@ -1851,6 +1989,14 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-env@3.972.37':
+    dependencies:
+      '@aws-sdk/core': 3.974.11
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-http@3.972.36':
     dependencies:
       '@aws-sdk/core': 3.974.8
@@ -1862,6 +2008,16 @@ snapshots:
       '@smithy/smithy-client': 4.13.0
       '@smithy/types': 4.14.1
       '@smithy/util-stream': 4.6.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.39':
+    dependencies:
+      '@aws-sdk/core': 3.974.11
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.972.38':
@@ -1883,6 +2039,22 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-ini@3.972.41':
+    dependencies:
+      '@aws-sdk/core': 3.974.11
+      '@aws-sdk/credential-provider-env': 3.972.37
+      '@aws-sdk/credential-provider-http': 3.972.39
+      '@aws-sdk/credential-provider-login': 3.972.41
+      '@aws-sdk/credential-provider-process': 3.972.37
+      '@aws-sdk/credential-provider-sso': 3.972.41
+      '@aws-sdk/credential-provider-web-identity': 3.972.41
+      '@aws-sdk/nested-clients': 3.997.9
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/credential-provider-imds': 4.3.3
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.38':
     dependencies:
       '@aws-sdk/core': 3.974.8
@@ -1895,6 +2067,15 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.41':
+    dependencies:
+      '@aws-sdk/core': 3.974.11
+      '@aws-sdk/nested-clients': 3.997.9
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
 
   '@aws-sdk/credential-provider-node@3.972.39':
     dependencies:
@@ -1913,12 +2094,34 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-node@3.972.42':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.37
+      '@aws-sdk/credential-provider-http': 3.972.39
+      '@aws-sdk/credential-provider-ini': 3.972.41
+      '@aws-sdk/credential-provider-process': 3.972.37
+      '@aws-sdk/credential-provider-sso': 3.972.41
+      '@aws-sdk/credential-provider-web-identity': 3.972.41
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/credential-provider-imds': 4.3.3
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.34':
     dependencies:
       '@aws-sdk/core': 3.974.8
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.3.0
       '@smithy/shared-ini-file-loader': 4.5.0
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.37':
+    dependencies:
+      '@aws-sdk/core': 3.974.11
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
@@ -1935,6 +2138,16 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-sso@3.972.41':
+    dependencies:
+      '@aws-sdk/core': 3.974.11
+      '@aws-sdk/nested-clients': 3.997.9
+      '@aws-sdk/token-providers': 3.1048.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.38':
     dependencies:
       '@aws-sdk/core': 3.974.8
@@ -1946,6 +2159,15 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.41':
+    dependencies:
+      '@aws-sdk/core': 3.974.11
+      '@aws-sdk/nested-clients': 3.997.9
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
 
   '@aws-sdk/middleware-bucket-endpoint@3.972.10':
     dependencies:
@@ -1988,6 +2210,11 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-host-header@3.972.12':
+    dependencies:
+      '@aws-sdk/core': 3.974.11
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-location-constraint@3.972.10':
     dependencies:
       '@aws-sdk/types': 3.973.8
@@ -2006,6 +2233,11 @@ snapshots:
       '@aws/lambda-invoke-store': 0.2.4
       '@smithy/protocol-http': 5.4.0
       '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-recursion-detection@3.972.13':
+    dependencies:
+      '@aws-sdk/core': 3.974.11
       tslib: 2.8.1
 
   '@aws-sdk/middleware-sdk-s3@3.972.37':
@@ -2034,6 +2266,13 @@ snapshots:
       '@smithy/util-utf8': 4.3.0
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-sdk-sqs@3.972.24':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-ssec@3.972.10':
     dependencies:
       '@aws-sdk/types': 3.973.8
@@ -2049,6 +2288,11 @@ snapshots:
       '@smithy/protocol-http': 5.4.0
       '@smithy/types': 4.14.1
       '@smithy/util-retry': 4.4.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.972.41':
+    dependencies:
+      '@aws-sdk/core': 3.974.11
       tslib: 2.8.1
 
   '@aws-sdk/nested-clients@3.997.6':
@@ -2095,6 +2339,19 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/nested-clients@3.997.9':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.11
+      '@aws-sdk/signature-v4-multi-region': 3.996.27
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/region-config-resolver@3.972.13':
     dependencies:
       '@aws-sdk/types': 3.973.8
@@ -2103,12 +2360,25 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/region-config-resolver@3.972.15':
+    dependencies:
+      '@aws-sdk/core': 3.974.11
+      tslib: 2.8.1
+
   '@aws-sdk/signature-v4-multi-region@3.996.25':
     dependencies:
       '@aws-sdk/middleware-sdk-s3': 3.972.37
       '@aws-sdk/types': 3.973.8
       '@smithy/protocol-http': 5.4.0
       '@smithy/signature-v4': 5.4.0
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.27':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/signature-v4': 5.4.3
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
@@ -2124,6 +2394,15 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/token-providers@3.1048.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.11
+      '@aws-sdk/nested-clients': 3.997.9
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/types@3.973.8':
     dependencies:
       '@smithy/types': 4.14.1
@@ -2131,6 +2410,12 @@ snapshots:
 
   '@aws-sdk/util-arn-parser@3.972.3':
     dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.996.10':
+    dependencies:
+      '@aws-sdk/core': 3.974.11
+      '@smithy/core': 3.24.3
       tslib: 2.8.1
 
   '@aws-sdk/util-endpoints@3.996.8':
@@ -2152,6 +2437,11 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/util-user-agent-browser@3.972.12':
+    dependencies:
+      '@aws-sdk/core': 3.974.11
+      tslib: 2.8.1
+
   '@aws-sdk/util-user-agent-node@3.973.24':
     dependencies:
       '@aws-sdk/middleware-user-agent': 3.972.38
@@ -2161,11 +2451,23 @@ snapshots:
       '@smithy/util-config-provider': 4.3.0
       tslib: 2.8.1
 
+  '@aws-sdk/util-user-agent-node@3.973.27':
+    dependencies:
+      '@aws-sdk/core': 3.974.11
+      tslib: 2.8.1
+
   '@aws-sdk/xml-builder@3.972.22':
     dependencies:
       '@nodable/entities': 2.1.0
       '@smithy/types': 4.14.1
       fast-xml-parser: 5.7.2
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.24':
+    dependencies:
+      '@nodable/entities': 2.1.0
+      '@smithy/types': 4.14.1
+      fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.4': {}
@@ -2185,39 +2487,39 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@biomejs/biome@1.9.4':
+  '@biomejs/biome@2.4.15':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 1.9.4
-      '@biomejs/cli-darwin-x64': 1.9.4
-      '@biomejs/cli-linux-arm64': 1.9.4
-      '@biomejs/cli-linux-arm64-musl': 1.9.4
-      '@biomejs/cli-linux-x64': 1.9.4
-      '@biomejs/cli-linux-x64-musl': 1.9.4
-      '@biomejs/cli-win32-arm64': 1.9.4
-      '@biomejs/cli-win32-x64': 1.9.4
+      '@biomejs/cli-darwin-arm64': 2.4.15
+      '@biomejs/cli-darwin-x64': 2.4.15
+      '@biomejs/cli-linux-arm64': 2.4.15
+      '@biomejs/cli-linux-arm64-musl': 2.4.15
+      '@biomejs/cli-linux-x64': 2.4.15
+      '@biomejs/cli-linux-x64-musl': 2.4.15
+      '@biomejs/cli-win32-arm64': 2.4.15
+      '@biomejs/cli-win32-x64': 2.4.15
 
-  '@biomejs/cli-darwin-arm64@1.9.4':
+  '@biomejs/cli-darwin-arm64@2.4.15':
     optional: true
 
-  '@biomejs/cli-darwin-x64@1.9.4':
+  '@biomejs/cli-darwin-x64@2.4.15':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@1.9.4':
+  '@biomejs/cli-linux-arm64-musl@2.4.15':
     optional: true
 
-  '@biomejs/cli-linux-arm64@1.9.4':
+  '@biomejs/cli-linux-arm64@2.4.15':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@1.9.4':
+  '@biomejs/cli-linux-x64-musl@2.4.15':
     optional: true
 
-  '@biomejs/cli-linux-x64@1.9.4':
+  '@biomejs/cli-linux-x64@2.4.15':
     optional: true
 
-  '@biomejs/cli-win32-arm64@1.9.4':
+  '@biomejs/cli-win32-arm64@2.4.15':
     optional: true
 
-  '@biomejs/cli-win32-x64@1.9.4':
+  '@biomejs/cli-win32-x64@2.4.15':
     optional: true
 
   '@emnapi/core@1.10.0':
@@ -2285,7 +2587,7 @@ snapshots:
 
   '@lokalise/universal-ts-utils@4.10.0': {}
 
-  '@message-queue-toolkit/core@25.4.0(zod@4.4.3)':
+  '@message-queue-toolkit/core@25.5.0(zod@4.4.3)':
     dependencies:
       '@lokalise/node-core': 14.8.1(zod@4.4.3)
       '@lokalise/universal-ts-utils': 4.10.0
@@ -2301,26 +2603,26 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@message-queue-toolkit/sns@24.6.1(@aws-sdk/client-sns@3.1045.0)(@aws-sdk/client-sqs@3.1045.0)(@aws-sdk/client-sts@3.1045.0)(@message-queue-toolkit/core@25.4.0(zod@4.4.3))(@message-queue-toolkit/schemas@7.1.0(zod@4.4.3))(@message-queue-toolkit/sqs@24.2.1(@aws-sdk/client-sqs@3.1045.0)(@message-queue-toolkit/core@25.4.0(zod@4.4.3))(zod@4.4.3))(zod@4.4.3)':
+  '@message-queue-toolkit/sns@24.6.1(@aws-sdk/client-sns@3.1048.0)(@aws-sdk/client-sqs@3.1048.0)(@aws-sdk/client-sts@3.1047.0)(@message-queue-toolkit/core@25.5.0(zod@4.4.3))(@message-queue-toolkit/schemas@7.1.0(zod@4.4.3))(@message-queue-toolkit/sqs@24.2.1(@aws-sdk/client-sqs@3.1048.0)(@message-queue-toolkit/core@25.5.0(zod@4.4.3))(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      '@aws-sdk/client-sns': 3.1045.0
-      '@aws-sdk/client-sqs': 3.1045.0
-      '@aws-sdk/client-sts': 3.1045.0
+      '@aws-sdk/client-sns': 3.1048.0
+      '@aws-sdk/client-sqs': 3.1048.0
+      '@aws-sdk/client-sts': 3.1047.0
       '@lokalise/node-core': 14.8.1(zod@4.4.3)
-      '@message-queue-toolkit/core': 25.4.0(zod@4.4.3)
+      '@message-queue-toolkit/core': 25.5.0(zod@4.4.3)
       '@message-queue-toolkit/schemas': 7.1.0(zod@4.4.3)
-      '@message-queue-toolkit/sqs': 24.2.1(@aws-sdk/client-sqs@3.1045.0)(@message-queue-toolkit/core@25.4.0(zod@4.4.3))(zod@4.4.3)
-      sqs-consumer: 14.2.8(@aws-sdk/client-sqs@3.1045.0)
+      '@message-queue-toolkit/sqs': 24.2.1(@aws-sdk/client-sqs@3.1048.0)(@message-queue-toolkit/core@25.5.0(zod@4.4.3))(zod@4.4.3)
+      sqs-consumer: 14.2.8(@aws-sdk/client-sqs@3.1048.0)
       zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  '@message-queue-toolkit/sqs@24.2.1(@aws-sdk/client-sqs@3.1045.0)(@message-queue-toolkit/core@25.4.0(zod@4.4.3))(zod@4.4.3)':
+  '@message-queue-toolkit/sqs@24.2.1(@aws-sdk/client-sqs@3.1048.0)(@message-queue-toolkit/core@25.5.0(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      '@aws-sdk/client-sqs': 3.1045.0
+      '@aws-sdk/client-sqs': 3.1048.0
       '@lokalise/node-core': 14.8.1(zod@4.4.3)
-      '@message-queue-toolkit/core': 25.4.0(zod@4.4.3)
-      sqs-consumer: 14.2.8(@aws-sdk/client-sqs@3.1045.0)
+      '@message-queue-toolkit/core': 25.5.0(zod@4.4.3)
+      sqs-consumer: 14.2.8(@aws-sdk/client-sqs@3.1048.0)
       zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -2414,10 +2716,22 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@smithy/core@3.24.3':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.3.0':
     dependencies:
       '@smithy/core': 3.24.0
       '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.3.3':
+    dependencies:
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@smithy/eventstream-serde-browser@4.3.0':
@@ -2439,6 +2753,12 @@ snapshots:
     dependencies:
       '@smithy/core': 3.24.0
       '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.4.3':
+    dependencies:
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@smithy/hash-blob-browser@4.3.0':
@@ -2511,6 +2831,12 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.7.3':
+    dependencies:
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/property-provider@4.3.0':
     dependencies:
       '@smithy/core': 3.24.0
@@ -2532,6 +2858,12 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@smithy/signature-v4@5.4.3':
+    dependencies:
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/smithy-client@4.13.0':
     dependencies:
       '@smithy/core': 3.24.0
@@ -2539,6 +2871,10 @@ snapshots:
       tslib: 2.8.1
 
   '@smithy/types@4.14.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.2':
     dependencies:
       tslib: 2.8.1
 
@@ -2638,14 +2974,14 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
-  '@types/node@22.19.18':
+  '@types/node@25.8.0':
     dependencies:
-      undici-types: 6.21.0
+      undici-types: 7.24.6
 
-  '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
+  '@vitest/coverage-v8@4.1.6(vitest@4.1.6)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.5
+      '@vitest/utils': 4.1.6
       ast-v8-to-istanbul: 1.0.0
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
@@ -2654,46 +2990,46 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@22.19.18)(@vitest/coverage-v8@4.1.5)(vite@8.0.11(@types/node@22.19.18))
+      vitest: 4.1.6(@types/node@25.8.0)(@vitest/coverage-v8@4.1.6)(vite@8.0.11(@types/node@25.8.0))
 
-  '@vitest/expect@4.1.5':
+  '@vitest/expect@4.1.6':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.5
-      '@vitest/utils': 4.1.5
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.11(@types/node@22.19.18))':
+  '@vitest/mocker@4.1.6(vite@8.0.11(@types/node@25.8.0))':
     dependencies:
-      '@vitest/spy': 4.1.5
+      '@vitest/spy': 4.1.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.11(@types/node@22.19.18)
+      vite: 8.0.11(@types/node@25.8.0)
 
-  '@vitest/pretty-format@4.1.5':
+  '@vitest/pretty-format@4.1.6':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.5':
+  '@vitest/runner@4.1.6':
     dependencies:
-      '@vitest/utils': 4.1.5
+      '@vitest/utils': 4.1.6
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.5':
+  '@vitest/snapshot@4.1.6':
     dependencies:
-      '@vitest/pretty-format': 4.1.5
-      '@vitest/utils': 4.1.5
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/utils': 4.1.6
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.5': {}
+  '@vitest/spy@4.1.6': {}
 
-  '@vitest/utils@4.1.5':
+  '@vitest/utils@4.1.6':
     dependencies:
-      '@vitest/pretty-format': 4.1.5
+      '@vitest/pretty-format': 4.1.6
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -2834,6 +3170,13 @@ snapshots:
       path-expression-matcher: 1.5.0
       strnum: 2.3.0
 
+  fast-xml-parser@5.7.3:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.3.0
+
   fastify-plugin@5.1.0: {}
 
   fastify@5.8.5:
@@ -2858,7 +3201,7 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
-  fauxqs@2.5.0(typescript@5.9.3):
+  fauxqs@2.5.0(typescript@6.0.3):
     dependencies:
       '@aws-sdk/client-s3': 3.1045.0
       '@aws-sdk/client-sns': 3.1045.0
@@ -2867,7 +3210,7 @@ snapshots:
       '@smithy/node-http-handler': 4.7.0
       fastify: 5.8.5
       toad-cache: 3.7.0
-      valibot: 1.4.0(typescript@5.9.3)
+      valibot: 1.4.0(typescript@6.0.3)
     transitivePeerDependencies:
       - aws-crt
       - typescript
@@ -3197,9 +3540,9 @@ snapshots:
 
   split2@4.2.0: {}
 
-  sqs-consumer@14.2.8(@aws-sdk/client-sqs@3.1045.0):
+  sqs-consumer@14.2.8(@aws-sdk/client-sqs@3.1048.0):
     dependencies:
-      '@aws-sdk/client-sqs': 3.1045.0
+      '@aws-sdk/client-sqs': 3.1048.0
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -3243,23 +3586,25 @@ snapshots:
 
   toad-cache@3.7.0: {}
 
+  toad-cache@3.7.1: {}
+
   tslib@2.8.1: {}
 
   type-fest@5.6.0:
     dependencies:
       tagged-tag: 1.0.0
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
-  undici-types@6.21.0: {}
+  undici-types@7.24.6: {}
 
   unicorn-magic@0.3.0: {}
 
-  valibot@1.4.0(typescript@5.9.3):
+  valibot@1.4.0(typescript@6.0.3):
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  vite@8.0.11(@types/node@22.19.18):
+  vite@8.0.11(@types/node@25.8.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -3267,18 +3612,18 @@ snapshots:
       rolldown: 1.0.0-rc.18
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 22.19.18
+      '@types/node': 25.8.0
       fsevents: 2.3.3
 
-  vitest@4.1.5(@types/node@22.19.18)(@vitest/coverage-v8@4.1.5)(vite@8.0.11(@types/node@22.19.18)):
+  vitest@4.1.6(@types/node@25.8.0)(@vitest/coverage-v8@4.1.6)(vite@8.0.11(@types/node@25.8.0)):
     dependencies:
-      '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.11(@types/node@22.19.18))
-      '@vitest/pretty-format': 4.1.5
-      '@vitest/runner': 4.1.5
-      '@vitest/snapshot': 4.1.5
-      '@vitest/spy': 4.1.5
-      '@vitest/utils': 4.1.5
+      '@vitest/expect': 4.1.6
+      '@vitest/mocker': 4.1.6(vite@8.0.11(@types/node@25.8.0))
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/runner': 4.1.6
+      '@vitest/snapshot': 4.1.6
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -3290,11 +3635,11 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.11(@types/node@22.19.18)
+      vite: 8.0.11(@types/node@25.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.19.18
-      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
+      '@types/node': 25.8.0
+      '@vitest/coverage-v8': 4.1.6(vitest@4.1.6)
     transitivePeerDependencies:
       - msw
 

--- a/test/GroupLoader-async-refresh.spec.ts
+++ b/test/GroupLoader-async-refresh.spec.ts
@@ -68,12 +68,12 @@ describe('GroupLoader Async Refresh', () => {
         dataSources: [loader],
       })
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(await operation.asyncCache.getFromGroup(user1.userId, user1.companyId)).toBeUndefined()
       expect(loader.counter).toBe(0)
       expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
       expect(loader.counter).toBe(1)
-      // @ts-ignore
+      // @ts-expect-error
       const expirationTimePre = await operation.asyncCache.getExpirationTimeFromGroup(
         user1.userId,
         user1.companyId,
@@ -85,7 +85,7 @@ describe('GroupLoader Async Refresh', () => {
       expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
       await setTimeout(5)
       expect(loader.counter).toBe(2)
-      // @ts-ignore
+      // @ts-expect-error
       const expirationTimePost = await operation.asyncCache.getExpirationTimeFromGroup(
         user1.userId,
         user1.companyId,
@@ -114,7 +114,7 @@ describe('GroupLoader Async Refresh', () => {
         dataSources: [loader],
       })
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(await operation.asyncCache.getFromGroup(user1.userId, user1.companyId)).toBeUndefined()
       expect(loader.counter).toBe(0)
       const promise0 = operation.get(user1.userId, user1.companyId)
@@ -122,7 +122,7 @@ describe('GroupLoader Async Refresh', () => {
       await loader.finishLoading()
       expect(await promise0).toEqual(user1)
       expect(loader.counter).toBe(1)
-      // @ts-ignore
+      // @ts-expect-error
       const expirationTimePre = await operation.asyncCache.getExpirationTimeFromGroup(
         user1.userId,
         user1.companyId,
@@ -141,7 +141,7 @@ describe('GroupLoader Async Refresh', () => {
 
       expect(loader.counter).toBe(2)
       await setTimeout(5)
-      // @ts-ignore
+      // @ts-expect-error
       const expirationTimePost = await operation.asyncCache.getExpirationTimeFromGroup(
         user1.userId,
         user1.companyId,
@@ -171,7 +171,7 @@ describe('GroupLoader Async Refresh', () => {
         dataSources: [loader],
       })
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(await operation.asyncCache.getFromGroup(user1.userId, user1.companyId)).toBeUndefined()
       expect(loader.counter).toBe(0)
       const promise0 = operation.get(user1.userId, user1.companyId)
@@ -179,7 +179,7 @@ describe('GroupLoader Async Refresh', () => {
       await loader.finishLoading()
       expect(await promise0).toEqual(user1)
       expect(loader.counter).toBe(1)
-      // @ts-ignore
+      // @ts-expect-error
       const expirationTimePre = await operation.asyncCache.getExpirationTimeFromGroup(
         user1.userId,
         user1.companyId,
@@ -199,7 +199,7 @@ describe('GroupLoader Async Refresh', () => {
       expect(await promise2).toEqual(user1)
       expect(loader.counter).toBe(2)
       await setTimeout(5)
-      // @ts-ignore
+      // @ts-expect-error
       const expirationTimePost = await operation.asyncCache.getExpirationTimeFromGroup(
         user1.userId,
         user1.companyId,
@@ -236,7 +236,7 @@ describe('GroupLoader Async Refresh', () => {
       await setTimeout(5)
       expect(loader.counter).toBe(2)
 
-      // @ts-ignore
+      // @ts-expect-error
       const groupRefreshFlags: Map<string, Set<string>> = operation.groupRefreshFlags
       // The empty Set for the group should have been cleaned up
       expect(groupRefreshFlags.has(user1.companyId)).toBe(false)
@@ -256,7 +256,7 @@ describe('GroupLoader Async Refresh', () => {
         throwIfUnresolved: true,
       })
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(await operation.asyncCache.getFromGroup(user1.userId, user1.companyId)).toBeUndefined()
       expect(loader.counter).toBe(0)
       expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)

--- a/test/GroupLoader-main.spec.ts
+++ b/test/GroupLoader-main.spec.ts
@@ -5,12 +5,12 @@ import { GroupLoader } from '../lib/GroupLoader'
 import type { InMemoryGroupCacheConfiguration } from '../lib/memory/InMemoryGroupCache'
 import { CountingGroupedLoader } from './fakes/CountingGroupedLoader'
 import type { DummyLoaderManyParams, DummyLoaderParams } from './fakes/DummyDataSourceWithParams'
-import { DummyGroupNotificationConsumer } from './fakes/DummyGroupNotificationConsumer'
-import { DummyGroupNotificationConsumerMultiplexer } from './fakes/DummyGroupNotificationConsumerMultiplexer'
-import { DummyGroupNotificationPublisher } from './fakes/DummyGroupNotificationPublisher'
 import { DummyGroupedCache } from './fakes/DummyGroupedCache'
 import { DummyGroupedDataSourceWithParams } from './fakes/DummyGroupedDataSourceWithParams'
 import { DummyGroupedLoader } from './fakes/DummyGroupedLoader'
+import { DummyGroupNotificationConsumer } from './fakes/DummyGroupNotificationConsumer'
+import { DummyGroupNotificationConsumerMultiplexer } from './fakes/DummyGroupNotificationConsumerMultiplexer'
+import { DummyGroupNotificationPublisher } from './fakes/DummyGroupNotificationPublisher'
 import { TemporaryThrowingGroupedLoader } from './fakes/TemporaryThrowingGroupedLoader'
 import { ThrowingGroupedCache } from './fakes/ThrowingGroupedCache'
 import { ThrowingGroupedLoader } from './fakes/ThrowingGroupedLoader'
@@ -310,7 +310,7 @@ describe('GroupLoader Main', () => {
       // getInMemoryOnly should NOT create an entry in runningLoads for a group that doesn't need refresh
       operation.getInMemoryOnly(user1.userId, user1.companyId)
 
-      // @ts-ignore
+      // @ts-expect-error
       const runningLoads: Map<string, Map<string, unknown>> = operation.runningLoads
       // Either the group doesn't exist in runningLoads, or it has no entries
       const groupLoads = runningLoads.get(user1.companyId)
@@ -332,7 +332,7 @@ describe('GroupLoader Main', () => {
       expect(loader.counter).toBe(0)
       expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
       expect(loader.counter).toBe(1)
-      // @ts-ignore
+      // @ts-expect-error
       const expirationTimePre = operation.inMemoryCache.getExpirationTimeFromGroup(
         user1.userId,
         user1.companyId,
@@ -345,7 +345,7 @@ describe('GroupLoader Main', () => {
       await setTimeout(1)
       expect(loader.counter).toBe(2)
       await Promise.resolve()
-      // @ts-ignore
+      // @ts-expect-error
       const expirationTimePost = operation.inMemoryCache.getExpirationTimeFromGroup(
         user1.userId,
         user1.companyId,
@@ -498,7 +498,7 @@ describe('GroupLoader Main', () => {
 
     it('returns value when resolved via single loader', async () => {
       const operation = new GroupLoader<User>({ inMemoryCache: IN_MEMORY_CACHE_CONFIG })
-      // @ts-ignore
+      // @ts-expect-error
       operation.inMemoryCache.setForGroup(user1.userId, user1, user1.companyId)
 
       const result = await operation.get(user1.userId, user1.companyId)
@@ -530,7 +530,7 @@ describe('GroupLoader Main', () => {
           new DummyGroupedLoader(userValues),
         ],
       })
-      // @ts-ignore
+      // @ts-expect-error
       const cache1 = operation.inMemoryCache
 
       const valuePre = cache1.getFromGroup(user1.userId, user1.companyId)
@@ -551,7 +551,7 @@ describe('GroupLoader Main', () => {
         dataSources: [new DummyGroupedDataSourceWithParams(userValues)],
         cacheKeyFromLoadParamsResolver: (value) => value.id,
       })
-      // @ts-ignore
+      // @ts-expect-error
       const cache1 = operation.inMemoryCache
 
       const valuePre = await cache1.getFromGroup(user1.userId, user1.companyId)
@@ -729,7 +729,7 @@ describe('GroupLoader Main', () => {
         inMemoryCache: IN_MEMORY_CACHE_CONFIG,
         cacheKeyFromValueResolver: idResolver,
       })
-      // @ts-ignore
+      // @ts-expect-error
       operation.inMemoryCache.setForGroup(user1.userId, user1, user1.companyId)
 
       const result = await operation.getMany([user1.userId], user1.companyId)
@@ -763,7 +763,7 @@ describe('GroupLoader Main', () => {
         ],
         cacheKeyFromValueResolver: idResolver,
       })
-      // @ts-ignore
+      // @ts-expect-error
       const cache1 = operation.inMemoryCache
 
       const valuePre = cache1.getFromGroup(user1.userId, user1.companyId)
@@ -784,7 +784,7 @@ describe('GroupLoader Main', () => {
         dataSources: [new DummyGroupedDataSourceWithParams(userValues)],
         cacheKeyFromValueResolver: idResolver,
       })
-      // @ts-ignore
+      // @ts-expect-error
       const cache1 = operation.inMemoryCache
 
       const valuePre = await cache1.getFromGroup(user1.userId, user1.companyId)

--- a/test/Loader-async-refresh.spec.ts
+++ b/test/Loader-async-refresh.spec.ts
@@ -32,12 +32,12 @@ describe('Loader Async', () => {
         asyncCache,
         dataSources: [loader],
       })
-      // @ts-ignore
+      // @ts-expect-error
       expect(await operation.asyncCache.get('key')).toBeUndefined()
       expect(loader.counter).toBe(0)
       expect(await operation.get('key')).toBe('value')
       expect(loader.counter).toBe(1)
-      // @ts-ignore
+      // @ts-expect-error
       const expirationTimePre = await operation.asyncCache.getExpirationTime('key')
 
       await setTimeout(100)
@@ -49,7 +49,7 @@ describe('Loader Async', () => {
         await setTimeout(10)
       }
       expect(loader.counter).toBe(2)
-      // @ts-ignore
+      // @ts-expect-error
       const expirationTimePost = await operation.asyncCache.getExpirationTime('key')
 
       expect(await operation.get('key')).toBe('value')
@@ -74,7 +74,7 @@ describe('Loader Async', () => {
         dataSources: [loader],
       })
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(await operation.asyncCache.get('key')).toBeUndefined()
       expect(loader.counter).toBe(0)
       const promise0 = operation.get('key')
@@ -82,7 +82,7 @@ describe('Loader Async', () => {
       await loader.finishLoading()
       expect(await promise0).toBe('value')
       expect(loader.counter).toBe(1)
-      // @ts-ignore
+      // @ts-expect-error
       const expirationTimePre = await operation.asyncCache.getExpirationTime('key')
 
       expect(await operation.get('key')).toBe('value')
@@ -98,7 +98,7 @@ describe('Loader Async', () => {
 
       expect(loader.counter).toBe(2)
       await setTimeout(5)
-      // @ts-ignore
+      // @ts-expect-error
       const expirationTimePost = await operation.asyncCache.getExpirationTime('key')
 
       expect(await operation.get('key')).toBe('value')
@@ -148,7 +148,7 @@ describe('Loader Async', () => {
       expect(loader.counter).toBe(2)
 
       // Sanity check: Redis is now fresh
-      // @ts-ignore
+      // @ts-expect-error
       expect(await operation.asyncCache.get('key')).toBe('v2')
 
       // The next read should observe the fresh value that the background refresh fetched.
@@ -167,7 +167,7 @@ describe('Loader Async', () => {
         dataSources: [loader],
         throwIfUnresolved: true,
       })
-      // @ts-ignore
+      // @ts-expect-error
       expect(await operation.asyncCache.get('key')).toBeUndefined()
       expect(loader.counter).toBe(0)
       expect(await operation.get('key')).toBe('value')

--- a/test/Loader-main.spec.ts
+++ b/test/Loader-main.spec.ts
@@ -11,11 +11,11 @@ import { CountingTimedCache } from './fakes/CountingTimedCache'
 import { DummyCache } from './fakes/DummyCache'
 import { DummyDataSource } from './fakes/DummyDataSource'
 import {
+  DummyDataSourceWithParams,
   type DummyLoaderManyParams,
   type DummyLoaderParams,
   DummyParamKeyResolver,
 } from './fakes/DummyDataSourceWithParams'
-import { DummyDataSourceWithParams } from './fakes/DummyDataSourceWithParams'
 import { DummyNotificationConsumer } from './fakes/DummyNotificationConsumer'
 import { DummyNotificationConsumerMultiplexer } from './fakes/DummyNotificationConsumerMultiplexer'
 import { DummyNotificationPublisher } from './fakes/DummyNotificationPublisher'
@@ -293,7 +293,7 @@ describe('Loader Main', () => {
       expect(loader.counter).toBe(0)
       expect(await operation.get('key')).toBe('value')
       expect(loader.counter).toBe(1)
-      // @ts-ignore
+      // @ts-expect-error
       const expirationTimePre = operation.inMemoryCache.getExpirationTime('key')
 
       await setTimeout(100)
@@ -309,7 +309,7 @@ describe('Loader Main', () => {
       await Promise.resolve()
       await Promise.resolve()
       await Promise.resolve()
-      // @ts-ignore
+      // @ts-expect-error
       const expirationTimePost = operation.inMemoryCache.getExpirationTime('key')
 
       expect(operation.getInMemoryOnly('key')).toBe('value')
@@ -513,7 +513,7 @@ describe('Loader Main', () => {
 
     it('returns value when resolved via single loader', async () => {
       const operation = new Loader<string>({ inMemoryCache: IN_MEMORY_CACHE_CONFIG })
-      // @ts-ignore
+      // @ts-expect-error
       operation.inMemoryCache.set('key', 'value')
 
       const result = await operation.get('key')
@@ -572,7 +572,7 @@ describe('Loader Main', () => {
         asyncCache: cache2,
         dataSources: [new DummyDataSource(undefined), new DummyDataSource('value')],
       })
-      // @ts-ignore
+      // @ts-expect-error
       const cache1 = operation.inMemoryCache
 
       const valuePre = await cache1.get('key')
@@ -593,7 +593,7 @@ describe('Loader Main', () => {
         dataSources: [new DummyDataSourceWithParams('value')],
         cacheKeyFromLoadParamsResolver: DummyParamKeyResolver,
       })
-      // @ts-ignore
+      // @ts-expect-error
       const cache1 = operation.inMemoryCache
 
       const valuePre = await cache1.get('key')
@@ -614,7 +614,7 @@ describe('Loader Main', () => {
         dataSources: [new DummyDataSourceWithParams('value')],
         cacheKeyFromLoadParamsResolver: DEFAULT_FROM_ID_RESOLVER,
       })
-      // @ts-ignore
+      // @ts-expect-error
       const cache1 = operation.inMemoryCache
 
       const valuePre = await cache1.get('key')
@@ -822,7 +822,7 @@ describe('Loader Main', () => {
         inMemoryCache: IN_MEMORY_CACHE_CONFIG,
         cacheKeyFromValueResolver: idResolver,
       })
-      // @ts-ignore
+      // @ts-expect-error
       operation.inMemoryCache.set('key', 'value')
 
       const result = await operation.getMany(['key'])
@@ -894,7 +894,7 @@ describe('Loader Main', () => {
         ],
         cacheKeyFromValueResolver: idResolver,
       })
-      // @ts-ignore
+      // @ts-expect-error
       const inMemoryCache = operation.inMemoryCache
 
       const valuePre = inMemoryCache.getMany(['key'])
@@ -924,7 +924,7 @@ describe('Loader Main', () => {
         dataSources: [new DummyDataSourceWithParams('value')],
         cacheKeyFromValueResolver: idResolver,
       })
-      // @ts-ignore
+      // @ts-expect-error
       const cache1 = operation.inMemoryCache
 
       const valuePre = cache1.getMany(['key'])

--- a/test/ManualCache.spec.ts
+++ b/test/ManualCache.spec.ts
@@ -94,7 +94,7 @@ describe('ManualCache', () => {
       const operation = new ManualCache<string>({
         inMemoryCache: IN_MEMORY_CACHE_CONFIG,
       })
-      // @ts-ignore
+      // @ts-expect-error
       const cache = operation.inMemoryCache
       await cache.set('key', 'value')
 
@@ -124,7 +124,7 @@ describe('ManualCache', () => {
         inMemoryCache: IN_MEMORY_CACHE_CONFIG,
         asyncCache: cache2,
       })
-      // @ts-ignore
+      // @ts-expect-error
       const cache1 = operation.inMemoryCache
 
       const valuePre = await cache1.get('key')

--- a/test/ManualGroupCache.spec.ts
+++ b/test/ManualGroupCache.spec.ts
@@ -203,7 +203,7 @@ describe('ManualGroupCache', () => {
         inMemoryCache: IN_MEMORY_CACHE_CONFIG,
         asyncCache: cache2,
       })
-      // @ts-ignore
+      // @ts-expect-error
       const cache1 = operation.inMemoryCache
 
       const valuePre = await cache1.getFromGroup(user1.userId, user1.companyId)

--- a/test/fakes/CountingCache.ts
+++ b/test/fakes/CountingCache.ts
@@ -7,7 +7,7 @@ export class CountingCache implements Cache<string> {
   public counter = 0
   name = 'Counting cache'
   readonly ttlLeftBeforeRefreshInMsecs = 999999
-  // @ts-ignore
+  // @ts-expect-error
   readonly expirationTimeLoadingOperation = null
 
   constructor(returnedValue: string | undefined) {

--- a/test/fakes/CountingTimedCache.ts
+++ b/test/fakes/CountingTimedCache.ts
@@ -7,7 +7,7 @@ export class CountingTimedCache implements Cache<string> {
   public counter = 0
   name = 'Counting cache'
   readonly ttlLeftBeforeRefreshInMsecs = 0
-  // @ts-ignore
+  // @ts-expect-error
   readonly expirationTimeLoadingOperation: any = null
   public readonly cache: FifoMap<string | null>
 

--- a/test/fakes/DummyGroupNotificationConsumerMultiplexer.ts
+++ b/test/fakes/DummyGroupNotificationConsumerMultiplexer.ts
@@ -18,7 +18,7 @@ export class DummyGroupNotificationConsumerMultiplexer extends AbstractNotificat
 
   setTargetCache(targetCache: InMemoryGroupCache<User>) {
     for (var consumer of this.notificationConsumers) {
-      // @ts-ignore
+      // @ts-expect-error
       if (!consumer.targetCache) {
         consumer.setTargetCache(targetCache)
       }

--- a/test/fakes/DummyNotificationConsumerMultiplexer.ts
+++ b/test/fakes/DummyNotificationConsumerMultiplexer.ts
@@ -14,7 +14,7 @@ export class DummyNotificationConsumerMultiplexer extends AbstractNotificationCo
 
   setTargetCache(targetCache: SynchronousCache<string>) {
     for (var consumer of this.notificationConsumers) {
-      // @ts-ignore
+      // @ts-expect-error
       if (!consumer.targetCache) {
         consumer.setTargetCache(targetCache)
       }

--- a/test/fakes/DummyRecordCache.ts
+++ b/test/fakes/DummyRecordCache.ts
@@ -25,7 +25,7 @@ export class DummyRecordCache implements Cache<string> {
       .map((entry) => entry[1])
 
     const unresolvedKeys = keys.filter((key) => {
-      return !Object.prototype.hasOwnProperty.call(this.values, key)
+      return !Object.hasOwn(this.values, key)
     })
 
     return Promise.resolve({

--- a/test/fakes/FakeThrowingRedis.ts
+++ b/test/fakes/FakeThrowingRedis.ts
@@ -38,7 +38,6 @@ export class FakeThrowingRedis extends Redis {
     return createLongDelayPromise()
   }
 
-  // biome-ignore lint/suspicious/useAwait : It is important this throws within a promise
   async publish(): Promise<number> {
     throw new Error('Operation has failed')
   }

--- a/test/redis/RedisNotificationPublisher.spec.ts
+++ b/test/redis/RedisNotificationPublisher.spec.ts
@@ -1,13 +1,12 @@
 import { setTimeout } from 'node:timers/promises'
 import Redis from 'ioredis'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { Loader } from '../../lib/Loader'
 import type { InMemoryCacheConfiguration } from '../../lib/memory/InMemoryCache'
-import { redisOptions } from '../fakes/TestRedisConfig'
-
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { createNotificationPair } from '../../lib/redis/RedisNotificationFactory'
 import { DummyCache } from '../fakes/DummyCache'
 import { FakeThrowingRedis } from '../fakes/FakeThrowingRedis'
+import { redisOptions } from '../fakes/TestRedisConfig'
 import { waitAndRetry } from '../utils/waitUtils'
 
 const IN_MEMORY_CACHE_CONFIG = { ttlInMsecs: 99999 } satisfies InMemoryCacheConfiguration

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,8 @@
     "baseUrl": ".",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": false,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "ignoreDeprecations": "6.0"
   },
   "exclude": ["node_modules", "dist", "test", "packages",
     "vitest.config.mts"


### PR DESCRIPTION
## Summary
- Bump all dependencies to their latest versions across root and `packages/sqs`
- Add `26.x` to the CI build matrix
- Migrate config and apply auto-fixes required by major version bumps

## Notable major bumps
- `@biomejs/biome` 1.9.4 → 2.4.15 — ran `biome migrate` to update config; added an override to disable `useAwait` for `test/**` (async test callbacks without await are an established idiom)
- `typescript` 5.9 → 6.0 — added `ignoreDeprecations: "6.0"` to `tsconfig.json` to silence warnings on `moduleResolution: node`, `baseUrl`, and `esModuleInterop: false`, which are deprecated and slated for removal in TS 7
- `@types/node` 22 → 25
- `pnpm` 10.33.0 → 11.1.2 (via `packageManager` field)
- AWS SDK clients and `@message-queue-toolkit/core` bumped in `packages/sqs`

## Other changes
- Biome 2 auto-fixes applied: `@ts-ignore` → `@ts-expect-error`, import ordering, JSON formatting in `package.json`, `Object.hasOwn` over `Object.prototype.hasOwnProperty.call`
- Removed one now-unnecessary `biome-ignore` comment

## Test plan
- [x] `pnpm install` succeeds on pnpm 11
- [x] `pnpm -r run build` passes under TypeScript 6
- [x] `pnpm -r run lint` (biome 2 + tsc --noEmit) passes
- [ ] Redis-backed test suite (`pnpm test:coverage`) — relies on Docker, will be exercised in CI
- [ ] Node 26 job in the new CI matrix passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI/CD to test against additional Node.js version
  * Upgraded development dependencies and package manager to latest versions
  * Refined linter and TypeScript configuration for improved code quality

* **Tests**
  * Enhanced TypeScript error-handling precision in test suite

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kibertoad/layered-loader/pull/396?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->