### PR TITLE
feat(sqs): triggers own subscription config so spread needs no workarounds

### DIFF
--- a/packages/sqs/README.md
+++ b/packages/sqs/README.md
@@ -610,7 +610,13 @@ A trigger source **is** the underlying `message-queue-toolkit` consumer options 
 - **Explicit** — spell options out inline (`creationConfig`/`locatorConfig`, `deadLetterQueue`, `subscriptionConfig`, `concurrentConsumersAmount`, `consumerOverrides`, ...). An unknown key or a wrong-typed value is a compile error.
 - **Spread** — resolve options elsewhere — e.g. with `@lokalise/aws-config`'s `getSnsMqtOptionsResolver()` — and spread the result straight in.
 
-The trigger always overrides `handlers` with the ones it builds from `bindings`; everything else flows through untouched.
+A trigger is not a plain consumer — it owns its handlers, its subscription filtering, and its lifecycle — so a few fields are claimed by the trigger and the rest flow through untouched. You can spread a resolved options object straight in without un-setting anything:
+
+- **`handlers`** — always rebuilt from `bindings`.
+- **subscription filter policy** (`subscriptionConfig.Attributes`) — `resolveConsumerOptions` derives a `FilterPolicy` from the consumer's handlers. The trigger has its own handlers (from `bindings`), so the resolver's policy — built from an empty handler list — would reject every message. The trigger drops it and defaults the subscription to accept-all. Other `subscriptionConfig` settings you pass are preserved.
+- **`subscriptionDeadLetterQueue`** — the trigger handles failures through the queue-level `deadLetterQueue`; a subscription-level redrive policy is dropped.
+
+Everything else (`creationConfig`/`locatorConfig`, `deadLetterQueue`, `concurrentConsumersAmount`, `consumerOverrides`, ...) flows through as-is.
 
 ```ts
 const resolver = getSnsMqtOptionsResolver({ appEnv: 'production' })

--- a/packages/sqs/README.md
+++ b/packages/sqs/README.md
@@ -610,13 +610,12 @@ A trigger source **is** the underlying `message-queue-toolkit` consumer options 
 - **Explicit** — spell options out inline (`creationConfig`/`locatorConfig`, `deadLetterQueue`, `subscriptionConfig`, `concurrentConsumersAmount`, `consumerOverrides`, ...). An unknown key or a wrong-typed value is a compile error.
 - **Spread** — resolve options elsewhere — e.g. with `@lokalise/aws-config`'s `getSnsMqtOptionsResolver()` — and spread the result straight in.
 
-A trigger is not a plain consumer — it owns its handlers, its subscription filtering, and its lifecycle — so a few fields are claimed by the trigger and the rest flow through untouched. You can spread a resolved options object straight in without un-setting anything:
+A trigger is not a plain consumer — it owns its handlers and its subscription *filtering* — so just those two things are claimed by the trigger and everything else flows through untouched. You can spread a resolved options object straight in without un-setting anything:
 
 - **`handlers`** — always rebuilt from `bindings`.
-- **subscription filter policy** (`subscriptionConfig.Attributes`) — `resolveConsumerOptions` derives a `FilterPolicy` from the consumer's handlers. The trigger has its own handlers (from `bindings`), so the resolver's policy — built from an empty handler list — would reject every message. The trigger drops it and defaults the subscription to accept-all. Other `subscriptionConfig` settings you pass are preserved.
-- **`subscriptionDeadLetterQueue`** — the trigger handles failures through the queue-level `deadLetterQueue`; a subscription-level redrive policy is dropped.
+- **subscription filter policy** (`subscriptionConfig.Attributes.FilterPolicy` / `FilterPolicyScope`) — `resolveConsumerOptions` derives a `FilterPolicy` from the consumer's handlers. The trigger has its own handlers (from `bindings`), so the resolver's policy — built from an empty handler list — would reject every message. The trigger drops just those keys and defaults the subscription to accept-all.
 
-Everything else (`creationConfig`/`locatorConfig`, `deadLetterQueue`, `concurrentConsumersAmount`, `consumerOverrides`, ...) flows through as-is.
+Everything else flows through as-is, including `creationConfig`/`locatorConfig`, `deadLetterQueue`, `concurrentConsumersAmount`, `consumerOverrides`, and the **subscription-level dead-letter queue** — both `subscriptionConfig.Attributes.RedrivePolicy` and a spread-in `subscriptionDeadLetterQueue` are preserved.
 
 ```ts
 const resolver = getSnsMqtOptionsResolver({ appEnv: 'production' })

