### PR TITLE
Fix correctness issues in caching layers

### DIFF
--- a/lib/AbstractFlatCache.ts
+++ b/lib/AbstractFlatCache.ts
@@ -48,13 +48,20 @@ export abstract class AbstractFlatCache<LoadedValue, LoadParams = string, LoadMa
 
     loadingPromise
       .then((resolvedValue) => {
-        if (resolvedValue !== undefined) {
-          this.inMemoryCache.set(key, resolvedValue)
+        // Only apply the result if this load still owns the key - a concurrent set(),
+        // forceSetValue() or invalidation deletes the runningLoads entry, and writing
+        // the (now stale) loaded value would clobber the newer state.
+        if (this.runningLoads.get(key) === loadingPromise) {
+          if (resolvedValue !== undefined) {
+            this.inMemoryCache.set(key, resolvedValue)
+          }
+          this.runningLoads.delete(key)
         }
-        this.runningLoads.delete(key)
       })
       .catch(() => {
-        this.runningLoads.delete(key)
+        if (this.runningLoads.get(key) === loadingPromise) {
+          this.runningLoads.delete(key)
+        }
       })
 
     return loadingPromise

--- a/lib/AbstractGroupCache.ts
+++ b/lib/AbstractGroupCache.ts
@@ -67,13 +67,20 @@ export abstract class AbstractGroupCache<LoadedValue, LoadParams = string, LoadM
 
     loadingPromise
       .then((resolvedValue) => {
-        if (resolvedValue !== undefined) {
-          this.inMemoryCache.setForGroup(key, resolvedValue, group)
+        // Only apply the result if this load still owns the key - a concurrent set() or
+        // invalidation deletes the runningLoads entry (or the whole group map), and writing
+        // the (now stale) loaded value would clobber the newer state.
+        if (this.runningLoads.get(group) === groupLoads && groupLoads.get(key) === loadingPromise) {
+          if (resolvedValue !== undefined) {
+            this.inMemoryCache.setForGroup(key, resolvedValue, group)
+          }
+          this.deleteGroupRunningLoad(groupLoads, group, key)
         }
-        this.deleteGroupRunningLoad(groupLoads, group, key)
       })
       .catch(() => {
-        this.deleteGroupRunningLoad(groupLoads, group, key)
+        if (this.runningLoads.get(group) === groupLoads && groupLoads.get(key) === loadingPromise) {
+          this.deleteGroupRunningLoad(groupLoads, group, key)
+        }
       })
 
     return loadingPromise

--- a/lib/GroupLoader.ts
+++ b/lib/GroupLoader.ts
@@ -41,7 +41,9 @@ export class GroupLoader<LoadedValue, LoadParams = string, LoadManyParams = Load
           let isAlreadyRefreshing = groupSet?.has(key)
 
           if (!isAlreadyRefreshing) {
-            this.asyncCache.expirationTimeLoadingGroupedOperation.get(key, group).then((expirationTime) => {
+            this.asyncCache.expirationTimeLoadingGroupedOperation
+              .get(key, group)
+              .then((expirationTime) => {
               if (expirationTime && expirationTime - Date.now() < this.asyncCache!.ttlLeftBeforeRefreshInMsecs!) {
                 // Check if someone else didn't start refreshing while we were checking expiration time
                 groupSet = this.groupRefreshFlags.get(group)
@@ -54,6 +56,16 @@ export class GroupLoader<LoadedValue, LoadParams = string, LoadManyParams = Load
                   groupSet.add(key)
 
                   this.loadFromLoaders(key, group, loadParams)
+                    .then((freshValue) => {
+                      // Propagate the freshly loaded value to the in-memory cache as well.
+                      // Without this, the in-memory layer keeps serving the stale value that
+                      // was read from the async cache before this background refresh started,
+                      // and its TTL is reset on the next read, so subsequent reads stay stale
+                      // for another full ttlInMsecs window even though the async cache is fresh.
+                      if (freshValue !== undefined) {
+                        this.inMemoryCache.setForGroup(key, freshValue, group)
+                      }
+                    })
                     .catch((err) => {
                       this.logger.error(err.message)
                     })
@@ -66,6 +78,11 @@ export class GroupLoader<LoadedValue, LoadParams = string, LoadManyParams = Load
                 }
               }
             })
+              .catch((err) => {
+                // expiration lookup is fire-and-forget; a rejection here must not become
+                // an unhandled promise rejection
+                this.logger.error(err.message)
+              })
           }
         }
         return cachedValue

--- a/lib/Loader.ts
+++ b/lib/Loader.ts
@@ -114,7 +114,9 @@ export class Loader<LoadedValue, LoadParams = string, LoadManyParams = LoadParam
       if (cachedValue !== undefined) {
         if (this.asyncCache?.ttlLeftBeforeRefreshInMsecs) {
           if (!this.isKeyRefreshing.has(key)) {
-            this.asyncCache.expirationTimeLoadingOperation.get(key).then((expirationTime) => {
+            this.asyncCache.expirationTimeLoadingOperation
+              .get(key)
+              .then((expirationTime) => {
               if (expirationTime && expirationTime - Date.now() < this.asyncCache!.ttlLeftBeforeRefreshInMsecs!) {
                 // check second time, maybe someone obtained the lock while we were checking the expiration date
                 if (!this.isKeyRefreshing.has(key)) {
@@ -139,6 +141,11 @@ export class Loader<LoadedValue, LoadParams = string, LoadManyParams = LoadParam
                 }
               }
             })
+              .catch((err) => {
+                // expiration lookup is fire-and-forget; a rejection here must not become
+                // an unhandled promise rejection
+                this.logger.error(err.message)
+              })
           }
         }
 

--- a/lib/memory/InMemoryCache.ts
+++ b/lib/memory/InMemoryCache.ts
@@ -60,8 +60,9 @@ export class InMemoryCache<T> implements SynchronousCache<T> {
 
     for (let i = 0; i < keys.length; i++) {
       const resolvedValue = this.cache.get(keys[i])
-      if (resolvedValue) {
-        resolvedValues.push(resolvedValue)
+      // null is a valid cached value ("resolved to empty"), only undefined means a miss
+      if (resolvedValue !== undefined) {
+        resolvedValues.push(resolvedValue as T)
       } else {
         unresolvedKeys.push(keys[i])
       }

--- a/lib/memory/InMemoryGroupCache.ts
+++ b/lib/memory/InMemoryGroupCache.ts
@@ -77,19 +77,28 @@ export class InMemoryGroupCache<T> implements SynchronousGroupCache<T> {
   }
 
   getFromGroup(key: string, groupId: string) {
-    const group = this.resolveGroup(groupId)
-    return group.get(key)
+    // do not use resolveGroup here - reads must not insert empty groups into the LRU,
+    // or a miss on a nonexistent group could evict a real group's still-valid data
+    return this.groups.get(groupId)?.get(key)
   }
 
   getManyFromGroup(keys: string[], group: string): GetManyResult<T> {
     const resolvedValues: T[] = []
     const unresolvedKeys: string[] = []
-    const groupCache = this.resolveGroup(group)
+    const groupCache = this.groups.get(group)
+
+    if (!groupCache) {
+      return {
+        resolvedValues,
+        unresolvedKeys: [...keys],
+      }
+    }
 
     for (let i = 0; i < keys.length; i++) {
       const resolvedValue = groupCache.get(keys[i])
-      if (resolvedValue) {
-        resolvedValues.push(resolvedValue)
+      // null is a valid cached value ("resolved to empty"), only undefined means a miss
+      if (resolvedValue !== undefined) {
+        resolvedValues.push(resolvedValue as T)
       } else {
         unresolvedKeys.push(keys[i])
       }
@@ -107,8 +116,7 @@ export class InMemoryGroupCache<T> implements SynchronousGroupCache<T> {
   }
 
   deleteFromGroup(key: string, groupId: string): void {
-    const group = this.resolveGroup(groupId)
-    group.delete(key)
+    this.groups.get(groupId)?.delete(key)
   }
 
   clear(): void {
@@ -116,7 +124,6 @@ export class InMemoryGroupCache<T> implements SynchronousGroupCache<T> {
   }
 
   getExpirationTimeFromGroup(key: string, groupId: string): number | undefined {
-    const group = this.resolveGroup(groupId)
-    return group.expiresAt(key)
+    return this.groups.get(groupId)?.expiresAt(key)
   }
 }

--- a/lib/redis/RedisGroupCache.ts
+++ b/lib/redis/RedisGroupCache.ts
@@ -50,8 +50,11 @@ export class RedisGroupCache<T> extends AbstractRedisCache<RedisGroupCacheConfig
 
   async deleteGroup(group: string) {
     const key = this.resolveGroupIndexPrefix(group)
-    if (this.config.ttlInMsecs) {
-      await this.redis.multi().incr(key).pexpire(key, this.config.ttlInMsecs).exec()
+    // the group index key's lifetime is governed by groupTtlInMsecs everywhere else
+    // (see setForGroup/setManyForGroup); using entry ttlInMsecs here would silently
+    // re-scope the generation counter to the entry TTL
+    if (this.config.groupTtlInMsecs) {
+      await this.redis.multi().incr(key).pexpire(key, this.config.groupTtlInMsecs).exec()
       return
     }
 

--- a/lib/redis/RedisGroupNotificationConsumer.ts
+++ b/lib/redis/RedisGroupNotificationConsumer.ts
@@ -7,6 +7,7 @@ import type {
   GroupNotificationCommand,
 } from './RedisGroupNotificationPublisher'
 import type { RedisConsumerConfig } from './RedisNotificationConsumer'
+import { defaultLogger } from '../util/Logger'
 
 export class RedisGroupNotificationConsumer<LoadedValue> extends AbstractNotificationConsumer<
   LoadedValue,
@@ -41,7 +42,20 @@ export class RedisGroupNotificationConsumer<LoadedValue> extends AbstractNotific
   subscribe(): Promise<void> {
     return this.redis.subscribe(this.channel).then(() => {
       this.messageHandler = (channel, message) => {
-        const parsedMessage: GroupNotificationCommand = JSON.parse(message)
+        // ioredis emits 'message' for every channel the connection is subscribed to;
+        // without this check a shared consumer connection would cross-apply commands
+        // from other channels against this target cache
+        if (channel !== this.channel) {
+          return
+        }
+
+        let parsedMessage: GroupNotificationCommand
+        try {
+          parsedMessage = JSON.parse(message)
+        } catch (err) {
+          this.errorHandler(err as Error, this.channel, defaultLogger)
+          return
+        }
         // this is a local message, ignore
         if (parsedMessage.originUuid === this.serverUuid) {
           return

--- a/lib/redis/RedisNotificationConsumer.ts
+++ b/lib/redis/RedisNotificationConsumer.ts
@@ -1,6 +1,7 @@
 import type { Redis } from 'ioredis'
 import { AbstractNotificationConsumer } from '../notifications/AbstractNotificationConsumer'
 import type { SynchronousCache } from '../types/SyncDataSources'
+import { defaultLogger } from '../util/Logger'
 import type {
   DeleteManyNotificationCommand,
   DeleteNotificationCommand,
@@ -46,7 +47,20 @@ export class RedisNotificationConsumer<LoadedValue> extends AbstractNotification
   subscribe(): Promise<void> {
     return this.redis.subscribe(this.channel).then(() => {
       this.messageHandler = (channel, message) => {
-        const parsedMessage: NotificationCommand = JSON.parse(message)
+        // ioredis emits 'message' for every channel the connection is subscribed to;
+        // without this check a shared consumer connection would cross-apply commands
+        // from other channels against this target cache
+        if (channel !== this.channel) {
+          return
+        }
+
+        let parsedMessage: NotificationCommand
+        try {
+          parsedMessage = JSON.parse(message)
+        } catch (err) {
+          this.errorHandler(err as Error, this.channel, defaultLogger)
+          return
+        }
         // this is a local message, ignore
         if (parsedMessage.originUuid === this.serverUuid) {
           return

--- a/test/GroupLoader-async-refresh.spec.ts
+++ b/test/GroupLoader-async-refresh.spec.ts
@@ -214,6 +214,55 @@ describe('GroupLoader Async Refresh', () => {
       expect(expirationTimePost! > expirationTimePre!).toBe(true)
     })
 
+    it('two-layer cache propagates fresh value to in-memory after background refresh', async () => {
+      const loader = new CountingGroupedLoader(userValues)
+      const asyncCache = new RedisGroupCache<User>(redis, {
+        ttlInMsecs: 5000,
+        json: true,
+        ttlLeftBeforeRefreshInMsecs: 4500,
+      })
+
+      const operation = new GroupLoader<User>({
+        inMemoryCache: {
+          cacheId: 'two-layer-group-refresh',
+          cacheType: 'lru-object',
+          ttlInMsecs: 5000,
+          ttlLeftBeforeRefreshInMsecs: 4500,
+        },
+        asyncCache,
+        dataSources: [loader],
+      })
+
+      // Populates both layers with the initial value
+      expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+      expect(loader.counter).toBe(1)
+
+      // Source value changes
+      const updatedUser1: User = { ...user1, parametrized: 'updated' }
+      loader.groupValues![user1.companyId][user1.userId] = updatedUser1
+
+      // Wait until both layers' entries are within the refresh window
+      await setTimeout(600)
+
+      // SWR: returns stale value and triggers a background refresh
+      expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+
+      // Wait for the background refresh to actually call the data source
+      for (let attempt = 0; attempt < 20 && loader.counter < 2; attempt++) {
+        await setTimeout(10)
+      }
+      expect(loader.counter).toBe(2)
+
+      // Sanity check: Redis is now fresh
+      // @ts-expect-error
+      expect(await operation.asyncCache.getFromGroup(user1.userId, user1.companyId)).toEqual(
+        updatedUser1,
+      )
+
+      // The next read should observe the fresh value that the background refresh fetched
+      expect(await operation.get(user1.userId, user1.companyId)).toEqual(updatedUser1)
+    })
+
     it('cleans up groupRefreshFlags after background refresh completes', async () => {
       const loader = new CountingGroupedLoader(userValues)
       const asyncCache = new RedisGroupCache<User>(redis, {

--- a/test/GroupLoader-main.spec.ts
+++ b/test/GroupLoader-main.spec.ts
@@ -4,6 +4,7 @@ import type { CacheKeyResolver } from '../lib/AbstractCache'
 import { GroupLoader } from '../lib/GroupLoader'
 import type { InMemoryGroupCacheConfiguration } from '../lib/memory/InMemoryGroupCache'
 import { CountingGroupedLoader } from './fakes/CountingGroupedLoader'
+import { DelayedCountingGroupedLoader } from './fakes/DelayedCountingGroupedLoader'
 import type { DummyLoaderManyParams, DummyLoaderParams } from './fakes/DummyDataSourceWithParams'
 import { DummyGroupedCache } from './fakes/DummyGroupedCache'
 import { DummyGroupedDataSourceWithParams } from './fakes/DummyGroupedDataSourceWithParams'
@@ -872,6 +873,40 @@ describe('GroupLoader Main', () => {
       expect(valuePre).toEqual(user1)
       expect(valuePost).toEqual(user1)
       expect(loader2.counter).toBe(2)
+    })
+
+    it('is not undone by a load that was in flight when the key was invalidated', async () => {
+      const loader = new DelayedCountingGroupedLoader(userValues)
+
+      const operation = new GroupLoader<User>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        dataSources: [loader],
+      })
+
+      const loadPromise = operation.get(user1.userId, user1.companyId)
+      await operation.invalidateCacheFor(user1.userId, user1.companyId)
+      await loader.finishLoading()
+      expect(await loadPromise).toEqual(user1)
+
+      // the resolved in-flight load must not resurrect the invalidated entry
+      expect(operation.getInMemoryOnly(user1.userId, user1.companyId)).toBeUndefined()
+    })
+
+    it('is not undone by a load that was in flight when the group was invalidated', async () => {
+      const loader = new DelayedCountingGroupedLoader(userValues)
+
+      const operation = new GroupLoader<User>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        dataSources: [loader],
+      })
+
+      const loadPromise = operation.get(user1.userId, user1.companyId)
+      await operation.invalidateCacheForGroup(user1.companyId)
+      await loader.finishLoading()
+      expect(await loadPromise).toEqual(user1)
+
+      // the resolved in-flight load must not resurrect the invalidated entry
+      expect(operation.getInMemoryOnly(user1.userId, user1.companyId)).toBeUndefined()
     })
 
     it('correctly handles errors during invalidation', async () => {

--- a/test/Loader-main.spec.ts
+++ b/test/Loader-main.spec.ts
@@ -8,6 +8,7 @@ import type { InMemoryCacheConfiguration } from '../lib/memory/InMemoryCache'
 import { CountingDataSource } from './fakes/CountingDataSource'
 import { CountingRecordLoader } from './fakes/CountingRecordLoader'
 import { CountingTimedCache } from './fakes/CountingTimedCache'
+import { DelayedCountingLoader } from './fakes/DelayedCountingLoader'
 import { DummyCache } from './fakes/DummyCache'
 import { DummyDataSource } from './fakes/DummyDataSource'
 import {
@@ -1055,6 +1056,23 @@ describe('Loader Main', () => {
       expect(valuePost).toBe('value2')
       expect(loader.counter).toBe(1)
     })
+
+    it('is not overwritten by a load that was in flight when the value was set', async () => {
+      const loader = new DelayedCountingLoader('stale')
+
+      const operation = new Loader<string>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        dataSources: [loader],
+      })
+
+      const loadPromise = operation.get('key')
+      await operation.forceSetValue('key', 'fresh')
+      await loader.finishLoading()
+      expect(await loadPromise).toBe('stale')
+
+      expect(operation.getInMemoryOnly('key')).toBe('fresh')
+      expect(await operation.get('key')).toBe('fresh')
+    })
   })
 
   describe('invalidateCacheFor', () => {
@@ -1077,6 +1095,23 @@ describe('Loader Main', () => {
       expect(valuePre).toBe('value')
       expect(valuePost).toBe('value')
       expect(loader2.counter).toBe(2)
+    })
+
+    it('is not undone by a load that was in flight when the key was invalidated', async () => {
+      const loader = new DelayedCountingLoader('stale')
+
+      const operation = new Loader<string>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        dataSources: [loader],
+      })
+
+      const loadPromise = operation.get('key')
+      await operation.invalidateCacheFor('key')
+      await loader.finishLoading()
+      expect(await loadPromise).toBe('stale')
+
+      // the resolved in-flight load must not resurrect the invalidated entry
+      expect(operation.getInMemoryOnly('key')).toBeUndefined()
     })
 
     it('correctly handles errors during invalidation', async () => {

--- a/test/memory/InMemoryCache.spec.ts
+++ b/test/memory/InMemoryCache.spec.ts
@@ -147,6 +147,25 @@ describe('InMemoryCache', () => {
         resolvedValues: ['value', 'value2'],
       })
     })
+
+    it('resolves falsy and null cached values', () => {
+      const cache = new InMemoryCache<unknown>({
+        cacheId: 'dummy',
+        cacheType: 'lru-map',
+        maxItems: 5,
+        ttlInMsecs: 9999,
+      })
+      cache.set('zero', 0)
+      cache.set('emptyString', '')
+      cache.set('false', false)
+      cache.set('null', null)
+
+      const values = cache.getMany(['zero', 'emptyString', 'false', 'null', 'missing'])
+      expect(values).toEqual({
+        unresolvedKeys: ['missing'],
+        resolvedValues: [0, '', false, null],
+      })
+    })
   })
 
   describe('getExpirationTime', () => {

--- a/test/memory/InMemoryGroupCache.spec.ts
+++ b/test/memory/InMemoryGroupCache.spec.ts
@@ -130,6 +130,62 @@ describe('InMemoryCache', () => {
         resolvedValues: ['value', 'value2'],
       })
     })
+
+    it('resolves falsy and null cached values', () => {
+      const cache = new InMemoryGroupCache<unknown>({
+        maxGroups: 2,
+        ttlInMsecs: 9999,
+      })
+      cache.setForGroup('zero', 0, 'group')
+      cache.setForGroup('emptyString', '', 'group')
+      cache.setForGroup('false', false, 'group')
+      cache.setForGroup('null', null, 'group')
+
+      const values = cache.getManyFromGroup(
+        ['zero', 'emptyString', 'false', 'null', 'missing'],
+        'group',
+      )
+      expect(values).toEqual({
+        unresolvedKeys: ['missing'],
+        resolvedValues: [0, '', false, null],
+      })
+    })
+
+    it('returns all keys as unresolved for a nonexistent group', () => {
+      const cache = new InMemoryGroupCache({
+        maxGroups: 2,
+        ttlInMsecs: 9999,
+      })
+
+      const values = cache.getManyFromGroup(['key', 'key2'], 'no-such-group')
+      expect(values).toEqual({
+        unresolvedKeys: ['key', 'key2'],
+        resolvedValues: [],
+      })
+    })
+  })
+
+  describe('read operations on nonexistent groups', () => {
+    it('do not evict existing groups from the groups cache', () => {
+      const cache = new InMemoryGroupCache({
+        maxGroups: 2,
+        ttlInMsecs: 9999,
+      })
+      cache.setForGroup('key', 'value1', 'group1')
+      cache.setForGroup('key', 'value2', 'group2')
+
+      // each of these reads used to insert an empty group, evicting a populated one
+      expect(cache.getFromGroup('key', 'group3')).toBeUndefined()
+      expect(cache.getManyFromGroup(['key'], 'group4')).toEqual({
+        resolvedValues: [],
+        unresolvedKeys: ['key'],
+      })
+      expect(cache.getExpirationTimeFromGroup('key', 'group5')).toBeUndefined()
+      cache.deleteFromGroup('key', 'group6')
+
+      expect(cache.getFromGroup('key', 'group1')).toBe('value1')
+      expect(cache.getFromGroup('key', 'group2')).toBe('value2')
+    })
   })
 
   describe('getExpirationTimeFromGroup', () => {

--- a/test/redis/RedisGroupCache.spec.ts
+++ b/test/redis/RedisGroupCache.spec.ts
@@ -309,6 +309,43 @@ describe('RedisGroupCache', () => {
     })
   })
 
+  describe('deleteGroup', () => {
+    it('invalidates existing group entries', async () => {
+      const cache = new RedisGroupCache(redis, { ttlInMsecs: 9999 })
+      await cache.setForGroup('key', 'value', 'group')
+
+      await cache.deleteGroup('group')
+
+      expect(await cache.getFromGroup('key', 'group')).toBeUndefined()
+    })
+
+    it('expires the group index with groupTtlInMsecs, not the entry ttl', async () => {
+      const cache = new RedisGroupCache(redis, {
+        ttlInMsecs: 500,
+        groupTtlInMsecs: 60000,
+      })
+      await cache.setForGroup('key', 'value', 'group')
+
+      await cache.deleteGroup('group')
+
+      const indexTtl = await redis.pttl(cache.resolveGroupIndexPrefix('group'))
+      // the group index counter must live as long as groupTtlInMsecs dictates;
+      // scoping it to the entry ttl would let the counter expire and reset early
+      expect(indexTtl).toBeGreaterThan(500)
+      expect(indexTtl).toBeLessThanOrEqual(60000)
+    })
+
+    it('does not expire the group index when groupTtlInMsecs is not set', async () => {
+      const cache = new RedisGroupCache(redis, { ttlInMsecs: 500 })
+      await cache.setForGroup('key', 'value', 'group')
+
+      await cache.deleteGroup('group')
+
+      const indexTtl = await redis.pttl(cache.resolveGroupIndexPrefix('group'))
+      expect(indexTtl).toBe(-1) // no TTL, consistent with setForGroup
+    })
+  })
+
   describe('clear', () => {
     it('clears values', async () => {
       const cache = new RedisGroupCache(redis)

--- a/test/redis/RedisNotificationPublisher.spec.ts
+++ b/test/redis/RedisNotificationPublisher.spec.ts
@@ -469,6 +469,101 @@ describe('RedisNotificationPublisher', () => {
     expect(redisConsumer.listenerCount('message')).toBe(0)
   })
 
+  it('Ignores messages from other channels on a shared consumer connection', async () => {
+    const { publisher: notificationPublisherA, consumer: notificationConsumerA } =
+      createNotificationPair<string>({
+        channel: 'channel_a',
+        consumerRedis: redisConsumer,
+        publisherRedis: redisPublisher,
+      })
+
+    const { publisher: notificationPublisherB, consumer: notificationConsumerB } =
+      createNotificationPair<string>({
+        channel: 'channel_b',
+        consumerRedis: redisConsumer,
+        publisherRedis: redisPublisher,
+      })
+
+    const operationA = new Loader<string>({
+      inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+      asyncCache: new DummyCache('value'),
+      notificationConsumer: notificationConsumerA,
+      notificationPublisher: notificationPublisherA,
+    })
+    const operationB = new Loader<string>({
+      inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+      asyncCache: new DummyCache('value'),
+      notificationConsumer: notificationConsumerB,
+      notificationPublisher: notificationPublisherB,
+    })
+    await operationA.init()
+    await operationB.init()
+
+    await operationA.getAsyncOnly('key')
+    await operationB.getAsyncOnly('key')
+    expect(operationA.getInMemoryOnly('key')).toBe('value')
+    expect(operationB.getInMemoryOnly('key')).toBe('value')
+
+    // Publish a DELETE on channel_a only, from a foreign origin
+    await redisPublisher.publish(
+      'channel_a',
+      JSON.stringify({
+        actionId: 'DELETE',
+        key: 'key',
+        originUuid: 'different-uuid',
+      }),
+    )
+
+    // consumer A must apply it...
+    await waitAndRetry(() => operationA.getInMemoryOnly('key') === undefined, 50, 100)
+    expect(operationA.getInMemoryOnly('key')).toBeUndefined()
+
+    // ...but consumer B, sharing the same Redis connection on another channel, must not
+    expect(operationB.getInMemoryOnly('key')).toBe('value')
+
+    await notificationConsumerA.close()
+    await notificationPublisherA.close()
+  })
+
+  it('Survives malformed messages', async () => {
+    const { publisher: notificationPublisher1, consumer: notificationConsumer1 } =
+      createNotificationPair<string>({
+        channel: CHANNEL_ID,
+        consumerRedis: redisConsumer,
+        publisherRedis: redisPublisher,
+      })
+
+    const operation = new Loader<string>({
+      inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+      asyncCache: new DummyCache('value'),
+      notificationConsumer: notificationConsumer1,
+      notificationPublisher: notificationPublisher1,
+    })
+    await operation.init()
+
+    const resultPre = await operation.get('key')
+    expect(resultPre).toBe('value')
+
+    // A non-JSON payload must not crash the consumer
+    await redisPublisher.publish(CHANNEL_ID, 'this is not json')
+
+    // A valid message afterwards must still be processed
+    await redisPublisher.publish(
+      CHANNEL_ID,
+      JSON.stringify({
+        actionId: 'DELETE',
+        key: 'key',
+        originUuid: 'different-uuid',
+      }),
+    )
+
+    await waitAndRetry(() => operation.getInMemoryOnly('key') === undefined, 50, 100)
+    expect(operation.getInMemoryOnly('key')).toBeUndefined()
+
+    await notificationConsumer1.close()
+    await notificationPublisher1.close()
+  })
+
   it('Handles error by default', async () => {
     expect.assertions(1)
     const { publisher: notificationPublisher, consumer: notificationConsumer } =


### PR DESCRIPTION
- InMemoryCache.getMany / InMemoryGroupCache.getManyFromGroup treated
  cached falsy values (0, '', false, null) as unresolved due to a truthy
  check, re-loading them from lower layers on every call; use an
  undefined check instead, consistent with single get and RedisCache
- InMemoryGroupCache read operations (getFromGroup, getManyFromGroup,
  getExpirationTimeFromGroup, deleteFromGroup) inserted an empty group
  into the LRU groups cache on miss, which could evict a populated
  group's still-valid data; reads no longer create groups
- GroupLoader background refresh never propagated the freshly loaded
  value to the in-memory cache, so it kept serving the stale value for
  another full TTL window; mirror the fix already present in Loader
- getAsyncOnly in AbstractFlatCache/AbstractGroupCache unconditionally
  wrote the loaded value to the in-memory cache when the load settled,
  clobbering a concurrent set()/forceSetValue()/invalidation; the write
  now only happens if the load still owns the runningLoads entry
- preemptive-refresh expiration lookups in Loader/GroupLoader were
  fire-and-forget without a .catch, turning async-cache errors into
  unhandled promise rejections
- RedisGroupCache.deleteGroup expired the group index with ttlInMsecs
  instead of groupTtlInMsecs, inconsistent with setForGroup and
  setManyForGroup
- Redis notification consumers applied messages from every channel on
  a shared connection and crashed on malformed payloads; filter by
  channel and guard JSON.parse

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Mq9YdTczCiMiy6fxHzzxst