### PR TITLE
test(sqs): cover single binding over a union event schema

### DIFF
--- a/packages/sqs/README.md
+++ b/packages/sqs/README.md
@@ -468,6 +468,45 @@ Rules:
 - If a source has only one binding, `messageType` and `messageTypeField` are optional — the binding handles every message.
 - If a source has two or more bindings, the source must specify `messageTypeField` and every binding must specify `messageType`. `messageTypeField` is a dotted path (e.g. `'metadata.eventId'`).
 
+#### One binding over a union of event types
+
+When several event types should all flow through a **single** resolver, you do not need one binding per type. Bind a single `z.union(...)` (or `z.discriminatedUnion(...)`) schema instead and branch inside the resolver. This is the natural shape when you already have message-queue-toolkit message definitions and want to react to a couple of their `consumerSchema`s:
+
+```ts
+const PROJECT_LANGUAGE_EVENT_SCHEMA = z.union([
+  ExpertProjectLanguageEvent['project_language.added'].consumerSchema,
+  ExpertProjectLanguageEvent['project_language.removed'].consumerSchema,
+])
+
+const trigger = new SnsTopicInvalidationTrigger({
+  target: projectLoader,
+  dependencies: consumerDeps,
+  sources: [
+    {
+      creationConfig: {
+        topic: { Name: 'domain-events.project-languages' },
+        queue: { QueueName: `project-language-trigger-${process.env.HOSTNAME}` },
+      },
+      // No messageTypeField: this is still a single binding.
+      bindings: [
+        {
+          messageSchema: PROJECT_LANGUAGE_EVENT_SCHEMA,
+          resolver: (msg) => ({ kind: 'delete', key: msg.projectId }),
+        },
+      ],
+    },
+  ],
+})
+```
+
+How routing behaves with this shape:
+
+- **Every member of the union is routed.** Because there is one binding, every message is validated against the union schema and, on success, handed to the resolver — regardless of which union member it matched.
+- **Event types outside the union are dropped.** A message that matches *neither* union member fails schema validation and is rejected **before** the resolver runs (it goes back to the queue / DLQ as a validation error — see [Error handling and retries](#error-handling-and-retries)). It never reaches your resolver and never invalidates anything.
+- **Do not set `messageTypeField` for the union shape.** `messageTypeField` switches the source into the multi-binding routing mode above, where the extracted type must match a binding's `messageType`. With a single union binding there is no per-member `messageType` to match, so setting it would cause every message to be treated as an unknown type and dropped. Leave it unset so all messages route to the one binding and the union schema does the filtering.
+
+Reach for the multi-binding `messageTypeField` form when each event type needs a **different** resolver; reach for the single union binding when one resolver handles them all and you simply want everything outside the union ignored.
+
 ### Mixing source kinds with `composeTriggers`
 
 A single trigger class is homogeneous (only SNS topics, or only SQS queues). When a deployment needs both, build one of each and wrap them:

--- a/packages/sqs/test/SqsInvalidationTrigger.spec.ts
+++ b/packages/sqs/test/SqsInvalidationTrigger.spec.ts
@@ -513,6 +513,132 @@ describe('SnsTopicInvalidationTrigger', () => {
       await Promise.allSettled([trigger.stop(), peer.consumer.close(), peer.publisher.close()])
     }
   })
+
+  it('routes every member of a single union-schema binding and drops events outside it', async () => {
+    const suffix = Math.random().toString(36).slice(2, 8)
+    const invalidationTopic = `union-sns-${suffix}`
+
+    const peer = createNotificationPair<string>({
+      publisher: {
+        dependencies: buildPublisherDeps(clients),
+        creationConfig: { topic: { Name: invalidationTopic } },
+      },
+      consumer: {
+        dependencies: buildConsumerDeps(clients),
+        creationConfig: {
+          topic: { Name: invalidationTopic },
+          queue: { QueueName: `union-sns-peer-q-${suffix}` },
+        },
+      },
+    })
+
+    const loader = new Loader<string>({
+      inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+      asyncCache: new StubAsyncCache('value'),
+      notificationConsumer: peer.consumer,
+      notificationPublisher: peer.publisher,
+    })
+
+    const upstreamTopicName = `union-sns-domain-${suffix}`
+    const upstreamTopicArn = (
+      await clients.snsClient.send(new CreateTopicCommand({ Name: upstreamTopicName }))
+    ).TopicArn!
+
+    // A single binding whose schema is a z.union of two event types — the
+    // flexible-trigger analogue of binding one consumer to a union of two
+    // message-queue-toolkit consumerSchemas. Because there is exactly one
+    // binding and no messageTypeField, every message routes to this handler and
+    // is validated against the union; events matching neither member are
+    // rejected before the resolver runs.
+    const LANGUAGE_ADDED = z.object({
+      type: z.literal('project_language.added'),
+      key: z.string(),
+    })
+    const LANGUAGE_REMOVED = z.object({
+      type: z.literal('project_language.removed'),
+      key: z.string(),
+    })
+    const PROJECT_LANGUAGE_EVENT_SCHEMA = z.union([LANGUAGE_ADDED, LANGUAGE_REMOVED])
+
+    let addedCalls = 0
+    let removedCalls = 0
+
+    const trigger = new SnsTopicInvalidationTrigger({
+      target: loader,
+      dependencies: buildConsumerDeps(clients),
+      sources: [
+        {
+          creationConfig: {
+            topic: { Name: upstreamTopicName },
+            queue: { QueueName: `union-sns-trigger-q-${suffix}` },
+          },
+          bindings: [
+            {
+              messageSchema: PROJECT_LANGUAGE_EVENT_SCHEMA,
+              resolver: (msg: z.infer<typeof PROJECT_LANGUAGE_EVENT_SCHEMA>) => {
+                if (msg.type === 'project_language.added') {
+                  addedCalls += 1
+                  return { kind: 'delete', key: msg.key }
+                }
+                if (msg.type === 'project_language.removed') {
+                  removedCalls += 1
+                  return { kind: 'delete', key: msg.key }
+                }
+                return null
+              },
+            },
+          ],
+        },
+      ],
+    })
+
+    try {
+      await loader.init()
+      await trigger.start()
+
+      await loader.getAsyncOnly('lang-a')
+      await loader.getAsyncOnly('lang-b')
+      await loader.getAsyncOnly('lang-c')
+
+      // Both union members get routed...
+      await clients.snsClient.send(
+        new PublishCommand({
+          TopicArn: upstreamTopicArn,
+          Message: JSON.stringify({ type: 'project_language.added', key: 'lang-a' }),
+        }),
+      )
+      await clients.snsClient.send(
+        new PublishCommand({
+          TopicArn: upstreamTopicArn,
+          Message: JSON.stringify({ type: 'project_language.removed', key: 'lang-b' }),
+        }),
+      )
+      // ...while an event type that is NOT part of the union is dropped: it
+      // fails union validation and never reaches the resolver.
+      await clients.snsClient.send(
+        new PublishCommand({
+          TopicArn: upstreamTopicArn,
+          Message: JSON.stringify({ type: 'project_language.renamed', key: 'lang-c' }),
+        }),
+      )
+
+      await waitFor(
+        () =>
+          loader.getInMemoryOnly('lang-a') === undefined &&
+          loader.getInMemoryOnly('lang-b') === undefined,
+      )
+      // Give the excluded event the same window the routed ones had, then assert
+      // it was never processed: resolver counts stay at one apiece and its entry
+      // is untouched.
+      await new Promise((r) => setTimeout(r, 200))
+
+      expect(addedCalls).toBe(1)
+      expect(removedCalls).toBe(1)
+      expect(loader.getInMemoryOnly('lang-c')).toBe('value')
+    } finally {
+      await Promise.allSettled([trigger.stop(), peer.consumer.close(), peer.publisher.close()])
+    }
+  })
 })
 
 describe('SqsQueueInvalidationTrigger', () => {

--- a/packages/sqs/test/SqsInvalidationTrigger.spec.ts
+++ b/packages/sqs/test/SqsInvalidationTrigger.spec.ts
@@ -516,27 +516,10 @@ describe('SnsTopicInvalidationTrigger', () => {
 
   it('routes every member of a single union-schema binding and drops events outside it', async () => {
     const suffix = Math.random().toString(36).slice(2, 8)
-    const invalidationTopic = `union-sns-${suffix}`
-
-    const peer = createNotificationPair<string>({
-      publisher: {
-        dependencies: buildPublisherDeps(clients),
-        creationConfig: { topic: { Name: invalidationTopic } },
-      },
-      consumer: {
-        dependencies: buildConsumerDeps(clients),
-        creationConfig: {
-          topic: { Name: invalidationTopic },
-          queue: { QueueName: `union-sns-peer-q-${suffix}` },
-        },
-      },
-    })
 
     const loader = new Loader<string>({
       inMemoryCache: IN_MEMORY_CACHE_CONFIG,
       asyncCache: new StubAsyncCache('value'),
-      notificationConsumer: peer.consumer,
-      notificationPublisher: peer.publisher,
     })
 
     const upstreamTopicName = `union-sns-domain-${suffix}`
@@ -562,6 +545,13 @@ describe('SnsTopicInvalidationTrigger', () => {
 
     let addedCalls = 0
     let removedCalls = 0
+    // Anything reaching the resolver that is neither union member would land
+    // here. Union validation should reject such events before the resolver
+    // runs, so this must stay at 0 — it is the assertion that actually proves
+    // the "drops events outside the union" behavior, rather than relying on the
+    // absence of an invalidation (which a null-returning resolver would also
+    // produce).
+    let otherCalls = 0
 
     const trigger = new SnsTopicInvalidationTrigger({
       target: loader,
@@ -584,6 +574,7 @@ describe('SnsTopicInvalidationTrigger', () => {
                   removedCalls += 1
                   return { kind: 'delete', key: msg.key }
                 }
+                otherCalls += 1
                 return null
               },
             },
@@ -600,6 +591,17 @@ describe('SnsTopicInvalidationTrigger', () => {
       await loader.getAsyncOnly('lang-b')
       await loader.getAsyncOnly('lang-c')
 
+      // Publish the excluded event FIRST so the two union members that follow
+      // act as a drain marker: once they have been processed, the renamed event
+      // ahead of them in the queue has had at least as long to be pulled and
+      // (correctly) rejected. An event type that is NOT part of the union should
+      // fail union validation and never reach the resolver.
+      await clients.snsClient.send(
+        new PublishCommand({
+          TopicArn: upstreamTopicArn,
+          Message: JSON.stringify({ type: 'project_language.renamed', key: 'lang-c' }),
+        }),
+      )
       // Both union members get routed...
       await clients.snsClient.send(
         new PublishCommand({
@@ -613,30 +615,27 @@ describe('SnsTopicInvalidationTrigger', () => {
           Message: JSON.stringify({ type: 'project_language.removed', key: 'lang-b' }),
         }),
       )
-      // ...while an event type that is NOT part of the union is dropped: it
-      // fails union validation and never reaches the resolver.
-      await clients.snsClient.send(
-        new PublishCommand({
-          TopicArn: upstreamTopicArn,
-          Message: JSON.stringify({ type: 'project_language.renamed', key: 'lang-c' }),
-        }),
-      )
 
       await waitFor(
         () =>
           loader.getInMemoryOnly('lang-a') === undefined &&
           loader.getInMemoryOnly('lang-b') === undefined,
       )
-      // Give the excluded event the same window the routed ones had, then assert
-      // it was never processed: resolver counts stay at one apiece and its entry
-      // is untouched.
+      // Small extra margin on top of the drain marker, then assert the excluded
+      // event never reached the resolver and never invalidated its entry. Note
+      // SNS->SQS ordering is best-effort, so the drain marker plus margin is a
+      // strong-but-not-absolute guarantee that the renamed event was dequeued.
       await new Promise((r) => setTimeout(r, 200))
 
-      expect(addedCalls).toBe(1)
-      expect(removedCalls).toBe(1)
+      // >= 1 rather than === 1: SQS is at-least-once, so a redelivery could
+      // legitimately bump a union member's count. The drop assertion below
+      // stays strict — a redelivered valid event never increments otherCalls.
+      expect(addedCalls).toBeGreaterThanOrEqual(1)
+      expect(removedCalls).toBeGreaterThanOrEqual(1)
+      expect(otherCalls).toBe(0)
       expect(loader.getInMemoryOnly('lang-c')).toBe('value')
     } finally {
-      await Promise.allSettled([trigger.stop(), peer.consumer.close(), peer.publisher.close()])
+      await trigger.stop()
     }
   })
 })


### PR DESCRIPTION
## What

Adds an integration test and documentation for the flexible-invalidation-trigger shape where a **single** binding's `messageSchema` is a `z.union` of several event types and one resolver handles them all — e.g.

```ts
const PROJECT_LANGUAGE_EVENT_SCHEMA = z.union([
  ExpertProjectLanguageEvent['project_language.added'].consumerSchema,
  ExpertProjectLanguageEvent['project_language.removed'].consumerSchema,
])
```

## Why

We already tested the *multi-binding* routing shape (separate schemas + `messageTypeField` discriminator), but had no coverage for binding a single union schema. This is a common shape when reacting to a couple of existing message-queue-toolkit `consumerSchema`s through one resolver, and its routing semantics weren't documented.

## Behaviour verified

With one binding and **no `messageTypeField`**, the consumer's message-type resolver is a `{ literal }` constant, so every message routes to the single handler and is validated against the union schema:

- **Every member of the union is routed** to the resolver.
- **Event types outside the union are dropped** — they fail union validation *before* the resolver runs, so nothing is invalidated.
- `messageTypeField` must stay **unset** for this shape (setting it switches to multi-binding mode, where the extracted type must match a per-binding `messageType` the union binding doesn't have).

## Changes

- **`packages/sqs/test/SqsInvalidationTrigger.spec.ts`** — new test `routes every member of a single union-schema binding and drops events outside it`. Sends both union members (asserts each is routed and its cache entry invalidated, resolver hit once each) plus an excluded event type (asserts the resolver never runs and its entry stays intact).
- **`packages/sqs/README.md`** — new subsection "One binding over a union of event types" documenting the pattern and the routing rules above.

## Test

```
✓ SnsTopicInvalidationTrigger > routes every member of a single union-schema binding and drops events outside it
```

`tsc --noEmit` is clean. The logged `MessageValidationError` during the run is the excluded event being rejected pre-resolver — exactly the behaviour under test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for routing multiple upstream event types through a single binding using union message schemas, including routing behavior, validation rejection of non-matching messages, and when to use single- vs multi-binding routing.

* **Tests**
  * Added tests validating union-schema event routing, ensuring matching events trigger handlers (with at-least-once semantics) and non-matching messages are rejected without affecting unrelated cache entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->