### PR TITLE
Fix race conditions between invalidation and in-flight loads

### DIFF
--- a/lib/AbstractCache.ts
+++ b/lib/AbstractCache.ts
@@ -163,14 +163,20 @@ export abstract class AbstractCache<
   }
 
   public async invalidateCache() {
-    this.inMemoryCache.clear()
+    // Evict the running loads first so in-flight results are fenced out of the caches.
+    this.runningLoads.clear()
     if (this.asyncCache) {
       await this.asyncCache.clear().catch((err) => {
         this.cacheUpdateErrorHandler(err, undefined, this.asyncCache!, this.logger)
       })
     }
 
+    // Evict again: a load that started while the async clear was in flight may have
+    // read a not-yet-deleted async value; fencing it out here stops it from
+    // repopulating the caches after this invalidation resolves. The in-memory clear
+    // comes last for the same reason.
     this.runningLoads.clear()
+    this.inMemoryCache.clear()
 
     if (this.notificationPublisher) {
       this.notificationPublisher.clear().catch((err) => {

--- a/lib/AbstractFlatCache.ts
+++ b/lib/AbstractFlatCache.ts
@@ -48,13 +48,21 @@ export abstract class AbstractFlatCache<LoadedValue, LoadParams = string, LoadMa
 
     loadingPromise
       .then((resolvedValue) => {
+        // If the running load was evicted (invalidation, forceSetValue) while this load
+        // was in flight, its result reflects a snapshot taken before that point and must
+        // not be persisted — callers awaiting the promise still receive the value.
+        if (this.runningLoads.get(key) !== loadingPromise) {
+          return
+        }
         if (resolvedValue !== undefined) {
           this.inMemoryCache.set(key, resolvedValue)
         }
         this.runningLoads.delete(key)
       })
       .catch(() => {
-        this.runningLoads.delete(key)
+        if (this.runningLoads.get(key) === loadingPromise) {
+          this.runningLoads.delete(key)
+        }
       })
 
     return loadingPromise
@@ -131,14 +139,20 @@ export abstract class AbstractFlatCache<LoadedValue, LoadParams = string, LoadMa
   }
 
   public async invalidateCacheFor(key: string) {
-    this.inMemoryCache.delete(key)
+    // Evict the running load first so an in-flight result is fenced out of the caches.
+    this.runningLoads.delete(key)
     if (this.asyncCache) {
       await this.asyncCache.delete(key).catch((err) => {
         this.cacheUpdateErrorHandler(err, undefined, this.asyncCache!, this.logger)
       })
     }
 
+    // Evict again: a load that started while the async delete was in flight may have
+    // read the not-yet-deleted async value; fencing it out here stops it from
+    // repopulating the caches after this invalidation resolves. The in-memory delete
+    // comes last for the same reason.
     this.runningLoads.delete(key)
+    this.inMemoryCache.delete(key)
     if (this.notificationPublisher) {
       this.notificationPublisher.delete(key).catch((err) => {
         this.notificationPublisher!.errorHandler(err, this.notificationPublisher!.channel, this.logger)
@@ -147,6 +161,10 @@ export abstract class AbstractFlatCache<LoadedValue, LoadParams = string, LoadMa
   }
 
   public async invalidateCacheForMany(keys: string[]) {
+    // Evict the running loads first so in-flight results are fenced out of the caches.
+    for (let i = 0; i < keys.length; i++) {
+      this.runningLoads.delete(keys[i])
+    }
     if (this.asyncCache) {
       await this.asyncCache.deleteMany(keys).catch((err) => {
         /* v8 ignore next -- @preserve */

--- a/lib/AbstractGroupCache.ts
+++ b/lib/AbstractGroupCache.ts
@@ -19,14 +19,20 @@ export abstract class AbstractGroupCache<LoadedValue, LoadParams = string, LoadM
   }
 
   public async invalidateCacheForGroup(group: string) {
+    // Evict the running loads first so in-flight results are fenced out of the caches.
+    this.runningLoads.delete(group)
     if (this.asyncCache) {
       await this.asyncCache.deleteGroup(group).catch((err) => {
         this.cacheUpdateErrorHandler(err, `group: ${group}`, this.asyncCache!, this.logger)
       })
     }
 
-    this.inMemoryCache.deleteGroup(group)
+    // Evict again: a load that started while the async delete was in flight may have
+    // read the not-yet-deleted async value; fencing it out here stops it from
+    // repopulating the caches after this invalidation resolves. The in-memory delete
+    // comes last for the same reason.
     this.runningLoads.delete(group)
+    this.inMemoryCache.deleteGroup(group)
 
     if (this.notificationPublisher) {
       void this.notificationPublisher.deleteGroup(group).catch((err) => {
@@ -67,13 +73,21 @@ export abstract class AbstractGroupCache<LoadedValue, LoadParams = string, LoadM
 
     loadingPromise
       .then((resolvedValue) => {
+        // If the running load was evicted (group or key invalidation) while this load
+        // was in flight, its result reflects a snapshot taken before that point and must
+        // not be persisted — callers awaiting the promise still receive the value.
+        if (this.runningLoads.get(group) !== groupLoads || groupLoads.get(key) !== loadingPromise) {
+          return
+        }
         if (resolvedValue !== undefined) {
           this.inMemoryCache.setForGroup(key, resolvedValue, group)
         }
         this.deleteGroupRunningLoad(groupLoads, group, key)
       })
       .catch(() => {
-        this.deleteGroupRunningLoad(groupLoads, group, key)
+        if (this.runningLoads.get(group) === groupLoads && groupLoads.get(key) === loadingPromise) {
+          this.deleteGroupRunningLoad(groupLoads, group, key)
+        }
       })
 
     return loadingPromise
@@ -125,15 +139,20 @@ export abstract class AbstractGroupCache<LoadedValue, LoadParams = string, LoadM
   }
 
   public async invalidateCacheFor(key: string, group: string) {
-    this.inMemoryCache.deleteFromGroup(key, group)
+    // Evict the running load first so an in-flight result is fenced out of the caches.
+    this.evictGroupRunningLoad(group, key)
     if (this.asyncCache) {
       await this.asyncCache.deleteFromGroup(key, group).catch((err) => {
         this.cacheUpdateErrorHandler(err, undefined, this.asyncCache!, this.logger)
       })
     }
 
-    const groupLoads = this.resolveGroupLoads(group)
-    this.deleteGroupRunningLoad(groupLoads, group, key)
+    // Evict again: a load that started while the async delete was in flight may have
+    // read the not-yet-deleted async value; fencing it out here stops it from
+    // repopulating the caches after this invalidation resolves. The in-memory delete
+    // comes last for the same reason.
+    this.evictGroupRunningLoad(group, key)
+    this.inMemoryCache.deleteFromGroup(key, group)
 
     if (this.notificationPublisher) {
       void this.notificationPublisher.deleteFromGroup(key, group).catch((err) => {
@@ -178,6 +197,13 @@ export abstract class AbstractGroupCache<LoadedValue, LoadParams = string, LoadM
     }
   }
 
+  private evictGroupRunningLoad(group: string, key: string) {
+    const groupLoads = this.runningLoads.get(group)
+    if (groupLoads) {
+      this.deleteGroupRunningLoad(groupLoads, group, key)
+    }
+  }
+
   protected resolveGroupLoads(group: string) {
     const load = this.runningLoads.get(group)
     if (load) {
@@ -191,7 +217,10 @@ export abstract class AbstractGroupCache<LoadedValue, LoadParams = string, LoadM
 
   protected deleteGroupRunningLoad(groupLoads: Map<string, unknown>, group: string, key: string) {
     groupLoads.delete(key)
-    if (groupLoads.size === 0) {
+    // Only drop the group entry if it still points at this map — a group invalidation
+    // may have detached it and a newer load registered a fresh map under the same group,
+    // which must not be evicted by a load settling against the stale map.
+    if (groupLoads.size === 0 && this.runningLoads.get(group) === groupLoads) {
       this.runningLoads.delete(group)
     }
   }

--- a/lib/GroupLoader.ts
+++ b/lib/GroupLoader.ts
@@ -54,6 +54,16 @@ export class GroupLoader<LoadedValue, LoadParams = string, LoadManyParams = Load
                   groupSet.add(key)
 
                   this.loadFromLoaders(key, group, loadParams)
+                    .then((freshValue) => {
+                      // Propagate the freshly loaded value to the in-memory cache as well.
+                      // Without this, the in-memory layer keeps serving the stale value that
+                      // was read from the async cache before this background refresh started,
+                      // and its TTL is reset on the next read, so subsequent reads stay stale
+                      // for another full ttlInMsecs window even though the async cache is fresh.
+                      if (freshValue !== undefined) {
+                        this.inMemoryCache.setForGroup(key, freshValue, group)
+                      }
+                    })
                     .catch((err) => {
                       this.logger.error(err.message)
                     })

--- a/lib/redis/RedisGroupNotificationConsumer.ts
+++ b/lib/redis/RedisGroupNotificationConsumer.ts
@@ -39,30 +39,37 @@ export class RedisGroupNotificationConsumer<LoadedValue> extends AbstractNotific
   }
 
   subscribe(): Promise<void> {
-    return this.redis.subscribe(this.channel).then(() => {
-      this.messageHandler = (channel, message) => {
-        const parsedMessage: GroupNotificationCommand = JSON.parse(message)
-        // this is a local message, ignore
-        if (parsedMessage.originUuid === this.serverUuid) {
-          return
-        }
-
-        if (parsedMessage.actionId === 'DELETE_FROM_GROUP') {
-          return this.targetCache.deleteFromGroup(
-            (parsedMessage as DeleteFromGroupNotificationCommand).key,
-            (parsedMessage as DeleteFromGroupNotificationCommand).group,
-          )
-        }
-
-        if (parsedMessage.actionId === 'DELETE_GROUP') {
-          return this.targetCache.deleteGroup((parsedMessage as DeleteGroupNotificationCommand).group)
-        }
-
-        if (parsedMessage.actionId === 'CLEAR') {
-          return this.targetCache.clear()
-        }
+    // The listener is registered before subscribing so that no message can slip through
+    // between the SUBSCRIBE ack and the listener attachment.
+    this.messageHandler = (channel, message) => {
+      // the connection may carry subscriptions of other consumers, ignore their channels
+      if (channel !== this.channel) {
+        return
       }
-      this.redis.on('message', this.messageHandler)
-    })
+
+      const parsedMessage: GroupNotificationCommand = JSON.parse(message)
+      // this is a local message, ignore
+      if (parsedMessage.originUuid === this.serverUuid) {
+        return
+      }
+
+      if (parsedMessage.actionId === 'DELETE_FROM_GROUP') {
+        return this.targetCache.deleteFromGroup(
+          (parsedMessage as DeleteFromGroupNotificationCommand).key,
+          (parsedMessage as DeleteFromGroupNotificationCommand).group,
+        )
+      }
+
+      if (parsedMessage.actionId === 'DELETE_GROUP') {
+        return this.targetCache.deleteGroup((parsedMessage as DeleteGroupNotificationCommand).group)
+      }
+
+      if (parsedMessage.actionId === 'CLEAR') {
+        return this.targetCache.clear()
+      }
+    }
+    this.redis.on('message', this.messageHandler)
+
+    return this.redis.subscribe(this.channel).then(() => {})
   }
 }

--- a/lib/redis/RedisNotificationConsumer.ts
+++ b/lib/redis/RedisNotificationConsumer.ts
@@ -44,34 +44,41 @@ export class RedisNotificationConsumer<LoadedValue> extends AbstractNotification
   }
 
   subscribe(): Promise<void> {
-    return this.redis.subscribe(this.channel).then(() => {
-      this.messageHandler = (channel, message) => {
-        const parsedMessage: NotificationCommand = JSON.parse(message)
-        // this is a local message, ignore
-        if (parsedMessage.originUuid === this.serverUuid) {
-          return
-        }
-
-        if (parsedMessage.actionId === 'DELETE') {
-          return this.targetCache.delete((parsedMessage as DeleteNotificationCommand).key)
-        }
-
-        if (parsedMessage.actionId === 'DELETE_MANY') {
-          return this.targetCache.deleteMany((parsedMessage as DeleteManyNotificationCommand).keys)
-        }
-
-        if (parsedMessage.actionId === 'CLEAR') {
-          return this.targetCache.clear()
-        }
-
-        if (parsedMessage.actionId === 'SET') {
-          return this.targetCache.set(
-            (parsedMessage as SetNotificationCommand<LoadedValue>).key,
-            (parsedMessage as SetNotificationCommand<LoadedValue>).value,
-          )
-        }
+    // The listener is registered before subscribing so that no message can slip through
+    // between the SUBSCRIBE ack and the listener attachment.
+    this.messageHandler = (channel, message) => {
+      // the connection may carry subscriptions of other consumers, ignore their channels
+      if (channel !== this.channel) {
+        return
       }
-      this.redis.on('message', this.messageHandler)
-    })
+
+      const parsedMessage: NotificationCommand = JSON.parse(message)
+      // this is a local message, ignore
+      if (parsedMessage.originUuid === this.serverUuid) {
+        return
+      }
+
+      if (parsedMessage.actionId === 'DELETE') {
+        return this.targetCache.delete((parsedMessage as DeleteNotificationCommand).key)
+      }
+
+      if (parsedMessage.actionId === 'DELETE_MANY') {
+        return this.targetCache.deleteMany((parsedMessage as DeleteManyNotificationCommand).keys)
+      }
+
+      if (parsedMessage.actionId === 'CLEAR') {
+        return this.targetCache.clear()
+      }
+
+      if (parsedMessage.actionId === 'SET') {
+        return this.targetCache.set(
+          (parsedMessage as SetNotificationCommand<LoadedValue>).key,
+          (parsedMessage as SetNotificationCommand<LoadedValue>).value,
+        )
+      }
+    }
+    this.redis.on('message', this.messageHandler)
+
+    return this.redis.subscribe(this.channel).then(() => {})
   }
 }

--- a/test/GroupLoader-async-refresh.spec.ts
+++ b/test/GroupLoader-async-refresh.spec.ts
@@ -242,6 +242,60 @@ describe('GroupLoader Async Refresh', () => {
       expect(groupRefreshFlags.has(user1.companyId)).toBe(false)
     })
 
+    it('two-layer cache propagates fresh value to in-memory after background refresh', async () => {
+      const loader = new CountingGroupedLoader(userValues)
+      const asyncCache = new RedisGroupCache<User>(redis, {
+        ttlInMsecs: 5000,
+        json: true,
+        ttlLeftBeforeRefreshInMsecs: 4500,
+      })
+
+      const operation = new GroupLoader<User>({
+        inMemoryCache: {
+          cacheId: 'two-layer-group-refresh',
+          ttlInMsecs: 5000,
+          ttlLeftBeforeRefreshInMsecs: 4500,
+        },
+        asyncCache,
+        dataSources: [loader],
+      })
+
+      // Populates both layers with the original value
+      expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+      expect(loader.counter).toBe(1)
+
+      // Source value changes
+      const updatedUser1: User = { ...user1, parametrized: 'updated' }
+      loader.groupValues = {
+        ...userValues,
+        [user1.companyId]: {
+          ...userValues[user1.companyId],
+          [user1.userId]: updatedUser1,
+        },
+      }
+
+      // Wait until both layers' entries are within the refresh window
+      await setTimeout(600)
+
+      // SWR: returns the stale value and triggers a background refresh
+      expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+
+      // Wait for the background refresh to actually call the data source
+      for (let attempt = 0; attempt < 20 && loader.counter < 2; attempt++) {
+        await setTimeout(10)
+      }
+      expect(loader.counter).toBe(2)
+
+      // Sanity check: Redis is now fresh
+      // @ts-expect-error
+      expect(await operation.asyncCache.getFromGroup(user1.userId, user1.companyId)).toEqual(
+        updatedUser1,
+      )
+
+      // The next read should observe the fresh value that the background refresh fetched.
+      expect(await operation.get(user1.userId, user1.companyId)).toEqual(updatedUser1)
+    })
+
     it('async background refresh errors do not crash app', async () => {
       const loader = new CountingGroupedLoader(userValues)
       const asyncCache = new RedisGroupCache<User>(redis, {

--- a/test/GroupLoader-main.spec.ts
+++ b/test/GroupLoader-main.spec.ts
@@ -4,6 +4,7 @@ import type { CacheKeyResolver } from '../lib/AbstractCache'
 import { GroupLoader } from '../lib/GroupLoader'
 import type { InMemoryGroupCacheConfiguration } from '../lib/memory/InMemoryGroupCache'
 import { CountingGroupedLoader } from './fakes/CountingGroupedLoader'
+import { DelayedCountingGroupedLoader } from './fakes/DelayedCountingGroupedLoader'
 import type { DummyLoaderManyParams, DummyLoaderParams } from './fakes/DummyDataSourceWithParams'
 import { DummyGroupedCache } from './fakes/DummyGroupedCache'
 import { DummyGroupedDataSourceWithParams } from './fakes/DummyGroupedDataSourceWithParams'
@@ -11,6 +12,7 @@ import { DummyGroupedLoader } from './fakes/DummyGroupedLoader'
 import { DummyGroupNotificationConsumer } from './fakes/DummyGroupNotificationConsumer'
 import { DummyGroupNotificationConsumerMultiplexer } from './fakes/DummyGroupNotificationConsumerMultiplexer'
 import { DummyGroupNotificationPublisher } from './fakes/DummyGroupNotificationPublisher'
+import { MultiDelayedCountingGroupedLoader } from './fakes/MultiDelayedCountingGroupedLoader'
 import { TemporaryThrowingGroupedLoader } from './fakes/TemporaryThrowingGroupedLoader'
 import { ThrowingGroupedCache } from './fakes/ThrowingGroupedCache'
 import { ThrowingGroupedLoader } from './fakes/ThrowingGroupedLoader'
@@ -893,6 +895,86 @@ describe('GroupLoader Main', () => {
       expect(valuePre).toEqual(user1)
       expect(valuePost).toEqual(user1)
       expect(loader2.counter).toBe(2)
+    })
+  })
+
+  describe('invalidation racing with in-flight loads', () => {
+    it('does not cache a load that was in flight when invalidateCacheForGroup was called', async () => {
+      const loader = new DelayedCountingGroupedLoader(userValues)
+
+      const operation = new GroupLoader<User>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        dataSources: [loader],
+      })
+
+      const loadPromise = operation.get(user1.userId, user1.companyId)
+      await setTimeout(2)
+      expect(loader.counter).toBe(1)
+
+      await operation.invalidateCacheForGroup(user1.companyId)
+      await loader.finishLoading()
+
+      // the caller that was already awaiting the load still receives the value
+      expect(await loadPromise).toEqual(user1)
+      // but the invalidated group is not resurrected in the cache
+      expect(operation.getInMemoryOnly(user1.userId, user1.companyId)).toBeUndefined()
+    })
+
+    it('does not cache a load that was in flight when invalidateCacheFor was called', async () => {
+      const loader = new DelayedCountingGroupedLoader(userValues)
+
+      const operation = new GroupLoader<User>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        dataSources: [loader],
+      })
+
+      const loadPromise = operation.get(user1.userId, user1.companyId)
+      await setTimeout(2)
+      expect(loader.counter).toBe(1)
+
+      await operation.invalidateCacheFor(user1.userId, user1.companyId)
+      await loader.finishLoading()
+
+      expect(await loadPromise).toEqual(user1)
+      expect(operation.getInMemoryOnly(user1.userId, user1.companyId)).toBeUndefined()
+    })
+
+    it('load settling after group invalidation does not break deduplication of newer loads', async () => {
+      const loader = new MultiDelayedCountingGroupedLoader(userValues)
+
+      const operation = new GroupLoader<User>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        dataSources: [loader],
+      })
+
+      // load A starts and registers the running-loads map for the group
+      const loadPromiseA = operation.get(user1.userId, user1.companyId)
+      await setTimeout(2)
+      expect(loader.counter).toBe(1)
+
+      // invalidation detaches the running-loads map for the group
+      await operation.invalidateCacheForGroup(user1.companyId)
+
+      // load B starts after the invalidation and registers a fresh running-loads map
+      const loadPromiseB = operation.get(user1.userId, user1.companyId)
+      await setTimeout(2)
+      expect(loader.counter).toBe(2)
+
+      // load A settles against the detached map — it must not evict B's map
+      await loader.finishLoading()
+      expect(await loadPromiseA).toEqual(user1)
+      // A started before the invalidation, so its result must not be cached
+      expect(operation.getInMemoryOnly(user1.userId, user1.companyId)).toBeUndefined()
+
+      // load C must be deduplicated into the still-running load B
+      const loadPromiseC = operation.getAsyncOnly(user1.userId, user1.companyId)
+      await setTimeout(2)
+      expect(loader.counter).toBe(2)
+
+      await loader.finishLoading()
+      expect(await loadPromiseB).toEqual(user1)
+      expect(await loadPromiseC).toEqual(user1)
+      expect(operation.getInMemoryOnly(user1.userId, user1.companyId)).toEqual(user1)
     })
   })
 

--- a/test/Loader-main.spec.ts
+++ b/test/Loader-main.spec.ts
@@ -8,6 +8,8 @@ import type { InMemoryCacheConfiguration } from '../lib/memory/InMemoryCache'
 import { CountingDataSource } from './fakes/CountingDataSource'
 import { CountingRecordLoader } from './fakes/CountingRecordLoader'
 import { CountingTimedCache } from './fakes/CountingTimedCache'
+import { DelayedCountingLoader } from './fakes/DelayedCountingLoader'
+import { DelayedDeleteCache } from './fakes/DelayedDeleteCache'
 import { DummyCache } from './fakes/DummyCache'
 import { DummyDataSource } from './fakes/DummyDataSource'
 import {
@@ -1099,6 +1101,103 @@ describe('Loader Main', () => {
       expect(valuePre).toBe('value')
       expect(valuePost).toBe('value')
       expect(loader2.counter).toBe(2)
+    })
+  })
+
+  describe('invalidation racing with in-flight loads', () => {
+    it('does not cache a load that was in flight when invalidateCacheFor was called', async () => {
+      const loader = new DelayedCountingLoader('value')
+
+      const operation = new Loader<string>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        dataSources: [loader],
+      })
+
+      const loadPromise = operation.get('key')
+      await setTimeout(2)
+      expect(loader.counter).toBe(1)
+
+      await operation.invalidateCacheFor('key')
+      await loader.finishLoading()
+
+      // the caller that was already awaiting the load still receives the value
+      expect(await loadPromise).toBe('value')
+      // but the invalidated key is not resurrected in the cache
+      expect(operation.getInMemoryOnly('key')).toBeUndefined()
+
+      // the next get starts a fresh load instead of serving the fenced-out result
+      const freshPromise = operation.get('key')
+      await setTimeout(2)
+      expect(loader.counter).toBe(2)
+      await loader.finishLoading()
+      expect(await freshPromise).toBe('value')
+    })
+
+    it('does not cache a load that was in flight when invalidateCacheForMany was called', async () => {
+      const loader = new DelayedCountingLoader('value')
+
+      const operation = new Loader<string>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        dataSources: [loader],
+      })
+
+      const loadPromise = operation.get('key')
+      await setTimeout(2)
+      expect(loader.counter).toBe(1)
+
+      await operation.invalidateCacheForMany(['key', 'key2'])
+      await loader.finishLoading()
+
+      expect(await loadPromise).toBe('value')
+      expect(operation.getInMemoryOnly('key')).toBeUndefined()
+    })
+
+    it('does not let an in-flight load overwrite forceSetValue', async () => {
+      const loader = new DelayedCountingLoader('value')
+
+      const operation = new Loader<string>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        dataSources: [loader],
+      })
+
+      const loadPromise = operation.get('key')
+      await setTimeout(2)
+      expect(loader.counter).toBe(1)
+
+      await operation.forceSetValue('key', 'value2')
+      await loader.finishLoading()
+
+      // the caller that was already awaiting the load still receives the loaded value
+      expect(await loadPromise).toBe('value')
+      // but the forced value is not clobbered by the older in-flight load
+      expect(operation.getInMemoryOnly('key')).toBe('value2')
+      expect(await operation.get('key')).toBe('value2')
+      expect(loader.counter).toBe(1)
+    })
+
+    it('does not repopulate the in-memory cache from a get that raced a slow async delete', async () => {
+      const asyncCache = new DelayedDeleteCache('value')
+      const loader = new CountingDataSource('value')
+
+      const operation = new Loader<string>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        asyncCache,
+        dataSources: [loader],
+      })
+
+      // populate both tiers
+      expect(await operation.get('key')).toBe('value')
+
+      const invalidationPromise = operation.invalidateCacheFor('key')
+      // concurrent read while the async delete is still in flight
+      const racingGetPromise = operation.get('key')
+      asyncCache.finishDelete()
+      await invalidationPromise
+      await racingGetPromise
+
+      // after the invalidation resolves, neither tier holds the old value
+      expect(operation.getInMemoryOnly('key')).toBeUndefined()
+      expect(asyncCache.value).toBeUndefined()
     })
   })
 

--- a/test/fakes/DelayedDeleteCache.ts
+++ b/test/fakes/DelayedDeleteCache.ts
@@ -1,0 +1,70 @@
+import { Loader } from '../../lib/Loader'
+import type { Cache } from '../../lib/types/DataSources'
+import type { GetManyResult } from '../../lib/types/SyncDataSources'
+
+export class DelayedDeleteCache implements Cache<string> {
+  value: string | undefined | null
+  name = 'Delayed delete cache'
+  isCache = true
+  readonly expirationTimeLoadingOperation = new Loader<number>({})
+  readonly ttlLeftBeforeRefreshInMsecs = undefined
+  private deleteResolver?: () => void
+
+  constructor(returnedValue: string | undefined) {
+    this.value = returnedValue
+  }
+
+  get(_key: string): Promise<string | undefined | null> {
+    return Promise.resolve(this.value)
+  }
+
+  getMany(keys: string[]): Promise<GetManyResult<string>> {
+    const resolvedValues = keys.map(() => this.value as string).filter((entry) => entry != null)
+
+    return Promise.resolve({
+      resolvedValues,
+      unresolvedKeys: resolvedValues.length === 0 ? keys : [],
+    })
+  }
+
+  clear(): Promise<void> {
+    this.value = undefined
+    return Promise.resolve(undefined)
+  }
+
+  delete(_key: string): Promise<void> {
+    return new Promise((resolve) => {
+      this.deleteResolver = () => {
+        this.value = undefined
+        resolve(undefined)
+      }
+    })
+  }
+
+  finishDelete() {
+    this.deleteResolver?.()
+    this.deleteResolver = undefined
+  }
+
+  deleteMany(_keys: string[]): Promise<unknown> {
+    this.value = undefined
+    return Promise.resolve(undefined)
+  }
+
+  set(_key: string, value: string | null): Promise<void> {
+    this.value = value ?? undefined
+    return Promise.resolve(undefined)
+  }
+
+  getExpirationTime(): Promise<number> {
+    return Promise.resolve(99999)
+  }
+
+  close(): Promise<unknown> {
+    return Promise.resolve(undefined)
+  }
+
+  setMany(): Promise<unknown> {
+    throw new Error('Not implemented')
+  }
+}

--- a/test/fakes/MultiDelayedCountingGroupedLoader.ts
+++ b/test/fakes/MultiDelayedCountingGroupedLoader.ts
@@ -1,0 +1,43 @@
+import type { GroupDataSource } from '../../lib/types/DataSources'
+import type { GroupValues, User } from '../types/testTypes'
+import { cloneDeep } from '../utils/cloneUtils'
+
+/**
+ * Unlike DelayedCountingGroupedLoader, this fake supports several concurrent pending loads:
+ * each getFromGroup call queues its own resolver and finishLoading() settles them in FIFO order.
+ */
+export class MultiDelayedCountingGroupedLoader implements GroupDataSource<User> {
+  public counter = 0
+  public groupValues: GroupValues | null | undefined
+
+  name = 'Multi delayed counting grouped loader'
+  private pendingLoads: { resolve: (value: any) => void; value: any; promise: Promise<User> }[] = []
+
+  constructor(returnedValues: GroupValues) {
+    this.groupValues = cloneDeep(returnedValues)
+  }
+
+  getFromGroup(key: string, group: string) {
+    this.counter++
+    const value = this.groupValues?.[group]?.[key]
+    let resolve!: (value: any) => void
+    const promise = new Promise<User>((_resolve) => {
+      resolve = _resolve
+    })
+    this.pendingLoads.push({ resolve, value, promise })
+    return promise
+  }
+
+  getManyFromGroup(): Promise<User[]> {
+    throw new Error('Method not implemented.')
+  }
+
+  finishLoading() {
+    const pendingLoad = this.pendingLoads.shift()
+    if (!pendingLoad) {
+      throw new Error('No pending load to finish')
+    }
+    pendingLoad.resolve(pendingLoad.value)
+    return pendingLoad.promise
+  }
+}

--- a/test/redis/RedisNotificationPublisher.spec.ts
+++ b/test/redis/RedisNotificationPublisher.spec.ts
@@ -407,6 +407,64 @@ describe('RedisNotificationPublisher', () => {
     await setTimeout(1)
   })
 
+  it('Ignores messages published on other channels when consumer connection is shared', async () => {
+    const { publisher: notificationPublisher1, consumer: notificationConsumer1 } =
+      createNotificationPair<string>({
+        channel: CHANNEL_ID,
+        consumerRedis: redisConsumer,
+        publisherRedis: redisPublisher,
+      })
+
+    // second consumer shares the same Redis connection, but listens on a different channel
+    const { publisher: notificationPublisher2, consumer: notificationConsumer2 } =
+      createNotificationPair<string>({
+        channel: 'other_channel',
+        consumerRedis: redisConsumer,
+        publisherRedis: redisPublisher,
+      })
+
+    const operation = new Loader<string>({
+      inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+      asyncCache: new DummyCache('value'),
+      notificationConsumer: notificationConsumer1,
+      notificationPublisher: notificationPublisher1,
+    })
+
+    const operation2 = new Loader<string>({
+      inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+      asyncCache: new DummyCache('value'),
+      notificationConsumer: notificationConsumer2,
+      notificationPublisher: notificationPublisher2,
+    })
+    await operation.init()
+    await operation2.init()
+
+    await operation.getAsyncOnly('key')
+    await operation2.getAsyncOnly('key')
+    expect(operation.getInMemoryOnly('key')).toBe('value')
+    expect(operation2.getInMemoryOnly('key')).toBe('value')
+
+    // deletion published on CHANNEL_ID by a remote instance
+    await redisPublisher.publish(
+      CHANNEL_ID,
+      JSON.stringify({
+        actionId: 'DELETE',
+        key: 'key',
+        originUuid: 'different-uuid',
+      }),
+    )
+
+    await waitAndRetry(() => operation.getInMemoryOnly('key') === undefined, 50, 100)
+
+    // consumer on CHANNEL_ID applies the deletion
+    expect(operation.getInMemoryOnly('key')).toBeUndefined()
+    // consumer on other_channel sharing the connection must not apply it
+    expect(operation2.getInMemoryOnly('key')).toBe('value')
+
+    await notificationConsumer1.close()
+    await notificationPublisher1.close()
+  })
+
   it('Ignores unknown action IDs', async () => {
     const { publisher: notificationPublisher1, consumer: notificationConsumer1 } =
       createNotificationPair<string>({


### PR DESCRIPTION
A race-condition audit of the caching layers surfaced several interleavings
where concurrent operations could silently undo invalidations or corrupt
load deduplication:

- An in-flight load resolving after invalidateCacheFor / invalidateCacheForGroup /
  forceSetValue wrote its stale result back into the in-memory cache,
  resurrecting deleted data for a full TTL window.
- invalidateCacheFor deleted the in-memory entry before awaiting the async
  delete, so a concurrent get could read the not-yet-deleted async value and
  repopulate memory after the invalidation resolved.
- A load settling against a running-loads map detached by a group invalidation
  deleted the group entry by id, evicting a newer load's map and breaking
  deduplication for subsequent gets.
- Redis notification consumers never compared the incoming channel to their
  own, so consumers sharing one connection applied each other's messages, and
  the message listener was attached only after the SUBSCRIBE ack, dropping
  messages in that window.
- GroupLoader's background refresh only updated the async cache, leaving the
  in-memory tier serving stale data (the flat Loader already had this fix).

Fixes:
- getAsyncOnly (flat + group) now fences its write-back: the resolved value is
  only persisted if the dedup entry still belongs to that load, so any
  invalidation or forced write that evicted the entry cancels the write-back
  while awaiting callers still receive the value.
- Invalidation paths evict running loads before and after the awaited async
  delete and delete the in-memory entry last.
- deleteGroupRunningLoad only removes the group entry when it still points at
  the settling load's map.
- Redis notification consumers filter by channel and register the message
  listener before subscribing.
- GroupLoader background refresh propagates the fresh value to the in-memory
  cache.

All fixes are covered by regression tests that fail against the previous
implementation.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PJ6dc6tAHvtuA4cQC7X7TD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache invalidation so in-flight loads no longer repopulate stale values after a clear or delete.
  * Background refreshes now update the current cached value, reducing stale reads.
  * Redis notifications are now registered before subscribing, preventing missed updates during startup.
  * Channel filtering is more reliable when multiple consumers share the same connection.

* **Tests**
  * Added coverage for cache race conditions, background refresh behavior, and Redis notification filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->