--- a/packages/sqs/index.ts
+++ b/packages/sqs/index.ts
@@ -86,6 +86,7 @@ export {
   type SqsQueueSourceConfig,
 } from './lib/triggers/SqsQueueInvalidationTrigger.js'
 export {
+  buildSnsTriggerConsumerOptions,
   deriveSnsTopicChannelName,
   SnsTopicInvalidationTrigger,
   type SnsTopicInvalidationSource,

--- a/packages/sqs/lib/triggers/AbstractSqsTrigger.ts
+++ b/packages/sqs/lib/triggers/AbstractSqsTrigger.ts
@@ -80,7 +80,13 @@ export abstract class AbstractSqsTrigger implements InvalidationTrigger {
         const consumers = this.createConsumers()
         if (consumers.length === 0) return
         try {
-          await Promise.all(consumers.map((c) => c.init()))
+          // Only call start(): the underlying message-queue-toolkit consumer's
+          // start() already runs init() internally. Calling init() here as well
+          // would init() every consumer twice, and the second pass re-subscribes
+          // the queue to its topic — which conflicts with subscription attributes
+          // (filter policy, redrive policy) applied on the first pass. start()
+          // also provisions all resources, so nothing is lost by dropping the
+          // separate init() barrier.
           await Promise.all(consumers.map((c) => c.start()))
           this.internalConsumers = [...consumers]
         } catch (err) {

--- a/packages/sqs/lib/triggers/SnsTopicGroupInvalidationTrigger.ts
+++ b/packages/sqs/lib/triggers/SnsTopicGroupInvalidationTrigger.ts
@@ -1,18 +1,14 @@
-import type {
-  SNSSQSConsumerDependencies,
-  SNSSQSConsumerOptions,
-} from '@message-queue-toolkit/sns'
+import type { SNSSQSConsumerDependencies } from '@message-queue-toolkit/sns'
 import {
   AbstractSqsTrigger,
   type InternalConsumerHandle,
   SnsTopicTriggerConsumer,
 } from './AbstractSqsTrigger.js'
+import { buildGroupBindings, type GroupBinding } from './bindingHelpers.js'
 import {
-  type BindingHandlerContext,
-  buildGroupBindings,
-  type GroupBinding,
-} from './bindingHelpers.js'
-import type { SnsTopicSourceConfig } from './SnsTopicInvalidationTrigger.js'
+  buildSnsTriggerConsumerOptions,
+  type SnsTopicSourceConfig,
+} from './SnsTopicInvalidationTrigger.js'
 import type { GroupInvalidationTarget, TriggerErrorHandler } from './types.js'
 
 /**
@@ -64,7 +60,7 @@ export class SnsTopicGroupInvalidationTrigger extends AbstractSqsTrigger {
   private buildConsumer(source: SnsTopicGroupInvalidationSource): InternalConsumerHandle {
     const channel = this.channelOverride ?? deriveSnsTopicGroupChannelName(source)
     const { bindings, messageTypeField, ...consumerOptions } = source
-    const { handlers, context, messageTypeResolver } = buildGroupBindings(
+    const built = buildGroupBindings(
       bindings,
       messageTypeField,
       this.target,
@@ -72,30 +68,10 @@ export class SnsTopicGroupInvalidationTrigger extends AbstractSqsTrigger {
       this.errorHandler,
     )
 
-    // Forward every consumer option the caller supplied. This deliberately
-    // spreads the whole source (minus the trigger-only `bindings`/
-    // `messageTypeField`) so a pre-resolved options object — e.g. the output of
-    // `@lokalise/aws-config`'s `resolveConsumerOptions(...)` — can be spread
-    // straight into the source and have all of its fields (`creationConfig`/
-    // `locatorConfig`, `deadLetterQueue`, `concurrentConsumersAmount`,
-    // `consumerOverrides`, ...) flow through untouched. The trigger owns
-    // `handlers`, so the bindings-derived handlers always override any in the
-    // spread.
-    const options = {
-      ...consumerOptions,
-      handlers,
-      messageTypeResolver,
-      subscriptionConfig: source.subscriptionConfig ?? { updateAttributesIfExists: false },
-    }
-
     return new SnsTopicTriggerConsumer(
       this.dependencies,
-      options as SNSSQSConsumerOptions<
-        object,
-        BindingHandlerContext<GroupInvalidationTarget>,
-        undefined
-      >,
-      context,
+      buildSnsTriggerConsumerOptions(consumerOptions, built),
+      built.context,
     )
   }
 }

--- a/packages/sqs/lib/triggers/SnsTopicInvalidationTrigger.ts
+++ b/packages/sqs/lib/triggers/SnsTopicInvalidationTrigger.ts
@@ -10,6 +10,7 @@ import {
 import {
   type BindingHandlerContext,
   buildFlatBindings,
+  type BuiltBindings,
   type FlatBinding,
 } from './bindingHelpers.js'
 import type { InvalidationTarget, TriggerErrorHandler } from './types.js'
@@ -81,7 +82,7 @@ export class SnsTopicInvalidationTrigger extends AbstractSqsTrigger {
   private buildConsumer(source: SnsTopicInvalidationSource): InternalConsumerHandle {
     const channel = this.channelOverride ?? deriveSnsTopicChannelName(source)
     const { bindings, messageTypeField, ...consumerOptions } = source
-    const { handlers, context, messageTypeResolver } = buildFlatBindings(
+    const built = buildFlatBindings(
       bindings,
       messageTypeField,
       this.target,
@@ -89,32 +90,54 @@ export class SnsTopicInvalidationTrigger extends AbstractSqsTrigger {
       this.errorHandler,
     )
 
-    // Forward every consumer option the caller supplied. This deliberately
-    // spreads the whole source (minus the trigger-only `bindings`/
-    // `messageTypeField`) so a pre-resolved options object — e.g. the output of
-    // `@lokalise/aws-config`'s `resolveConsumerOptions(...)` — can be spread
-    // straight into the source and have all of its fields (`creationConfig`/
-    // `locatorConfig`, `deadLetterQueue`, `concurrentConsumersAmount`,
-    // `consumerOverrides`, ...) flow through untouched. The trigger owns
-    // `handlers`, so the bindings-derived handlers always override any in the
-    // spread.
-    const options = {
-      ...consumerOptions,
-      handlers,
-      messageTypeResolver,
-      subscriptionConfig: source.subscriptionConfig ?? { updateAttributesIfExists: false },
-    }
-
     return new SnsTopicTriggerConsumer(
       this.dependencies,
-      options as SNSSQSConsumerOptions<
-        object,
-        BindingHandlerContext<InvalidationTarget>,
-        undefined
-      >,
-      context,
+      buildSnsTriggerConsumerOptions(consumerOptions, built),
+      built.context,
     )
   }
+}
+
+/**
+ * Build the underlying SNS→SQS consumer options for a trigger source.
+ *
+ * A trigger is not a full consumer: it owns its handlers, its subscription
+ * filtering, and its lifecycle. So while the source still supports spreading in
+ * a pre-resolved options object — e.g. `@lokalise/aws-config`'s
+ * `resolveConsumerOptions(...)` — for `creationConfig`/`locatorConfig`,
+ * `deadLetterQueue`, `concurrentConsumersAmount`, `consumerOverrides`, etc., the
+ * fields the trigger owns are stripped here rather than left for the caller to
+ * un-set at every call site:
+ *
+ * - **`handlers`** — always rebuilt from `bindings` (the caller's destructure
+ *   already drops any spread-in handlers; we re-inject the binding-derived ones).
+ * - **subscription filter policy** (`subscriptionConfig.Attributes`) —
+ *   `resolveConsumerOptions` derives a `FilterPolicy` from the *consumer's*
+ *   handlers. The trigger supplies its own handlers from `bindings`, so the
+ *   policy the resolver built (from the empty handler list it was given) would
+ *   reject every message. We drop it and default the subscription to accept-all.
+ * - **`subscriptionDeadLetterQueue`** — the trigger handles failures through the
+ *   queue-level `deadLetterQueue`; a subscription-level redrive policy is
+ *   re-applied on every init and conflicts with that, so we drop it. (Not part of
+ *   the typed surface, but it can ride along on a spread-in resolved object.)
+ */
+export function buildSnsTriggerConsumerOptions<TTarget>(
+  consumerOptions: SnsTopicSourceConfig,
+  built: Pick<BuiltBindings<TTarget>, 'handlers' | 'messageTypeResolver'>,
+): SNSSQSConsumerOptions<object, BindingHandlerContext<TTarget>, undefined> {
+  const {
+    subscriptionConfig,
+    subscriptionDeadLetterQueue: _subscriptionDeadLetterQueue,
+    ...rest
+  } = consumerOptions as SnsTopicSourceConfig & { subscriptionDeadLetterQueue?: unknown }
+  const { Attributes: _filterPolicy, ...callerSubscriptionConfig } = subscriptionConfig ?? {}
+
+  return {
+    ...rest,
+    handlers: built.handlers,
+    messageTypeResolver: built.messageTypeResolver,
+    subscriptionConfig: { updateAttributesIfExists: false, ...callerSubscriptionConfig },
+  } as SNSSQSConsumerOptions<object, BindingHandlerContext<TTarget>, undefined>
 }
 
 /** Human-readable channel name derived from an SNS-topic source config. */

--- a/packages/sqs/lib/triggers/SnsTopicInvalidationTrigger.ts
+++ b/packages/sqs/lib/triggers/SnsTopicInvalidationTrigger.ts
@@ -101,43 +101,63 @@ export class SnsTopicInvalidationTrigger extends AbstractSqsTrigger {
 /**
  * Build the underlying SNS→SQS consumer options for a trigger source.
  *
- * A trigger is not a full consumer: it owns its handlers, its subscription
- * filtering, and its lifecycle. So while the source still supports spreading in
- * a pre-resolved options object — e.g. `@lokalise/aws-config`'s
- * `resolveConsumerOptions(...)` — for `creationConfig`/`locatorConfig`,
- * `deadLetterQueue`, `concurrentConsumersAmount`, `consumerOverrides`, etc., the
- * fields the trigger owns are stripped here rather than left for the caller to
+ * A trigger is not a full consumer: it owns its handlers and its subscription
+ * *filtering*. So while the source still supports spreading in a pre-resolved
+ * options object — e.g. `@lokalise/aws-config`'s `resolveConsumerOptions(...)` —
+ * for `creationConfig`/`locatorConfig`, `deadLetterQueue`,
+ * `concurrentConsumersAmount`, `consumerOverrides`, etc., the two things the
+ * trigger genuinely owns are reset here rather than left for the caller to
  * un-set at every call site:
  *
  * - **`handlers`** — always rebuilt from `bindings` (the caller's destructure
  *   already drops any spread-in handlers; we re-inject the binding-derived ones).
- * - **subscription filter policy** (`subscriptionConfig.Attributes`) —
- *   `resolveConsumerOptions` derives a `FilterPolicy` from the *consumer's*
- *   handlers. The trigger supplies its own handlers from `bindings`, so the
- *   policy the resolver built (from the empty handler list it was given) would
- *   reject every message. We drop it and default the subscription to accept-all.
- * - **`subscriptionDeadLetterQueue`** — the trigger handles failures through the
- *   queue-level `deadLetterQueue`; a subscription-level redrive policy is
- *   re-applied on every init and conflicts with that, so we drop it. (Not part of
- *   the typed surface, but it can ride along on a spread-in resolved object.)
+ * - **subscription filter policy** (`subscriptionConfig.Attributes.FilterPolicy`
+ *   / `FilterPolicyScope`) — `resolveConsumerOptions` derives a `FilterPolicy`
+ *   from the *consumer's* handlers. The trigger supplies its own handlers from
+ *   `bindings`, so the policy the resolver built (from the empty handler list it
+ *   was given) would reject every message. We drop just those keys and default
+ *   the subscription to accept-all.
+ *
+ * Everything else on `subscriptionConfig` is preserved — notably any
+ * `Attributes.RedrivePolicy` (the SNS subscription-level dead-letter queue) and
+ * a spread-in `subscriptionDeadLetterQueue` both flow through untouched.
  */
 export function buildSnsTriggerConsumerOptions<TTarget>(
   consumerOptions: SnsTopicSourceConfig,
   built: Pick<BuiltBindings<TTarget>, 'handlers' | 'messageTypeResolver'>,
 ): SNSSQSConsumerOptions<object, BindingHandlerContext<TTarget>, undefined> {
-  const {
-    subscriptionConfig,
-    subscriptionDeadLetterQueue: _subscriptionDeadLetterQueue,
-    ...rest
-  } = consumerOptions as SnsTopicSourceConfig & { subscriptionDeadLetterQueue?: unknown }
-  const { Attributes: _filterPolicy, ...callerSubscriptionConfig } = subscriptionConfig ?? {}
+  const { subscriptionConfig, ...rest } = consumerOptions
 
   return {
     ...rest,
     handlers: built.handlers,
     messageTypeResolver: built.messageTypeResolver,
-    subscriptionConfig: { updateAttributesIfExists: false, ...callerSubscriptionConfig },
+    subscriptionConfig: stripSubscriptionFilterPolicy(subscriptionConfig),
   } as SNSSQSConsumerOptions<object, BindingHandlerContext<TTarget>, undefined>
+}
+
+/**
+ * Strip only the handler-derived filter-policy keys from a subscription config,
+ * leaving every other attribute (e.g. `RedrivePolicy`, `RawMessageDelivery`)
+ * intact. Defaults `updateAttributesIfExists` to `false` when unset.
+ */
+function stripSubscriptionFilterPolicy(
+  subscriptionConfig: SnsTopicSourceConfig['subscriptionConfig'],
+): SnsTopicSourceConfig['subscriptionConfig'] {
+  const { Attributes, updateAttributesIfExists, ...rest } = subscriptionConfig ?? {}
+  const {
+    FilterPolicy: _filterPolicy,
+    FilterPolicyScope: _filterPolicyScope,
+    ...remainingAttributes
+  } = Attributes ?? {}
+
+  return {
+    updateAttributesIfExists: updateAttributesIfExists ?? false,
+    ...rest,
+    // Omit Attributes entirely when nothing but the filter policy was present,
+    // so the subscription stays accept-all instead of carrying an empty object.
+    ...(Object.keys(remainingAttributes).length > 0 ? { Attributes: remainingAttributes } : {}),
+  }
 }
 
 /** Human-readable channel name derived from an SNS-topic source config. */

--- a/packages/sqs/test/triggerInternals.spec.ts
+++ b/packages/sqs/test/triggerInternals.spec.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import {
+  AbstractSqsTrigger,
+  type InternalConsumerHandle,
+} from '../lib/triggers/AbstractSqsTrigger.js'
+import { buildFlatBindings } from '../lib/triggers/bindingHelpers.js'
+import { buildSnsTriggerConsumerOptions } from '../lib/triggers/SnsTopicInvalidationTrigger.js'
+
+const EVENT_SCHEMA = z.object({ id: z.string() })
+
+function buildBindings() {
+  return buildFlatBindings(
+    [{ messageSchema: EVENT_SCHEMA, resolver: () => null }],
+    undefined,
+    { invalidate: async () => {}, invalidateMany: async () => {} } as never,
+    'test-channel',
+    undefined,
+  )
+}
+
+describe('buildSnsTriggerConsumerOptions', () => {
+  it('injects the binding-derived handlers and message-type resolver', () => {
+    const built = buildBindings()
+    const options = buildSnsTriggerConsumerOptions(
+      { creationConfig: { topic: { Name: 't' }, queue: { QueueName: 'q' } } },
+      built,
+    )
+
+    expect(options.handlers).toBe(built.handlers)
+    expect(options.messageTypeResolver).toBe(built.messageTypeResolver)
+  })
+
+  it('drops the handler-derived subscription filter policy (Attributes)', () => {
+    const built = buildBindings()
+    const options = buildSnsTriggerConsumerOptions(
+      {
+        creationConfig: { topic: { Name: 't' }, queue: { QueueName: 'q' } },
+        subscriptionConfig: {
+          updateAttributesIfExists: true,
+          // A reject-all policy resolveConsumerOptions() derived from empty handlers.
+          Attributes: { FilterPolicy: JSON.stringify({ type: ['__never__'] }) },
+        },
+      },
+      built,
+    )
+
+    expect(options.subscriptionConfig?.Attributes).toBeUndefined()
+    // ...but the caller's other subscription settings are preserved.
+    expect(options.subscriptionConfig?.updateAttributesIfExists).toBe(true)
+  })
+
+  it('defaults updateAttributesIfExists to false when no subscriptionConfig is given', () => {
+    const options = buildSnsTriggerConsumerOptions(
+      { creationConfig: { topic: { Name: 't' }, queue: { QueueName: 'q' } } },
+      buildBindings(),
+    )
+
+    expect(options.subscriptionConfig?.updateAttributesIfExists).toBe(false)
+  })
+
+  it('strips a spread-in subscriptionDeadLetterQueue (trigger owns queue-level DLQ)', () => {
+    const options = buildSnsTriggerConsumerOptions(
+      {
+        creationConfig: { topic: { Name: 't' }, queue: { QueueName: 'q' } },
+        deadLetterQueue: {
+          redrivePolicy: { maxReceiveCount: 3 },
+          creationConfig: { queue: { QueueName: 'q-dlq' } },
+        },
+        // Not part of the typed surface, but rides along on a resolveConsumerOptions() spread.
+        subscriptionDeadLetterQueue: { reuseConsumerDeadLetterQueue: true },
+      } as Parameters<typeof buildSnsTriggerConsumerOptions>[0],
+      buildBindings(),
+    )
+
+    expect('subscriptionDeadLetterQueue' in options).toBe(false)
+    // The queue-level DLQ the trigger does own is forwarded untouched.
+    expect(options.deadLetterQueue).toEqual({
+      redrivePolicy: { maxReceiveCount: 3 },
+      creationConfig: { queue: { QueueName: 'q-dlq' } },
+    })
+  })
+
+  it('forwards unrelated consumer options untouched', () => {
+    const options = buildSnsTriggerConsumerOptions(
+      {
+        creationConfig: { topic: { Name: 't' }, queue: { QueueName: 'q' } },
+        concurrentConsumersAmount: 4,
+      },
+      buildBindings(),
+    )
+
+    expect(options.creationConfig).toEqual({ topic: { Name: 't' }, queue: { QueueName: 'q' } })
+    expect(options.concurrentConsumersAmount).toBe(4)
+  })
+})
+
+describe('AbstractSqsTrigger lifecycle', () => {
+  class CountingHandle implements InternalConsumerHandle {
+    initCalls = 0
+    startCalls = 0
+    closeCalls = 0
+    async init() {
+      this.initCalls++
+    }
+    async start() {
+      this.startCalls++
+    }
+    async close() {
+      this.closeCalls++
+    }
+  }
+
+  class TestTrigger extends AbstractSqsTrigger {
+    constructor(private readonly handles: readonly InternalConsumerHandle[]) {
+      super()
+    }
+    protected createConsumers(): readonly InternalConsumerHandle[] {
+      return this.handles
+    }
+  }
+
+  it('starts each consumer exactly once and never calls init() separately', async () => {
+    // The underlying consumer's start() runs init() internally; the trigger must
+    // not also call init(), or every queue re-subscribes and conflicts with the
+    // attributes (filter/redrive policy) set on the first subscribe.
+    const handles = [new CountingHandle(), new CountingHandle()]
+    const trigger = new TestTrigger(handles)
+
+    await trigger.start()
+
+    for (const handle of handles) {
+      expect(handle.startCalls).toBe(1)
+      expect(handle.initCalls).toBe(0)
+    }
+  })
+
+  it('closes every consumer on stop()', async () => {
+    const handles = [new CountingHandle(), new CountingHandle()]
+    const trigger = new TestTrigger(handles)
+
+    await trigger.start()
+    await trigger.stop()
+
+    for (const handle of handles) {
+      expect(handle.closeCalls).toBe(1)
+    }
+  })
+})

--- a/packages/sqs/test/triggerInternals.spec.ts
+++ b/packages/sqs/test/triggerInternals.spec.ts
@@ -39,7 +39,10 @@ describe('buildSnsTriggerConsumerOptions', () => {
         subscriptionConfig: {
           updateAttributesIfExists: true,
           // A reject-all policy resolveConsumerOptions() derived from empty handlers.
-          Attributes: { FilterPolicy: JSON.stringify({ type: ['__never__'] }) },
+          Attributes: {
+            FilterPolicy: JSON.stringify({ type: ['__never__'] }),
+            FilterPolicyScope: 'MessageBody',
+          },
         },
       },
       built,
@@ -48,6 +51,32 @@ describe('buildSnsTriggerConsumerOptions', () => {
     expect(options.subscriptionConfig?.Attributes).toBeUndefined()
     // ...but the caller's other subscription settings are preserved.
     expect(options.subscriptionConfig?.updateAttributesIfExists).toBe(true)
+  })
+
+  it('preserves a subscription-level RedrivePolicy while dropping the filter policy', () => {
+    const redrivePolicy = JSON.stringify({ deadLetterTargetArn: 'arn:aws:sqs:::sub-dlq' })
+    const options = buildSnsTriggerConsumerOptions(
+      {
+        creationConfig: { topic: { Name: 't' }, queue: { QueueName: 'q' } },
+        subscriptionConfig: {
+          updateAttributesIfExists: true,
+          Attributes: {
+            FilterPolicy: JSON.stringify({ type: ['__never__'] }),
+            RedrivePolicy: redrivePolicy,
+            RawMessageDelivery: 'true',
+          },
+        },
+      },
+      buildBindings(),
+    )
+
+    // The subscription DLQ (and other non-filter attributes) survive...
+    expect(options.subscriptionConfig?.Attributes).toEqual({
+      RedrivePolicy: redrivePolicy,
+      RawMessageDelivery: 'true',
+    })
+    // ...while the handler-derived filter policy is gone.
+    expect(options.subscriptionConfig?.Attributes?.FilterPolicy).toBeUndefined()
   })
 
   it('defaults updateAttributesIfExists to false when no subscriptionConfig is given', () => {
@@ -59,7 +88,7 @@ describe('buildSnsTriggerConsumerOptions', () => {
     expect(options.subscriptionConfig?.updateAttributesIfExists).toBe(false)
   })
 
-  it('strips a spread-in subscriptionDeadLetterQueue (trigger owns queue-level DLQ)', () => {
+  it('forwards a spread-in subscriptionDeadLetterQueue untouched', () => {
     const options = buildSnsTriggerConsumerOptions(
       {
         creationConfig: { topic: { Name: 't' }, queue: { QueueName: 'q' } },
@@ -67,14 +96,18 @@ describe('buildSnsTriggerConsumerOptions', () => {
           redrivePolicy: { maxReceiveCount: 3 },
           creationConfig: { queue: { QueueName: 'q-dlq' } },
         },
-        // Not part of the typed surface, but rides along on a resolveConsumerOptions() spread.
+        // Not part of the vendored typed surface, but rides along on a
+        // resolveConsumerOptions() spread / newer toolkit versions.
         subscriptionDeadLetterQueue: { reuseConsumerDeadLetterQueue: true },
       } as Parameters<typeof buildSnsTriggerConsumerOptions>[0],
       buildBindings(),
     )
 
-    expect('subscriptionDeadLetterQueue' in options).toBe(false)
-    // The queue-level DLQ the trigger does own is forwarded untouched.
+    // The subscription-level DLQ directive flows through to the consumer.
+    expect((options as { subscriptionDeadLetterQueue?: unknown }).subscriptionDeadLetterQueue).toEqual(
+      { reuseConsumerDeadLetterQueue: true },
+    )
+    // The queue-level DLQ is forwarded untouched as well.
     expect(options.deadLetterQueue).toEqual({
       redrivePolicy: { maxReceiveCount: 3 },
       creationConfig: { queue: { QueueName: 'q-dlq' } },


### PR DESCRIPTION
## Problem

Spreading a pre-resolved consumer-options object (e.g. `@lokalise/aws-config`'s `resolveConsumerOptions(...)`) into a trigger source forced callers to hand-unset fields the resolver had computed for a *real* consumer. Real-world call sites looked like this:

```ts
sources: [{
  creationConfig: { ... },
  ...resolvedOptions,
  // resolveConsumerOptions derives the filter policy from handlers, but the
  // trigger builds its own handlers from bindings. Empty handlers => reject-all,
  // so we reset Attributes here to accept all messages.
  subscriptionConfig: { updateAttributesIfExists: ... },
  // The resolver sets subscriptionDeadLetterQueue; we override it to undefined to
  // avoid a second Subscribe conflicting with the updated attributes.
  subscriptionDeadLetterQueue: undefined,
}]
```

Root cause: a trigger is **not** a plain consumer — it owns its handlers and its subscription *filtering* — but it blindly spread a full consumer's options, leaving callers to un-set everything that didn''t apply.

## Changes

**A. Fix the double-init in `AbstractSqsTrigger`.** It called `c.init()` *and* `c.start()`, but the underlying `message-queue-toolkit` consumer''s `start()` already runs `init()` internally — so every consumer initted twice, and the second pass re-subscribed each queue, conflicting with the subscription attributes (filter policy, redrive policy) set on the first pass. Now it only calls `start()`.

**B. The trigger claims only what it truly owns, centrally.** `buildSnsTriggerConsumerOptions` resets:
- **`handlers`** — always rebuilt from `bindings`.
- **subscription filter policy** (`subscriptionConfig.Attributes.FilterPolicy` / `FilterPolicyScope`) — dropped (the reject-all policy the resolver derives from empty handlers); defaults to accept-all.

Everything else flows through, **including the subscription-level DLQ**. Since fix A removes the double-init conflict, there''s no longer any reason to strip it: `subscriptionConfig.Attributes.RedrivePolicy` (the subscription DLQ in the installed toolkit) is preserved alongside any other attributes, and a spread-in `subscriptionDeadLetterQueue` (used by `resolveConsumerOptions` / newer toolkits) flows through to the consumer.

Shared by the flat and group SNS triggers, and exported. SQS-queue triggers were already lifecycle-only and gain fix A for free.

After this, the call site is just `...resolvedOptions` + `creationConfig` + `bindings` — no `subscriptionConfig` patch, no `subscriptionDeadLetterQueue` override, no `Attributes` reset.

## Tests

New `test/triggerInternals.spec.ts` (8 deterministic unit tests): the option sanitizer (handler injection, `FilterPolicy`/`FilterPolicyScope` drop, **`RedrivePolicy` preserved**, `subscriptionDeadLetterQueue` forwarded, `updateAttributesIfExists` default/override, pass-through of unrelated options) and the lifecycle fix (each consumer `start()`ed exactly once, `init()` never called separately; `stop()` closes all). Full suite: 42 passed, no type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)