### PR TITLE
Add optional staleness checker for conditional cache refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## Unreleased
+
+### Added
+
+- Optional `isEntryStillCurrentFn` staleness checker for conditional cache refresh. When a cached
+  entry enters the `ttlLeftBeforeRefreshInMsecs` window, the loader can run a lightweight freshness
+  check instead of unconditionally refetching, and reset the entry's TTL when it is still current.
+  Backed by new optional `resetTtl` / `resetTtlFromGroup` cache methods (implemented by `RedisCache`
+  and `RedisGroupCache`). See the README section "Conditional refresh with a staleness check".
+- `GroupLoader.forceSetValueForGroup`, the group counterpart to `Loader.forceSetValue`.
+
+### Changed
+
+- `GroupLoader` now propagates the value fetched during a preemptive background refresh into the
+  in-memory group cache, matching `Loader`'s existing behavior. Previously the in-memory group layer
+  kept serving the pre-refresh value until its own TTL expired. This affects every two-layer
+  `GroupLoader` setup that has `ttlLeftBeforeRefreshInMsecs` configured, independently of whether the
+  new `isEntryStillCurrentFn` option is used.

--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ Loader has the following config parameters:
 - `loadErrorHandler: LoaderErrorHandler` - error handler to use when non-last data source throws an error during data retrieval.
 - `cacheKeyFromLoadParamsResolver: CacheKeyResolver<LoadParams>` - mapper from LoadParams to a cache key. Defaults to a simple string passthrough when LoadParams are just a string key to begin with (which is the default)
 - `cacheKeyFromValueResolver: CacheKeyResolver<LoadParams>` - mapper from entity to be cached to a cache key. Defaults to a dummy resolver which throws an error when methods that depend on it are used. Make sure to provide a real resolver if you are using the bulk API (getMany/getManyFromGroup)
+- `isEntryStillCurrentFn` - optional lightweight staleness check that lets an entry entering the refresh window bump its TTL instead of refetching. See [Conditional refresh with a staleness check](#conditional-refresh-with-a-staleness-check).
 
 Loader provides following methods:
 
@@ -632,6 +633,12 @@ In certain cases you may want to explicitly store a specific value in all of you
 ```ts
 // This will set the value of all configured caches for the key "1" to a value "newValue", and fire a NotificationPublisher set value command, if publisher is set  
 await cache.forceSetValue('1', 'newValue')
+```
+
+For a `GroupLoader` use `forceSetValueForGroup`, which takes the extra `group` argument. Note that group notification publishers only broadcast deletions, so no set command is published; other nodes converge via their own TTL expiry.
+
+```ts
+await groupCache.forceSetValueForGroup('1', 'newValue', 'group1')
 ```
 
 ## Usage in high-performance systems

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ You can watch [NodeConf EU 2023 talk](https://www.youtube.com/watch?v=O0Nk3XhxxY
 - [Usage in high-performance systems](#usage-in-high-performance-systems)
   - [Synchronous short-circuit](#synchronous-short-circuit)
   - [Preemptive background refresh](#preemptive-background-refresh)
+  - [Conditional refresh with a staleness check](#conditional-refresh-with-a-staleness-check)
 - [Group operations](#group-operations)
 - [Provided async caches](#provided-async-caches)
   - [RedisCache](#rediscache)
@@ -699,6 +700,55 @@ const asyncCache = new RedisCache<string>(redis, {
 
 Note that there is overhead involved in performing refresh checks (especially for Redis). Always measure performance before and after enabling preemptive refresh in order to determine, whether it improves or worsens the performance of your system.
 Bulk operations (`getMany()`) do not support preemptive background refresh.
+
+### Conditional refresh with a staleness check
+
+If refetching an entry is expensive, but *verifying* that it is still up-to-date is cheap (e. g. comparing an `updatedAt` timestamp, a version column or a content hash), you can avoid unnecessary refetches by providing `isEntryStillCurrentFn`. This is the loader-level equivalent of HTTP conditional revalidation (`ETag` / `If-Modified-Since`).
+
+When an entry enters the `ttlLeftBeforeRefreshInMsecs` window, the loader first invokes your check with the cached value instead of immediately starting a full background refresh:
+
+- if it resolves to `true`, the entry's TTL is reset to the full `ttlInMsecs` in both the async cache and the in-memory cache, and no data source call is made;
+- if it resolves to `false` (or throws, or the entry disappeared in the meantime), the usual full background refresh from the data sources runs.
+
+```ts
+const operation = new Loader<UserEntity>({
+  asyncCache: new RedisCache<UserEntity>(redis, {
+    json: true,
+    ttlInMsecs: 1000 * 60,
+    ttlLeftBeforeRefreshInMsecs: 1000 * 20,
+  }),
+  dataSources: [expensiveUserDataSource],
+  isEntryStillCurrentFn: async (cachedValue, loadParams) => {
+    // light query instead of refetching the whole entity
+    const updatedAt = await getUserUpdatedAt(loadParams)
+    return updatedAt.getTime() === new Date(cachedValue!.updatedAt).getTime()
+  },
+})
+```
+
+For `GroupLoader` the check additionally receives the group:
+
+```ts
+const operation = new GroupLoader<UserEntity>({
+  asyncCache: new RedisGroupCache<UserEntity>(redis, {
+    json: true,
+    ttlInMsecs: 1000 * 60,
+    ttlLeftBeforeRefreshInMsecs: 1000 * 20,
+  }),
+  dataSources: [expensiveUserDataSource],
+  isEntryStillCurrentFn: async (cachedValue, loadParams, group) => {
+    const updatedAt = await getUserUpdatedAt(loadParams, group)
+    return updatedAt.getTime() === new Date(cachedValue!.updatedAt).getTime()
+  },
+})
+```
+
+Things to keep in mind:
+
+- `isEntryStillCurrentFn` requires an `asyncCache` that implements `resetTtl` (`resetTtlFromGroup` for group caches). `RedisCache` and `RedisGroupCache` do; if you implement the `Cache` interface yourself, add the method to support conditional refresh.
+- Errors thrown by the check are routed to `loadErrorHandler` and treated as "stale", so the worst case degrades to a regular full background refresh.
+- Staleness checks are deduplicated the same way background refreshes are - only one check runs per key at a time, and `ttlCacheTtl` limits how often expiration times are read from Redis.
+- No update notifications are published when a TTL is merely bumped, since the data has not changed; in-memory copies on other nodes expire on their own schedule and re-read the shared cache.
 
 ## Group operations
 

--- a/README.md
+++ b/README.md
@@ -745,7 +745,7 @@ const operation = new GroupLoader<UserEntity>({
 
 Things to keep in mind:
 
-- `isEntryStillCurrentFn` requires an `asyncCache` that implements `resetTtl` (`resetTtlFromGroup` for group caches). `RedisCache` and `RedisGroupCache` do; if you implement the `Cache` interface yourself, add the method to support conditional refresh.
+- `isEntryStillCurrentFn` requires an `asyncCache` that has `ttlLeftBeforeRefreshInMsecs` configured (the check only runs inside that refresh window) and implements `resetTtl` (`resetTtlFromGroup` for group caches). `RedisCache` and `RedisGroupCache` implement the reset method; if you implement the `Cache` interface yourself, add the method to support conditional refresh. The loader throws at construction time if either requirement is missing.
 - Errors thrown by the check are routed to `loadErrorHandler` and treated as "stale", so the worst case degrades to a regular full background refresh.
 - Staleness checks are deduplicated the same way background refreshes are - only one check runs per key at a time, and `ttlCacheTtl` limits how often expiration times are read from Redis.
 - No update notifications are published when a TTL is merely bumped, since the data has not changed; in-memory copies on other nodes expire on their own schedule and re-read the shared cache.

--- a/README.md
+++ b/README.md
@@ -749,6 +749,8 @@ Things to keep in mind:
 - Errors thrown by the check are routed to `loadErrorHandler` and treated as "stale", so the worst case degrades to a regular full background refresh.
 - Staleness checks are deduplicated the same way background refreshes are - only one check runs per key at a time, and `ttlCacheTtl` limits how often expiration times are read from Redis.
 - No update notifications are published when a TTL is merely bumped, since the data has not changed; in-memory copies on other nodes expire on their own schedule and re-read the shared cache.
+- The check receives the value exactly as the async cache returns it. `RedisCache` / `RedisGroupCache` with `json: true` store an explicitly cached `null` as an empty string, so a null entry is passed to the check as `''`, not `null`. If you cache null values, handle that representation in your check.
+- A successful TTL bump extends only the entry, not the group index. Like adding entries to a group, it does not reset `groupTtlInMsecs`, so a bumped entry still becomes inaccessible once its group index expires and is reloaded from the data sources on the next read.
 
 ## Group operations
 

--- a/index.ts
+++ b/index.ts
@@ -42,6 +42,8 @@ export type {
   GroupDataSource,
   Cache,
   CommonCacheConfiguration,
+  IsEntryStillCurrentFn,
+  IsGroupEntryStillCurrentFn,
 } from './lib/types/DataSources'
 export type { Logger, LogFn } from './lib/util/Logger'
 

--- a/lib/AbstractCache.ts
+++ b/lib/AbstractCache.ts
@@ -170,6 +170,7 @@ export abstract class AbstractCache<
    */
   protected assertStalenessCheckSupported(
     isEntryStillCurrentFn: unknown,
+    resetTtlMethod: unknown,
     resetTtlMethodName: 'resetTtl' | 'resetTtlFromGroup',
   ): void {
     if (!isEntryStillCurrentFn) {
@@ -180,7 +181,7 @@ export abstract class AbstractCache<
         'isEntryStillCurrentFn requires an asyncCache - the staleness check only applies to the async cache preemptive refresh path.',
       )
     }
-    if (typeof (this.asyncCache as unknown as Record<string, unknown>)[resetTtlMethodName] !== 'function') {
+    if (typeof resetTtlMethod !== 'function') {
       throw new Error(
         `The configured asyncCache does not support ${resetTtlMethodName}, which is required by isEntryStillCurrentFn.`,
       )
@@ -190,6 +191,37 @@ export abstract class AbstractCache<
         'isEntryStillCurrentFn requires the asyncCache to have ttlLeftBeforeRefreshInMsecs configured - the staleness check only runs inside the preemptive refresh window.',
       )
     }
+  }
+
+  /**
+   * Runs the staleness check for an entry entering its refresh window and, when the check reports
+   * the entry as still current, extends its async cache TTL instead of refetching. Returns true
+   * only when the entry was confirmed current AND its TTL was successfully bumped, so the caller
+   * can safely skip the full background refresh. A check that throws is routed to loadErrorHandler
+   * and treated as stale; a bump that rejects is routed to cacheUpdateErrorHandler and also treated
+   * as stale, so the worst case degrades to a normal full refresh.
+   */
+  protected async isCurrentEntryTtlBumped(
+    key: string,
+    runStalenessCheck: () => Promise<boolean>,
+    runResetTtl: () => Promise<boolean>,
+  ): Promise<boolean> {
+    let isCurrent = false
+    try {
+      isCurrent = await runStalenessCheck()
+    } catch (err) {
+      // a failing check cannot confirm freshness, so fall through to a full refresh
+      this.loadErrorHandler(err as Error, key, { name: 'isEntryStillCurrentFn' }, this.logger)
+    }
+
+    if (!isCurrent) {
+      return false
+    }
+
+    return runResetTtl().catch((err) => {
+      this.cacheUpdateErrorHandler(err, key, this.asyncCache!, this.logger)
+      return false
+    })
   }
 
   public async invalidateCache() {

--- a/lib/AbstractCache.ts
+++ b/lib/AbstractCache.ts
@@ -162,6 +162,36 @@ export abstract class AbstractCache<
     this.initPromises = []
   }
 
+  /**
+   * Validates that an isEntryStillCurrentFn can actually run: it needs an asyncCache that has a
+   * refresh window configured (the check only fires inside it) and exposes the TTL-reset method
+   * used to bump the entry. Throws otherwise, so misconfiguration fails fast instead of silently
+   * turning the feature into a no-op.
+   */
+  protected assertStalenessCheckSupported(
+    isEntryStillCurrentFn: unknown,
+    resetTtlMethodName: 'resetTtl' | 'resetTtlFromGroup',
+  ): void {
+    if (!isEntryStillCurrentFn) {
+      return
+    }
+    if (!this.asyncCache) {
+      throw new Error(
+        'isEntryStillCurrentFn requires an asyncCache - the staleness check only applies to the async cache preemptive refresh path.',
+      )
+    }
+    if (typeof (this.asyncCache as unknown as Record<string, unknown>)[resetTtlMethodName] !== 'function') {
+      throw new Error(
+        `The configured asyncCache does not support ${resetTtlMethodName}, which is required by isEntryStillCurrentFn.`,
+      )
+    }
+    if (!this.asyncCache.ttlLeftBeforeRefreshInMsecs) {
+      throw new Error(
+        'isEntryStillCurrentFn requires the asyncCache to have ttlLeftBeforeRefreshInMsecs configured - the staleness check only runs inside the preemptive refresh window.',
+      )
+    }
+  }
+
   public async invalidateCache() {
     this.inMemoryCache.clear()
     if (this.asyncCache) {

--- a/lib/GroupLoader.ts
+++ b/lib/GroupLoader.ts
@@ -27,14 +27,7 @@ export class GroupLoader<LoadedValue, LoadParams = string, LoadManyParams = Load
     super(config)
     this.dataSources = config.dataSources ?? []
 
-    if (config.isEntryStillCurrentFn) {
-      if (!config.asyncCache) {
-        throw new Error('isEntryStillCurrentFn requires an asyncCache - the staleness check only applies to the async cache preemptive refresh path.')
-      }
-      if (typeof config.asyncCache.resetTtlFromGroup !== 'function') {
-        throw new Error('The configured asyncCache does not support resetTtlFromGroup, which is required by isEntryStillCurrentFn.')
-      }
-    }
+    this.assertStalenessCheckSupported(config.isEntryStillCurrentFn, 'resetTtlFromGroup')
     this.isEntryStillCurrentFn = config.isEntryStillCurrentFn
 
     this.throwIfLoadError = config.throwIfLoadError ?? true
@@ -109,15 +102,23 @@ export class GroupLoader<LoadedValue, LoadParams = string, LoadManyParams = Load
           return false
         })
         if (isTtlBumped) {
-          // re-set to reset the in-memory TTL as well; toad-cache has no touch operation
-          this.inMemoryCache.setForGroup(key, cachedValue, group)
+          // getAsyncOnly already re-set the in-memory entry to this same value when resolveGroupValue
+          // resolved, which reset its TTL; the value is unchanged on a bump, so nothing else to do.
           return
         }
         // the entry expired or its group was invalidated between the read and the bump, fall through to a full refresh
       }
     }
 
-    await this.loadFromLoaders(key, group, loadParams)
+    const freshValue = await this.loadFromLoaders(key, group, loadParams)
+    // Propagate the freshly loaded value to the in-memory group cache as well.
+    // Without this, the in-memory layer keeps serving the stale value that
+    // was read from the async cache before this background refresh started,
+    // and its TTL is reset on the next read, so subsequent reads stay stale
+    // for another full ttlInMsecs window even though the async cache is fresh.
+    if (freshValue !== undefined) {
+      this.inMemoryCache.setForGroup(key, freshValue, group)
+    }
   }
 
   protected override async resolveManyGroupValues(

--- a/lib/GroupLoader.ts
+++ b/lib/GroupLoader.ts
@@ -123,6 +123,7 @@ export class GroupLoader<LoadedValue, LoadParams = string, LoadManyParams = Load
 
     if (this.asyncCache) {
       await this.asyncCache.setForGroup(key, newValue, group).catch((err) => {
+        /* v8 ignore next -- @preserve */
         this.cacheUpdateErrorHandler(err, key, this.asyncCache!, this.logger)
       })
     }

--- a/lib/GroupLoader.ts
+++ b/lib/GroupLoader.ts
@@ -2,7 +2,7 @@ import { AbstractGroupCache } from './AbstractGroupCache'
 import type { LoaderConfig } from './Loader'
 import type { InMemoryGroupCache, InMemoryGroupCacheConfiguration } from './memory/InMemoryGroupCache'
 import type { GroupNotificationPublisher } from './notifications/GroupNotificationPublisher'
-import type { CacheEntry, GroupCache, GroupDataSource } from './types/DataSources'
+import type { CacheEntry, GroupCache, GroupDataSource, IsGroupEntryStillCurrentFn } from './types/DataSources'
 import type { GetManyResult } from './types/SyncDataSources'
 
 export type GroupLoaderConfig<LoadedValue, LoadParams = string, LoadManyParams = LoadParams> = LoaderConfig<
@@ -13,17 +13,30 @@ export type GroupLoaderConfig<LoadedValue, LoadParams = string, LoadManyParams =
   GroupDataSource<LoadedValue, LoadParams, LoadManyParams>,
   InMemoryGroupCacheConfiguration,
   InMemoryGroupCache<LoadedValue>,
-  GroupNotificationPublisher<LoadedValue>
+  GroupNotificationPublisher<LoadedValue>,
+  IsGroupEntryStillCurrentFn<LoadedValue, LoadParams>
 >
 export class GroupLoader<LoadedValue, LoadParams = string, LoadManyParams = LoadParams extends string ? undefined : LoadParams> extends AbstractGroupCache<LoadedValue, LoadParams, LoadManyParams> {
   private readonly dataSources: readonly GroupDataSource<LoadedValue, LoadParams, LoadManyParams>[]
   private readonly groupRefreshFlags: Map<string, Set<string>>
+  private readonly isEntryStillCurrentFn?: IsGroupEntryStillCurrentFn<LoadedValue, LoadParams>
   protected readonly throwIfLoadError: boolean
   protected readonly throwIfUnresolved: boolean
 
   constructor(config: GroupLoaderConfig<LoadedValue, LoadParams, LoadManyParams>) {
     super(config)
     this.dataSources = config.dataSources ?? []
+
+    if (config.isEntryStillCurrentFn) {
+      if (!config.asyncCache) {
+        throw new Error('isEntryStillCurrentFn requires an asyncCache - the staleness check only applies to the async cache preemptive refresh path.')
+      }
+      if (typeof config.asyncCache.resetTtlFromGroup !== 'function') {
+        throw new Error('The configured asyncCache does not support resetTtlFromGroup, which is required by isEntryStillCurrentFn.')
+      }
+    }
+    this.isEntryStillCurrentFn = config.isEntryStillCurrentFn
+
     this.throwIfLoadError = config.throwIfLoadError ?? true
     this.throwIfUnresolved = config.throwIfUnresolved ?? false
     this.groupRefreshFlags = new Map()
@@ -53,7 +66,7 @@ export class GroupLoader<LoadedValue, LoadParams = string, LoadManyParams = Load
                   }
                   groupSet.add(key)
 
-                  this.loadFromLoaders(key, group, loadParams)
+                  this.refreshOrBumpTtl(key, group, loadParams, cachedValue)
                     .catch((err) => {
                       this.logger.error(err.message)
                     })
@@ -73,6 +86,38 @@ export class GroupLoader<LoadedValue, LoadParams = string, LoadManyParams = Load
 
       return this.loadFromLoaders(key, group, loadParams)
     })
+  }
+
+  private async refreshOrBumpTtl(
+    key: string,
+    group: string,
+    loadParams: LoadParams,
+    cachedValue: LoadedValue | null,
+  ): Promise<void> {
+    if (this.isEntryStillCurrentFn) {
+      let isCurrent = false
+      try {
+        isCurrent = await this.isEntryStillCurrentFn(cachedValue, loadParams, group)
+      } catch (err) {
+        // a failing check cannot confirm freshness, so fall through to a full refresh
+        this.loadErrorHandler(err as Error, key, { name: 'isEntryStillCurrentFn' }, this.logger)
+      }
+
+      if (isCurrent) {
+        const isTtlBumped = await this.asyncCache!.resetTtlFromGroup!(key, group).catch((err) => {
+          this.cacheUpdateErrorHandler(err, key, this.asyncCache!, this.logger)
+          return false
+        })
+        if (isTtlBumped) {
+          // re-set to reset the in-memory TTL as well; toad-cache has no touch operation
+          this.inMemoryCache.setForGroup(key, cachedValue, group)
+          return
+        }
+        // the entry expired or its group was invalidated between the read and the bump, fall through to a full refresh
+      }
+    }
+
+    await this.loadFromLoaders(key, group, loadParams)
   }
 
   protected override async resolveManyGroupValues(

--- a/lib/GroupLoader.ts
+++ b/lib/GroupLoader.ts
@@ -27,7 +27,11 @@ export class GroupLoader<LoadedValue, LoadParams = string, LoadManyParams = Load
     super(config)
     this.dataSources = config.dataSources ?? []
 
-    this.assertStalenessCheckSupported(config.isEntryStillCurrentFn, 'resetTtlFromGroup')
+    this.assertStalenessCheckSupported(
+      config.isEntryStillCurrentFn,
+      this.asyncCache?.resetTtlFromGroup,
+      'resetTtlFromGroup',
+    )
     this.isEntryStillCurrentFn = config.isEntryStillCurrentFn
 
     this.throwIfLoadError = config.throwIfLoadError ?? true
@@ -87,29 +91,21 @@ export class GroupLoader<LoadedValue, LoadParams = string, LoadManyParams = Load
     loadParams: LoadParams,
     cachedValue: LoadedValue | null,
   ): Promise<void> {
-    if (this.isEntryStillCurrentFn) {
-      let isCurrent = false
-      try {
-        isCurrent = await this.isEntryStillCurrentFn(cachedValue, loadParams, group)
-      } catch (err) {
-        // a failing check cannot confirm freshness, so fall through to a full refresh
-        this.loadErrorHandler(err as Error, key, { name: 'isEntryStillCurrentFn' }, this.logger)
-      }
-
-      if (isCurrent) {
-        const isTtlBumped = await this.asyncCache!.resetTtlFromGroup!(key, group).catch((err) => {
-          this.cacheUpdateErrorHandler(err, key, this.asyncCache!, this.logger)
-          return false
-        })
-        if (isTtlBumped) {
-          // getAsyncOnly already re-set the in-memory entry to this same value when resolveGroupValue
-          // resolved, which reset its TTL; the value is unchanged on a bump, so nothing else to do.
-          return
-        }
-        // the entry expired or its group was invalidated between the read and the bump, fall through to a full refresh
-      }
+    if (
+      this.isEntryStillCurrentFn &&
+      (await this.isCurrentEntryTtlBumped(
+        key,
+        () => this.isEntryStillCurrentFn!(cachedValue, loadParams, group),
+        () => this.asyncCache!.resetTtlFromGroup!(key, group),
+      ))
+    ) {
+      // getAsyncOnly already re-set the in-memory entry to this same value when resolveGroupValue
+      // resolved, which reset its TTL; the value is unchanged on a bump, so nothing else to do.
+      return
     }
 
+    // The entry is stale, the check failed, or the bump failed (entry expired or the group was
+    // invalidated meanwhile), so run the full background refresh from the data sources.
     const freshValue = await this.loadFromLoaders(key, group, loadParams)
     // Propagate the freshly loaded value to the in-memory group cache as well.
     // Without this, the in-memory layer keeps serving the stale value that
@@ -119,6 +115,19 @@ export class GroupLoader<LoadedValue, LoadParams = string, LoadManyParams = Load
     if (freshValue !== undefined) {
       this.inMemoryCache.setForGroup(key, freshValue, group)
     }
+  }
+
+  public async forceSetValueForGroup(key: string, newValue: LoadedValue | null, group: string) {
+    this.inMemoryCache.setForGroup(key, newValue, group)
+    this.deleteGroupRunningLoad(this.resolveGroupLoads(group), group, key)
+
+    if (this.asyncCache) {
+      await this.asyncCache.setForGroup(key, newValue, group).catch((err) => {
+        this.cacheUpdateErrorHandler(err, key, this.asyncCache!, this.logger)
+      })
+    }
+    // GroupNotificationPublisher only broadcasts deletions, so there is no set notification to
+    // publish here; other nodes converge via their own TTL expiry, same as setForGroup.
   }
 
   protected override async resolveManyGroupValues(

--- a/lib/Loader.ts
+++ b/lib/Loader.ts
@@ -67,7 +67,7 @@ export class Loader<LoadedValue, LoadParams = string, LoadManyParams = LoadParam
       this.dataSources = []
     }
 
-    this.assertStalenessCheckSupported(config.isEntryStillCurrentFn, 'resetTtl')
+    this.assertStalenessCheckSupported(config.isEntryStillCurrentFn, this.asyncCache?.resetTtl, 'resetTtl')
     this.isEntryStillCurrentFn = config.isEntryStillCurrentFn
 
     this.throwIfLoadError = config.throwIfLoadError ?? true
@@ -147,29 +147,21 @@ export class Loader<LoadedValue, LoadParams = string, LoadManyParams = LoadParam
   }
 
   private async refreshOrBumpTtl(key: string, loadParams: LoadParams, cachedValue: LoadedValue | null): Promise<void> {
-    if (this.isEntryStillCurrentFn) {
-      let isCurrent = false
-      try {
-        isCurrent = await this.isEntryStillCurrentFn(cachedValue, loadParams)
-      } catch (err) {
-        // a failing check cannot confirm freshness, so fall through to a full refresh
-        this.loadErrorHandler(err as Error, key, { name: 'isEntryStillCurrentFn' }, this.logger)
-      }
-
-      if (isCurrent) {
-        const isTtlBumped = await this.asyncCache!.resetTtl!(key).catch((err) => {
-          this.cacheUpdateErrorHandler(err, key, this.asyncCache!, this.logger)
-          return false
-        })
-        if (isTtlBumped) {
-          // getAsyncOnly already re-set the in-memory entry to this same value when resolveValue
-          // resolved, which reset its TTL; the value is unchanged on a bump, so nothing else to do.
-          return
-        }
-        // the entry expired or was deleted between the read and the bump, fall through to a full refresh
-      }
+    if (
+      this.isEntryStillCurrentFn &&
+      (await this.isCurrentEntryTtlBumped(
+        key,
+        () => this.isEntryStillCurrentFn!(cachedValue, loadParams),
+        () => this.asyncCache!.resetTtl!(key),
+      ))
+    ) {
+      // getAsyncOnly already re-set the in-memory entry to this same value when resolveValue
+      // resolved, which reset its TTL; the value is unchanged on a bump, so nothing else to do.
+      return
     }
 
+    // The entry is stale, the check failed, or the bump failed (entry expired/deleted meanwhile),
+    // so run the full background refresh from the data sources.
     const freshValue = await this.loadFromLoaders(key, loadParams)
     // Propagate the freshly loaded value to the in-memory cache as well.
     // Without this, the in-memory layer keeps serving the stale value that

--- a/lib/Loader.ts
+++ b/lib/Loader.ts
@@ -67,14 +67,7 @@ export class Loader<LoadedValue, LoadParams = string, LoadManyParams = LoadParam
       this.dataSources = []
     }
 
-    if (config.isEntryStillCurrentFn) {
-      if (!config.asyncCache) {
-        throw new Error('isEntryStillCurrentFn requires an asyncCache - the staleness check only applies to the async cache preemptive refresh path.')
-      }
-      if (typeof config.asyncCache.resetTtl !== 'function') {
-        throw new Error('The configured asyncCache does not support resetTtl, which is required by isEntryStillCurrentFn.')
-      }
-    }
+    this.assertStalenessCheckSupported(config.isEntryStillCurrentFn, 'resetTtl')
     this.isEntryStillCurrentFn = config.isEntryStillCurrentFn
 
     this.throwIfLoadError = config.throwIfLoadError ?? true
@@ -169,8 +162,8 @@ export class Loader<LoadedValue, LoadParams = string, LoadManyParams = LoadParam
           return false
         })
         if (isTtlBumped) {
-          // re-set to reset the in-memory TTL as well; toad-cache has no touch operation
-          this.inMemoryCache.set(key, cachedValue)
+          // getAsyncOnly already re-set the in-memory entry to this same value when resolveValue
+          // resolved, which reset its TTL; the value is unchanged on a bump, so nothing else to do.
           return
         }
         // the entry expired or was deleted between the read and the bump, fall through to a full refresh

--- a/lib/Loader.ts
+++ b/lib/Loader.ts
@@ -5,7 +5,7 @@ import type { InMemoryCacheConfiguration } from './memory/InMemoryCache'
 import type { InMemoryGroupCacheConfiguration } from './memory/InMemoryGroupCache'
 import type { GroupNotificationPublisher } from './notifications/GroupNotificationPublisher'
 import type { NotificationPublisher } from './notifications/NotificationPublisher'
-import type { Cache, CacheEntry, DataSource, GroupCache } from './types/DataSources'
+import type { Cache, CacheEntry, DataSource, GroupCache, IsEntryStillCurrentFn } from './types/DataSources'
 import type { GetManyResult, SynchronousCache, SynchronousGroupCache } from './types/SyncDataSources'
 
 export type LoaderConfig<
@@ -22,12 +22,14 @@ export type LoaderConfig<
     | SynchronousGroupCache<LoadedValue> = SynchronousCache<LoadedValue>,
   NotificationPublisherType extends
     | NotificationPublisher<LoadedValue>
-    | GroupNotificationPublisher<LoadedValue> = NotificationPublisher<LoadedValue>
+    | GroupNotificationPublisher<LoadedValue> = NotificationPublisher<LoadedValue>,
+  IsEntryStillCurrentFnType = IsEntryStillCurrentFn<LoadedValue, LoadParams>
 > = {
   dataSources?: readonly DataSourceType[]
   dataSourceGetOneFn?: (loadParams: LoadParams) => Promise<LoadedValue | undefined | null>
   dataSourceGetManyFn?: (keys: string[], loadParams?: LoadManyParams) => Promise<LoadedValue[]>
   dataSourceName?: string
+  isEntryStillCurrentFn?: IsEntryStillCurrentFnType
   throwIfLoadError?: boolean
   throwIfUnresolved?: boolean
 } & CommonCacheConfig<LoadedValue, CacheType, InMemoryCacheConfigType, InMemoryCacheType, NotificationPublisherType, LoadParams>
@@ -35,6 +37,7 @@ export type LoaderConfig<
 export class Loader<LoadedValue, LoadParams = string, LoadManyParams = LoadParams extends string ? undefined : LoadParams> extends AbstractFlatCache<LoadedValue, LoadParams, LoadManyParams> {
   private readonly dataSources: readonly DataSource<LoadedValue, LoadParams, LoadManyParams>[]
   private readonly isKeyRefreshing: Set<string>
+  private readonly isEntryStillCurrentFn?: IsEntryStillCurrentFn<LoadedValue, LoadParams>
   protected readonly throwIfLoadError: boolean
   protected readonly throwIfUnresolved: boolean
 
@@ -63,6 +66,16 @@ export class Loader<LoadedValue, LoadParams = string, LoadManyParams = LoadParam
     else {
       this.dataSources = []
     }
+
+    if (config.isEntryStillCurrentFn) {
+      if (!config.asyncCache) {
+        throw new Error('isEntryStillCurrentFn requires an asyncCache - the staleness check only applies to the async cache preemptive refresh path.')
+      }
+      if (typeof config.asyncCache.resetTtl !== 'function') {
+        throw new Error('The configured asyncCache does not support resetTtl, which is required by isEntryStillCurrentFn.')
+      }
+    }
+    this.isEntryStillCurrentFn = config.isEntryStillCurrentFn
 
     this.throwIfLoadError = config.throwIfLoadError ?? true
     this.throwIfUnresolved = config.throwIfUnresolved ?? false
@@ -119,17 +132,7 @@ export class Loader<LoadedValue, LoadParams = string, LoadManyParams = LoadParam
                 // check second time, maybe someone obtained the lock while we were checking the expiration date
                 if (!this.isKeyRefreshing.has(key)) {
                   this.isKeyRefreshing.add(key)
-                  this.loadFromLoaders(key, loadParams)
-                    .then((freshValue) => {
-                      // Propagate the freshly loaded value to the in-memory cache as well.
-                      // Without this, the in-memory layer keeps serving the stale value that
-                      // was read from the async cache before this background refresh started,
-                      // and its TTL is reset on the next read, so subsequent reads stay stale
-                      // for another full ttlInMsecs window even though the async cache is fresh.
-                      if (freshValue !== undefined) {
-                        this.inMemoryCache.set(key, freshValue)
-                      }
-                    })
+                  this.refreshOrBumpTtl(key, loadParams, cachedValue)
                     .catch((err) => {
                       this.logger.error(err.message)
                     })
@@ -148,6 +151,41 @@ export class Loader<LoadedValue, LoadParams = string, LoadManyParams = LoadParam
       // No cached value, we have to load instead
       return this.loadFromLoaders(key, loadParams)
     })
+  }
+
+  private async refreshOrBumpTtl(key: string, loadParams: LoadParams, cachedValue: LoadedValue | null): Promise<void> {
+    if (this.isEntryStillCurrentFn) {
+      let isCurrent = false
+      try {
+        isCurrent = await this.isEntryStillCurrentFn(cachedValue, loadParams)
+      } catch (err) {
+        // a failing check cannot confirm freshness, so fall through to a full refresh
+        this.loadErrorHandler(err as Error, key, { name: 'isEntryStillCurrentFn' }, this.logger)
+      }
+
+      if (isCurrent) {
+        const isTtlBumped = await this.asyncCache!.resetTtl!(key).catch((err) => {
+          this.cacheUpdateErrorHandler(err, key, this.asyncCache!, this.logger)
+          return false
+        })
+        if (isTtlBumped) {
+          // re-set to reset the in-memory TTL as well; toad-cache has no touch operation
+          this.inMemoryCache.set(key, cachedValue)
+          return
+        }
+        // the entry expired or was deleted between the read and the bump, fall through to a full refresh
+      }
+    }
+
+    const freshValue = await this.loadFromLoaders(key, loadParams)
+    // Propagate the freshly loaded value to the in-memory cache as well.
+    // Without this, the in-memory layer keeps serving the stale value that
+    // was read from the async cache before this background refresh started,
+    // and its TTL is reset on the next read, so subsequent reads stay stale
+    // for another full ttlInMsecs window even though the async cache is fresh.
+    if (freshValue !== undefined) {
+      this.inMemoryCache.set(key, freshValue)
+    }
   }
 
   private async loadFromLoaders(key: string, loadParams: LoadParams) {

--- a/lib/redis/RedisCache.ts
+++ b/lib/redis/RedisCache.ts
@@ -79,6 +79,24 @@ export class RedisCache<T> extends AbstractRedisCache<RedisCacheConfiguration, T
     })
   }
 
+  resetTtl(key: string): Promise<boolean> {
+    // without a TTL entries never expire, so there is nothing to reset
+    if (!this.config.ttlInMsecs) {
+      return Promise.resolve(false)
+    }
+
+    return this.redis.pexpire(this.resolveKey(key), this.config.ttlInMsecs).then((result) => {
+      // 0 means the key no longer exists - it expired or was deleted since it was read
+      if (result !== 1) {
+        return false
+      }
+      if (this.ttlLeftBeforeRefreshInMsecs) {
+        void this.expirationTimeLoadingOperation.invalidateCacheFor(key)
+      }
+      return true
+    })
+  }
+
   set(key: string, value: T | null): Promise<void> {
     return this.internalSet(this.resolveKey(key), value).then(() => {
       if (this.ttlLeftBeforeRefreshInMsecs) {

--- a/lib/redis/RedisCache.ts
+++ b/lib/redis/RedisCache.ts
@@ -91,7 +91,9 @@ export class RedisCache<T> extends AbstractRedisCache<RedisCacheConfiguration, T
         return false
       }
       if (this.ttlLeftBeforeRefreshInMsecs) {
-        void this.expirationTimeLoadingOperation.invalidateCacheFor(key)
+        // warm the cached expiration time with the value we just set, so the next read inside the
+        // refresh window does not have to issue an extra PTTL round-trip to relearn it
+        void this.expirationTimeLoadingOperation.forceSetValue(key, Date.now() + this.config.ttlInMsecs!)
       }
       return true
     })

--- a/lib/redis/RedisGroupCache.ts
+++ b/lib/redis/RedisGroupCache.ts
@@ -119,6 +119,32 @@ export class RedisGroupCache<T> extends AbstractRedisCache<RedisGroupCacheConfig
     return remainingTtl && remainingTtl > 0 ? now + remainingTtl : undefined
   }
 
+  async resetTtlFromGroup(key: string, groupId: string): Promise<boolean> {
+    // without a TTL entries never expire, so there is nothing to reset
+    if (!this.config.ttlInMsecs) {
+      return false
+    }
+
+    // a missing group index means the group was invalidated - the entry is effectively gone
+    const currentGroupKey = await this.redis.get(this.resolveGroupIndexPrefix(groupId))
+    if (!currentGroupKey) {
+      return false
+    }
+
+    const result = await this.redis.pexpire(
+      this.resolveKeyWithGroup(key, groupId, currentGroupKey),
+      this.config.ttlInMsecs,
+    )
+    // 0 means the key no longer exists - it expired or was deleted since it was read
+    if (result !== 1) {
+      return false
+    }
+    if (this.ttlLeftBeforeRefreshInMsecs) {
+      void this.expirationTimeLoadingGroupedOperation.invalidateCacheFor(key, groupId)
+    }
+    return true
+  }
+
   async setForGroup(key: string, value: T | null, groupId: string): Promise<void> {
     const getGroupKeyPromise = this.config.groupTtlInMsecs
       ? // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/lib/redis/RedisGroupCache.ts
+++ b/lib/redis/RedisGroupCache.ts
@@ -140,7 +140,12 @@ export class RedisGroupCache<T> extends AbstractRedisCache<RedisGroupCacheConfig
       return false
     }
     if (this.ttlLeftBeforeRefreshInMsecs) {
-      void this.expirationTimeLoadingGroupedOperation.invalidateCacheFor(key, groupId)
+      // warm the cached expiration time with the value we just set (see RedisCache.resetTtl)
+      void this.expirationTimeLoadingGroupedOperation.forceSetValueForGroup(
+        key,
+        Date.now() + this.config.ttlInMsecs!,
+        groupId,
+      )
     }
     return true
   }

--- a/lib/types/DataSources.ts
+++ b/lib/types/DataSources.ts
@@ -57,7 +57,8 @@ export interface Cache<LoadedValue> extends WriteCache<LoadedValue> {
   /**
    * Resets the entry's TTL back to the full configured ttlInMsecs without rewriting the value.
    * Returns `true` if the entry existed and its TTL was extended, `false` otherwise.
-   * Implementations must invalidate their cached expiration time for the key on success.
+   * Implementations that cache expiration times must refresh the cached value for the key on
+   * success (invalidate it, or update it to the new expiration).
    */
   resetTtl?: (key: string) => Promise<boolean>
 }
@@ -82,7 +83,8 @@ export interface GroupCache<LoadedValue> extends GroupWriteCache<LoadedValue> {
   /**
    * Resets the entry's TTL back to the full configured ttlInMsecs without rewriting the value.
    * Returns `true` if the entry existed and its TTL was extended, `false` otherwise.
-   * Implementations must invalidate their cached expiration time for the key on success.
+   * Implementations that cache expiration times must refresh the cached value for the key on
+   * success (invalidate it, or update it to the new expiration).
    */
   resetTtlFromGroup?: (key: string, group: string) => Promise<boolean>
 }

--- a/lib/types/DataSources.ts
+++ b/lib/types/DataSources.ts
@@ -18,6 +18,26 @@ export type CacheEntry<LoadedValue> = {
   value: LoadedValue
 }
 
+/**
+ * Lightweight staleness check invoked when a cached entry enters the refresh window.
+ *
+ * Return `true` if the cached value is still up-to-date (its TTL will be reset without a refetch),
+ * `false` to trigger a full background refetch from the data sources.
+ */
+export type IsEntryStillCurrentFn<LoadedValue, LoadParams = string> = (
+  cachedValue: LoadedValue | null,
+  loadParams: LoadParams,
+) => Promise<boolean>
+
+/**
+ * Group variant of {@link IsEntryStillCurrentFn}.
+ */
+export type IsGroupEntryStillCurrentFn<LoadedValue, LoadParams = string> = (
+  cachedValue: LoadedValue | null,
+  loadParams: LoadParams,
+  group: string,
+) => Promise<boolean>
+
 export interface WriteCache<LoadedValue> {
   set: (key: string, value: LoadedValue | null) => Promise<unknown>
   setMany: (entries: readonly CacheEntry<LoadedValue>[]) => Promise<unknown>
@@ -33,6 +53,13 @@ export interface Cache<LoadedValue> extends WriteCache<LoadedValue> {
   get: (key: string) => Promise<LoadedValue | undefined | null>
   getMany: (keys: string[]) => Promise<GetManyResult<LoadedValue>>
   getExpirationTime: (key: string) => Promise<number | undefined>
+
+  /**
+   * Resets the entry's TTL back to the full configured ttlInMsecs without rewriting the value.
+   * Returns `true` if the entry existed and its TTL was extended, `false` otherwise.
+   * Implementations must invalidate their cached expiration time for the key on success.
+   */
+  resetTtl?: (key: string) => Promise<boolean>
 }
 
 export interface GroupWriteCache<LoadedValue> {
@@ -51,6 +78,13 @@ export interface GroupCache<LoadedValue> extends GroupWriteCache<LoadedValue> {
   getFromGroup: (key: string, group: string) => Promise<LoadedValue | undefined | null>
   getManyFromGroup: (keys: string[], group: string) => Promise<GetManyResult<LoadedValue>>
   getExpirationTimeFromGroup: (key: string, group: string) => Promise<number | undefined>
+
+  /**
+   * Resets the entry's TTL back to the full configured ttlInMsecs without rewriting the value.
+   * Returns `true` if the entry existed and its TTL was extended, `false` otherwise.
+   * Implementations must invalidate their cached expiration time for the key on success.
+   */
+  resetTtlFromGroup?: (key: string, group: string) => Promise<boolean>
 }
 
 /**

--- a/test/GroupLoader-main.spec.ts
+++ b/test/GroupLoader-main.spec.ts
@@ -853,6 +853,29 @@ describe('GroupLoader Main', () => {
     })
   })
 
+  describe('forceSetValueForGroup', () => {
+    it('sets the explicit value in both cache layers without hitting the data source', async () => {
+      const asyncCache = new DummyGroupedCache(userValuesUndefined)
+      const loader = new CountingGroupedLoader(userValues)
+
+      const operation = new GroupLoader<User>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        asyncCache,
+        dataSources: [loader],
+      })
+
+      const valuePre = await operation.get(user1.userId, user1.companyId)
+      await operation.forceSetValueForGroup(user1.userId, user2, user1.companyId)
+      const valuePost = await operation.get(user1.userId, user1.companyId)
+
+      expect(valuePre).toEqual(user1)
+      expect(valuePost).toEqual(user2)
+      expect(await asyncCache.getFromGroup(user1.userId, user1.companyId)).toEqual(user2)
+      // the forced write did not trigger a data source load
+      expect(loader.counter).toBe(1)
+    })
+  })
+
   describe('invalidateCacheFor', () => {
     it('invalidates cache', async () => {
       const cache2 = new DummyGroupedCache(userValuesUndefined)

--- a/test/GroupLoader-staleness-check.spec.ts
+++ b/test/GroupLoader-staleness-check.spec.ts
@@ -132,6 +132,46 @@ describe('GroupLoader staleness check', () => {
       expect(otherGroupExpirationPost! <= otherGroupExpirationPre!).toBe(true)
     })
 
+    it('propagates the freshly refetched value into the in-memory group cache when stale', async () => {
+      const loader = new CountingGroupedLoader(userValues)
+      const asyncCache = new RedisGroupCache<User>(redis, {
+        ttlInMsecs: 300,
+        json: true,
+        ttlLeftBeforeRefreshInMsecs: 150,
+      })
+
+      const operation = new GroupLoader<User>({
+        inMemoryCache: {
+          cacheId: 'group-staleness-two-layer',
+          ttlInMsecs: 300,
+          ttlLeftBeforeRefreshInMsecs: 150,
+        },
+        asyncCache,
+        dataSources: [loader],
+        isEntryStillCurrentFn: async () => false,
+      })
+      expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+      expect(loader.counter).toBe(1)
+
+      // the data source now returns an updated entity
+      const updatedUser1: User = { ...user1, parametrized: 'updated' }
+      loader.groupValues![user1.companyId][user1.userId] = updatedUser1
+
+      await setTimeout(200)
+      // kick off the check, which reports the entry as stale and triggers a refetch
+      await operation.get(user1.userId, user1.companyId)
+      for (let attempt = 0; attempt < 20 && loader.counter < 2; attempt++) {
+        await setTimeout(10)
+      }
+      expect(loader.counter).toBe(2)
+
+      // the in-memory layer must now serve the fresh value, not the stale one
+      // @ts-expect-error accessing protected member for assertion
+      expect(operation.inMemoryCache.getFromGroup(user1.userId, user1.companyId)).toEqual(
+        updatedUser1,
+      )
+    })
+
     it('falls back to full background refetch when entry is stale', async () => {
       const loader = new CountingGroupedLoader(userValues)
       const asyncCache = new RedisGroupCache<User>(redis, {
@@ -322,6 +362,17 @@ describe('GroupLoader staleness check', () => {
             isEntryStillCurrentFn: async () => true,
           }),
       ).toThrow(/does not support resetTtlFromGroup/)
+    })
+
+    it('throws when the asyncCache has no ttlLeftBeforeRefreshInMsecs configured', () => {
+      expect(
+        () =>
+          new GroupLoader<User>({
+            asyncCache: new RedisGroupCache<User>(redis, { ttlInMsecs: 150, json: true }),
+            dataSources: [new CountingGroupedLoader(userValues)],
+            isEntryStillCurrentFn: async () => true,
+          }),
+      ).toThrow(/ttlLeftBeforeRefreshInMsecs/)
     })
   })
 })

--- a/test/GroupLoader-staleness-check.spec.ts
+++ b/test/GroupLoader-staleness-check.spec.ts
@@ -91,10 +91,12 @@ describe('GroupLoader staleness check', () => {
 
     it('does not touch other groups when bumping ttl', async () => {
       const loader = new CountingGroupedLoader(userValues)
+      // A wide refresh window lets group 1 enter it long before either group nears expiry, so the
+      // other group stays comfortably alive and the timing is not sensitive to CI load.
       const asyncCache = new RedisGroupCache<User>(redis, {
-        ttlInMsecs: 500,
+        ttlInMsecs: 2000,
         json: true,
-        ttlLeftBeforeRefreshInMsecs: 75,
+        ttlLeftBeforeRefreshInMsecs: 1500,
       })
       const isEntryStillCurrentFn = vitest.fn(async () => true)
 
@@ -111,7 +113,7 @@ describe('GroupLoader staleness check', () => {
         user3.companyId,
       )
 
-      await setTimeout(450)
+      await setTimeout(600)
       // kick off the check + bump for group 1 only
       expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
       for (
@@ -129,7 +131,9 @@ describe('GroupLoader staleness check', () => {
         user3.companyId,
       )
       expect(otherGroupExpirationPost).toBeDefined()
-      expect(otherGroupExpirationPost! <= otherGroupExpirationPre!).toBe(true)
+      // Bumping group 1 must not reset group 2's TTL: a reset would push its expiration ~600ms
+      // later, far beyond the few ms of Redis round-trip jitter the tolerance absorbs.
+      expect(otherGroupExpirationPost!).toBeLessThanOrEqual(otherGroupExpirationPre! + 200)
     })
 
     it('propagates the freshly refetched value into the in-memory group cache when stale', async () => {

--- a/test/GroupLoader-staleness-check.spec.ts
+++ b/test/GroupLoader-staleness-check.spec.ts
@@ -1,0 +1,327 @@
+import { setTimeout } from 'node:timers/promises'
+import Redis from 'ioredis'
+import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest'
+import { GroupLoader } from '../lib/GroupLoader'
+import { RedisGroupCache } from '../lib/redis/RedisGroupCache'
+import { CountingGroupedLoader } from './fakes/CountingGroupedLoader'
+import { DummyGroupedCache } from './fakes/DummyGroupedCache'
+import { redisOptions } from './fakes/TestRedisConfig'
+import type { User } from './types/testTypes'
+
+const user1: User = {
+  companyId: '1',
+  userId: '1',
+}
+
+const user3: User = {
+  companyId: '2',
+  userId: '3',
+}
+
+const userValues = {
+  [user1.companyId]: {
+    [user1.userId]: user1,
+  },
+  [user3.companyId]: {
+    [user3.userId]: user3,
+  },
+}
+
+describe('GroupLoader staleness check', () => {
+  let redis: Redis
+  beforeEach(async () => {
+    vitest.resetAllMocks()
+    redis = new Redis(redisOptions)
+    await redis.flushall()
+  })
+
+  afterEach(async () => {
+    await setTimeout(10)
+    await redis.disconnect()
+  })
+
+  describe('get', () => {
+    it('bumps ttl without refetching when entry is still current', async () => {
+      const loader = new CountingGroupedLoader(userValues)
+      const asyncCache = new RedisGroupCache<User>(redis, {
+        ttlInMsecs: 150,
+        json: true,
+        ttlLeftBeforeRefreshInMsecs: 75,
+      })
+      const isEntryStillCurrentFn = vitest.fn(async () => true)
+
+      const operation = new GroupLoader<User>({
+        asyncCache,
+        dataSources: [loader],
+        isEntryStillCurrentFn,
+      })
+      expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+      expect(loader.counter).toBe(1)
+      // @ts-expect-error
+      const expirationTimePre = await operation.asyncCache.getExpirationTimeFromGroup(
+        user1.userId,
+        user1.companyId,
+      )
+
+      await setTimeout(100)
+      // kick off the staleness check
+      expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+      // Wait for the background check to actually run.
+      for (
+        let attempt = 0;
+        attempt < 20 && isEntryStillCurrentFn.mock.calls.length < 1;
+        attempt++
+      ) {
+        await setTimeout(10)
+      }
+      expect(isEntryStillCurrentFn).toHaveBeenCalledWith(user1, user1.userId, user1.companyId)
+      await setTimeout(10)
+
+      // no full refetch happened
+      expect(loader.counter).toBe(1)
+      // @ts-expect-error
+      const expirationTimePost = await operation.asyncCache.getExpirationTimeFromGroup(
+        user1.userId,
+        user1.companyId,
+      )
+      expect(expirationTimePre).toBeDefined()
+      expect(expirationTimePost).toBeDefined()
+      expect(expirationTimePost! > expirationTimePre!).toBe(true)
+    })
+
+    it('does not touch other groups when bumping ttl', async () => {
+      const loader = new CountingGroupedLoader(userValues)
+      const asyncCache = new RedisGroupCache<User>(redis, {
+        ttlInMsecs: 500,
+        json: true,
+        ttlLeftBeforeRefreshInMsecs: 75,
+      })
+      const isEntryStillCurrentFn = vitest.fn(async () => true)
+
+      const operation = new GroupLoader<User>({
+        asyncCache,
+        dataSources: [loader],
+        isEntryStillCurrentFn,
+      })
+      expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+      expect(await operation.get(user3.userId, user3.companyId)).toEqual(user3)
+      // @ts-expect-error
+      const otherGroupExpirationPre = await operation.asyncCache.getExpirationTimeFromGroup(
+        user3.userId,
+        user3.companyId,
+      )
+
+      await setTimeout(450)
+      // kick off the check + bump for group 1 only
+      expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+      for (
+        let attempt = 0;
+        attempt < 20 && isEntryStillCurrentFn.mock.calls.length < 1;
+        attempt++
+      ) {
+        await setTimeout(10)
+      }
+      await setTimeout(10)
+
+      // @ts-expect-error
+      const otherGroupExpirationPost = await operation.asyncCache.getExpirationTimeFromGroup(
+        user3.userId,
+        user3.companyId,
+      )
+      expect(otherGroupExpirationPost).toBeDefined()
+      expect(otherGroupExpirationPost! <= otherGroupExpirationPre!).toBe(true)
+    })
+
+    it('falls back to full background refetch when entry is stale', async () => {
+      const loader = new CountingGroupedLoader(userValues)
+      const asyncCache = new RedisGroupCache<User>(redis, {
+        ttlInMsecs: 150,
+        json: true,
+        ttlLeftBeforeRefreshInMsecs: 75,
+      })
+      const isEntryStillCurrentFn = vitest.fn(async () => false)
+
+      const operation = new GroupLoader<User>({
+        asyncCache,
+        dataSources: [loader],
+        isEntryStillCurrentFn,
+      })
+      expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+      expect(loader.counter).toBe(1)
+
+      await setTimeout(100)
+      // kick off the check, which reports the entry as stale
+      expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+      // Wait for the background refresh to actually call the data source.
+      for (let attempt = 0; attempt < 20 && loader.counter < 2; attempt++) {
+        await setTimeout(10)
+      }
+      expect(loader.counter).toBe(2)
+    })
+
+    it('treats a throwing staleness check as stale and refetches', async () => {
+      const loader = new CountingGroupedLoader(userValues)
+      const asyncCache = new RedisGroupCache<User>(redis, {
+        ttlInMsecs: 150,
+        json: true,
+        ttlLeftBeforeRefreshInMsecs: 75,
+      })
+      const loadErrorHandler = vitest.fn()
+
+      const operation = new GroupLoader<User>({
+        asyncCache,
+        dataSources: [loader],
+        isEntryStillCurrentFn: async () => {
+          throw new Error('check failed')
+        },
+        loadErrorHandler,
+      })
+      expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+      expect(loader.counter).toBe(1)
+
+      await setTimeout(100)
+      // kick off the check, which throws
+      expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+      // Wait for the fallback background refresh to actually call the data source.
+      for (let attempt = 0; attempt < 20 && loader.counter < 2; attempt++) {
+        await setTimeout(10)
+      }
+      expect(loader.counter).toBe(2)
+      expect(loadErrorHandler).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'check failed' }),
+        user1.userId,
+        expect.objectContaining({ name: 'isEntryStillCurrentFn' }),
+        expect.anything(),
+      )
+    })
+
+    it('falls back to full refetch when the ttl bump fails', async () => {
+      const loader = new CountingGroupedLoader(userValues)
+      const asyncCache = new RedisGroupCache<User>(redis, {
+        ttlInMsecs: 150,
+        json: true,
+        ttlLeftBeforeRefreshInMsecs: 75,
+      })
+      vitest.spyOn(asyncCache, 'resetTtlFromGroup').mockRejectedValue(new Error('connection lost'))
+      const cacheUpdateErrorHandler = vitest.fn()
+
+      const operation = new GroupLoader<User>({
+        asyncCache,
+        dataSources: [loader],
+        isEntryStillCurrentFn: async () => true,
+        cacheUpdateErrorHandler,
+      })
+      expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+      expect(loader.counter).toBe(1)
+
+      await setTimeout(100)
+      // kick off the check; ttl bump rejects
+      expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+      // Wait for the fallback background refresh to actually call the data source.
+      for (let attempt = 0; attempt < 20 && loader.counter < 2; attempt++) {
+        await setTimeout(10)
+      }
+      expect(loader.counter).toBe(2)
+      expect(cacheUpdateErrorHandler).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'connection lost' }),
+        user1.userId,
+        asyncCache,
+        expect.anything(),
+      )
+    })
+
+    it('refetches when the group was invalidated between the read and the ttl bump', async () => {
+      const loader = new CountingGroupedLoader(userValues)
+      const asyncCache = new RedisGroupCache<User>(redis, {
+        ttlInMsecs: 150,
+        json: true,
+        ttlLeftBeforeRefreshInMsecs: 75,
+      })
+
+      const operation = new GroupLoader<User>({
+        asyncCache,
+        dataSources: [loader],
+        isEntryStillCurrentFn: async () => {
+          // simulate the group being invalidated while the check is in flight
+          await asyncCache.deleteGroup(user1.companyId)
+          return true
+        },
+      })
+      expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+      expect(loader.counter).toBe(1)
+
+      await setTimeout(100)
+      // kick off the check; ttl bump fails because the group index was rotated
+      expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+      // Wait for the fallback background refresh to actually call the data source.
+      for (let attempt = 0; attempt < 20 && loader.counter < 2; attempt++) {
+        await setTimeout(10)
+      }
+      expect(loader.counter).toBe(2)
+    })
+
+    it('only runs a single staleness check for concurrent gets', async () => {
+      const loader = new CountingGroupedLoader(userValues)
+      const asyncCache = new RedisGroupCache<User>(redis, {
+        ttlInMsecs: 9999,
+        json: true,
+        ttlLeftBeforeRefreshInMsecs: 9925,
+        ttlCacheTtl: 2000,
+      })
+
+      let finishCheck: (isCurrent: boolean) => void
+      const checkPromise = new Promise<boolean>((resolve) => {
+        finishCheck = resolve
+      })
+      const isEntryStillCurrentFn = vitest.fn(() => checkPromise)
+
+      const operation = new GroupLoader<User>({
+        asyncCache,
+        dataSources: [loader],
+        isEntryStillCurrentFn,
+      })
+      expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+      expect(loader.counter).toBe(1)
+
+      await setTimeout(90)
+      // kick off the check and keep it hanging while more gets come in
+      expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+      void operation.get(user1.userId, user1.companyId)
+      void operation.get(user1.userId, user1.companyId)
+      await setTimeout(10)
+      finishCheck!(true)
+      await setTimeout(10)
+
+      expect(isEntryStillCurrentFn).toHaveBeenCalledTimes(1)
+      expect(loader.counter).toBe(1)
+
+      // @ts-expect-error
+      const groupRefreshFlags: Map<string, Set<string>> = operation.groupRefreshFlags
+      // The empty Set for the group should have been cleaned up
+      expect(groupRefreshFlags.has(user1.companyId)).toBe(false)
+    })
+  })
+
+  describe('constructor', () => {
+    it('throws when isEntryStillCurrentFn is set without an asyncCache', () => {
+      expect(
+        () =>
+          new GroupLoader<User>({
+            dataSources: [new CountingGroupedLoader(userValues)],
+            isEntryStillCurrentFn: async () => true,
+          }),
+      ).toThrow(/isEntryStillCurrentFn requires an asyncCache/)
+    })
+
+    it('throws when the asyncCache does not support resetTtlFromGroup', () => {
+      expect(
+        () =>
+          new GroupLoader<User>({
+            asyncCache: new DummyGroupedCache(userValues),
+            dataSources: [new CountingGroupedLoader(userValues)],
+            isEntryStillCurrentFn: async () => true,
+          }),
+      ).toThrow(/does not support resetTtlFromGroup/)
+    })
+  })
+})

--- a/test/Loader-staleness-check.spec.ts
+++ b/test/Loader-staleness-check.spec.ts
@@ -350,5 +350,16 @@ describe('Loader staleness check', () => {
           }),
       ).toThrow(/does not support resetTtl/)
     })
+
+    it('throws when the asyncCache has no ttlLeftBeforeRefreshInMsecs configured', () => {
+      expect(
+        () =>
+          new Loader<string>({
+            asyncCache: new RedisCache<string>(redis, { ttlInMsecs: 150 }),
+            dataSources: [new CountingDataSource('value')],
+            isEntryStillCurrentFn: async () => true,
+          }),
+      ).toThrow(/ttlLeftBeforeRefreshInMsecs/)
+    })
   })
 })

--- a/test/Loader-staleness-check.spec.ts
+++ b/test/Loader-staleness-check.spec.ts
@@ -1,0 +1,354 @@
+import { setTimeout } from 'node:timers/promises'
+import Redis from 'ioredis'
+import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest'
+import { Loader } from '../lib/Loader'
+import { RedisCache } from '../lib/redis'
+import { CountingDataSource } from './fakes/CountingDataSource'
+import { DummyCache } from './fakes/DummyCache'
+import { redisOptions } from './fakes/TestRedisConfig'
+
+describe('Loader staleness check', () => {
+  let redis: Redis
+  beforeEach(async () => {
+    vitest.resetAllMocks()
+    redis = new Redis(redisOptions)
+    await redis.flushall()
+  })
+
+  afterEach(async () => {
+    await setTimeout(10)
+    await redis.disconnect()
+  })
+
+  describe('get', () => {
+    it('bumps ttl without refetching when entry is still current', async () => {
+      const loader = new CountingDataSource('value')
+      const asyncCache = new RedisCache<string>(redis, {
+        ttlInMsecs: 150,
+        ttlLeftBeforeRefreshInMsecs: 75,
+      })
+      const isEntryStillCurrentFn = vitest.fn(async () => true)
+
+      const operation = new Loader<string>({
+        asyncCache,
+        dataSources: [loader],
+        isEntryStillCurrentFn,
+      })
+      expect(await operation.get('key')).toBe('value')
+      expect(loader.counter).toBe(1)
+      // @ts-expect-error
+      const expirationTimePre = await operation.asyncCache.getExpirationTime('key')
+
+      await setTimeout(100)
+      // kick off the staleness check
+      expect(await operation.get('key')).toBe('value')
+      // Wait for the background check to actually run.
+      for (
+        let attempt = 0;
+        attempt < 20 && isEntryStillCurrentFn.mock.calls.length < 1;
+        attempt++
+      ) {
+        await setTimeout(10)
+      }
+      expect(isEntryStillCurrentFn).toHaveBeenCalledWith('value', 'key')
+      await setTimeout(10)
+
+      // no full refetch happened
+      expect(loader.counter).toBe(1)
+      // @ts-expect-error
+      const expirationTimePost = await operation.asyncCache.getExpirationTime('key')
+      expect(expirationTimePre).toBeDefined()
+      expect(expirationTimePost).toBeDefined()
+      expect(expirationTimePost! > expirationTimePre!).toBe(true)
+    })
+
+    it('falls back to full background refetch when entry is stale', async () => {
+      const loader = new CountingDataSource('v1')
+      const asyncCache = new RedisCache<string>(redis, {
+        ttlInMsecs: 150,
+        ttlLeftBeforeRefreshInMsecs: 75,
+      })
+      const isEntryStillCurrentFn = vitest.fn(async () => false)
+
+      const operation = new Loader<string>({
+        asyncCache,
+        dataSources: [loader],
+        isEntryStillCurrentFn,
+      })
+      expect(await operation.get('key')).toBe('v1')
+      expect(loader.counter).toBe(1)
+
+      loader.value = 'v2'
+      await setTimeout(100)
+      // kick off the check, which reports the entry as stale
+      expect(await operation.get('key')).toBe('v1')
+      // Wait for the background refresh to actually call the data source.
+      for (let attempt = 0; attempt < 20 && loader.counter < 2; attempt++) {
+        await setTimeout(10)
+      }
+      expect(loader.counter).toBe(2)
+      // @ts-expect-error
+      expect(await operation.asyncCache.get('key')).toBe('v2')
+    })
+
+    it('treats a throwing staleness check as stale and refetches', async () => {
+      const loader = new CountingDataSource('value')
+      const asyncCache = new RedisCache<string>(redis, {
+        ttlInMsecs: 150,
+        ttlLeftBeforeRefreshInMsecs: 75,
+      })
+      const loadErrorHandler = vitest.fn()
+
+      const operation = new Loader<string>({
+        asyncCache,
+        dataSources: [loader],
+        isEntryStillCurrentFn: async () => {
+          throw new Error('check failed')
+        },
+        loadErrorHandler,
+      })
+      expect(await operation.get('key')).toBe('value')
+      expect(loader.counter).toBe(1)
+
+      await setTimeout(100)
+      // kick off the check, which throws
+      expect(await operation.get('key')).toBe('value')
+      // Wait for the fallback background refresh to actually call the data source.
+      for (let attempt = 0; attempt < 20 && loader.counter < 2; attempt++) {
+        await setTimeout(10)
+      }
+      expect(loader.counter).toBe(2)
+      expect(loadErrorHandler).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'check failed' }),
+        'key',
+        expect.objectContaining({ name: 'isEntryStillCurrentFn' }),
+        expect.anything(),
+      )
+    })
+
+    it('falls back to full refetch when the ttl bump fails', async () => {
+      const loader = new CountingDataSource('value')
+      const asyncCache = new RedisCache<string>(redis, {
+        ttlInMsecs: 150,
+        ttlLeftBeforeRefreshInMsecs: 75,
+      })
+      vitest.spyOn(asyncCache, 'resetTtl').mockRejectedValue(new Error('connection lost'))
+      const cacheUpdateErrorHandler = vitest.fn()
+
+      const operation = new Loader<string>({
+        asyncCache,
+        dataSources: [loader],
+        isEntryStillCurrentFn: async () => true,
+        cacheUpdateErrorHandler,
+      })
+      expect(await operation.get('key')).toBe('value')
+      expect(loader.counter).toBe(1)
+
+      await setTimeout(100)
+      // kick off the check; ttl bump rejects
+      expect(await operation.get('key')).toBe('value')
+      // Wait for the fallback background refresh to actually call the data source.
+      for (let attempt = 0; attempt < 20 && loader.counter < 2; attempt++) {
+        await setTimeout(10)
+      }
+      expect(loader.counter).toBe(2)
+      expect(cacheUpdateErrorHandler).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'connection lost' }),
+        'key',
+        asyncCache,
+        expect.anything(),
+      )
+    })
+
+    it('refetches when the entry disappears between the read and the ttl bump', async () => {
+      const loader = new CountingDataSource('value')
+      const asyncCache = new RedisCache<string>(redis, {
+        ttlInMsecs: 150,
+        ttlLeftBeforeRefreshInMsecs: 75,
+      })
+
+      const operation = new Loader<string>({
+        asyncCache,
+        dataSources: [loader],
+        isEntryStillCurrentFn: async () => {
+          // simulate the entry being deleted while the check is in flight
+          await asyncCache.delete('key')
+          return true
+        },
+      })
+      expect(await operation.get('key')).toBe('value')
+      expect(loader.counter).toBe(1)
+
+      await setTimeout(100)
+      // kick off the check; ttl bump fails because the entry is gone
+      expect(await operation.get('key')).toBe('value')
+      // Wait for the fallback background refresh to actually call the data source.
+      for (let attempt = 0; attempt < 20 && loader.counter < 2; attempt++) {
+        await setTimeout(10)
+      }
+      expect(loader.counter).toBe(2)
+    })
+
+    it('only runs a single staleness check for concurrent gets', async () => {
+      const loader = new CountingDataSource('value')
+      const asyncCache = new RedisCache<string>(redis, {
+        ttlInMsecs: 9999,
+        ttlLeftBeforeRefreshInMsecs: 9925,
+        ttlCacheTtl: 2000,
+      })
+
+      let finishCheck: (isCurrent: boolean) => void
+      const checkPromise = new Promise<boolean>((resolve) => {
+        finishCheck = resolve
+      })
+      const isEntryStillCurrentFn = vitest.fn(() => checkPromise)
+
+      const operation = new Loader<string>({
+        asyncCache,
+        dataSources: [loader],
+        isEntryStillCurrentFn,
+      })
+      expect(await operation.get('key')).toBe('value')
+      expect(loader.counter).toBe(1)
+
+      await setTimeout(90)
+      // kick off the check and keep it hanging while more gets come in
+      expect(await operation.get('key')).toBe('value')
+      void operation.get('key')
+      void operation.get('key')
+      await setTimeout(10)
+      finishCheck!(true)
+      await setTimeout(10)
+
+      expect(isEntryStillCurrentFn).toHaveBeenCalledTimes(1)
+      expect(loader.counter).toBe(1)
+    })
+
+    it('does not re-run the check after a ttl bump until the refresh window is reached again', async () => {
+      const loader = new CountingDataSource('value')
+      const asyncCache = new RedisCache<string>(redis, {
+        ttlInMsecs: 500,
+        ttlLeftBeforeRefreshInMsecs: 100,
+        ttlCacheTtl: 5000,
+      })
+      const isEntryStillCurrentFn = vitest.fn(async () => true)
+
+      const operation = new Loader<string>({
+        asyncCache,
+        dataSources: [loader],
+        isEntryStillCurrentFn,
+      })
+      expect(await operation.get('key')).toBe('value')
+
+      await setTimeout(450)
+      // kick off the check + bump
+      expect(await operation.get('key')).toBe('value')
+      for (
+        let attempt = 0;
+        attempt < 20 && isEntryStillCurrentFn.mock.calls.length < 1;
+        attempt++
+      ) {
+        await setTimeout(10)
+      }
+      expect(isEntryStillCurrentFn).toHaveBeenCalledTimes(1)
+
+      // ttl was bumped and the cached expiration time invalidated, so gets
+      // outside of the refresh window do not re-trigger the check
+      await setTimeout(20)
+      expect(await operation.get('key')).toBe('value')
+      expect(await operation.get('key')).toBe('value')
+      await setTimeout(20)
+      expect(isEntryStillCurrentFn).toHaveBeenCalledTimes(1)
+      expect(loader.counter).toBe(1)
+    })
+
+    it('bumps the in-memory ttl as well in a two-layer setup', async () => {
+      const loader = new CountingDataSource('value')
+      const asyncCache = new RedisCache<string>(redis, {
+        ttlInMsecs: 150,
+        ttlLeftBeforeRefreshInMsecs: 75,
+      })
+
+      const operation = new Loader<string>({
+        inMemoryCache: {
+          cacheId: 'staleness-two-layer',
+          ttlInMsecs: 150,
+          ttlLeftBeforeRefreshInMsecs: 75,
+        },
+        asyncCache,
+        dataSources: [loader],
+        isEntryStillCurrentFn: async () => true,
+      })
+      expect(await operation.get('key')).toBe('value')
+      // @ts-expect-error
+      const inMemoryExpirationPre = operation.inMemoryCache.getExpirationTime('key')
+
+      await setTimeout(100)
+      // kick off the check + bump
+      expect(await operation.get('key')).toBe('value')
+      await setTimeout(30)
+
+      // @ts-expect-error
+      const inMemoryExpirationPost = operation.inMemoryCache.getExpirationTime('key')
+      expect(inMemoryExpirationPre).toBeDefined()
+      expect(inMemoryExpirationPost).toBeDefined()
+      expect(inMemoryExpirationPost! > inMemoryExpirationPre!).toBe(true)
+      expect(loader.counter).toBe(1)
+    })
+
+    it('passes the cached representation of a null value to the staleness check', async () => {
+      const loader = new CountingDataSource(null)
+      const asyncCache = new RedisCache<string>(redis, {
+        ttlInMsecs: 150,
+        ttlLeftBeforeRefreshInMsecs: 75,
+        json: true,
+      })
+      const isEntryStillCurrentFn = vitest.fn(async () => true)
+
+      const operation = new Loader<string>({
+        asyncCache,
+        dataSources: [loader],
+        isEntryStillCurrentFn,
+      })
+      expect(await operation.get('key')).toBe(null)
+      expect(loader.counter).toBe(1)
+
+      await setTimeout(100)
+      // kick off the check; Redis stores explicitly cached null as an empty string
+      expect(await operation.get('key')).toBe('')
+      for (
+        let attempt = 0;
+        attempt < 20 && isEntryStillCurrentFn.mock.calls.length < 1;
+        attempt++
+      ) {
+        await setTimeout(10)
+      }
+      expect(isEntryStillCurrentFn).toHaveBeenCalledWith('', 'key')
+      await setTimeout(10)
+      expect(loader.counter).toBe(1)
+    })
+  })
+
+  describe('constructor', () => {
+    it('throws when isEntryStillCurrentFn is set without an asyncCache', () => {
+      expect(
+        () =>
+          new Loader<string>({
+            dataSources: [new CountingDataSource('value')],
+            isEntryStillCurrentFn: async () => true,
+          }),
+      ).toThrow(/isEntryStillCurrentFn requires an asyncCache/)
+    })
+
+    it('throws when the asyncCache does not support resetTtl', () => {
+      expect(
+        () =>
+          new Loader<string>({
+            asyncCache: new DummyCache('value'),
+            dataSources: [new CountingDataSource('value')],
+            isEntryStillCurrentFn: async () => true,
+          }),
+      ).toThrow(/does not support resetTtl/)
+    })
+  })
+})

--- a/test/redis/RedisCache.spec.ts
+++ b/test/redis/RedisCache.spec.ts
@@ -75,6 +75,45 @@ describe('RedisCache', () => {
     })
   })
 
+  describe('resetTtl', () => {
+    it('resets ttl of an existing entry back to the full configured ttl', async () => {
+      const cache = new RedisCache(redis, { ttlInMsecs: TTL_IN_MSECS })
+      await cache.set('key', 'value')
+      await setTimeout(500)
+
+      const expiresAtPre = await cache.getExpirationTime('key')
+      const timeLeftPre = expiresAtPre! - Date.now()
+
+      const result = await cache.resetTtl('key')
+
+      const expiresAtPost = await cache.getExpirationTime('key')
+      const timeLeftPost = expiresAtPost! - Date.now()
+
+      expect(result).toBe(true)
+      expect(timeLeftPre < 530).toBe(true)
+      expect(timeLeftPost > 970).toBe(true)
+      // value was not rewritten
+      expect(await cache.get('key')).toBe('value')
+    })
+
+    it('returns false for non-existent entry', async () => {
+      const cache = new RedisCache(redis, { ttlInMsecs: TTL_IN_MSECS })
+
+      const result = await cache.resetTtl('dummy')
+
+      expect(result).toBe(false)
+    })
+
+    it('returns false when no ttl is configured', async () => {
+      const cache = new RedisCache(redis, { ttlInMsecs: undefined })
+      await cache.set('key', 'value')
+
+      const result = await cache.resetTtl('key')
+
+      expect(result).toBe(false)
+    })
+  })
+
   describe('get', () => {
     it('retrieves value with timeout', async () => {
       const cache = new RedisCache(redis, {

--- a/test/redis/RedisGroupCache.spec.ts
+++ b/test/redis/RedisGroupCache.spec.ts
@@ -86,6 +86,64 @@ describe('RedisGroupCache', () => {
     })
   })
 
+  describe('resetTtlFromGroup', () => {
+    it('resets ttl of an existing entry back to the full configured ttl', async () => {
+      const cache = new RedisGroupCache(redis, { ttlInMsecs: TTL_IN_MSECS })
+      await cache.setForGroup('key', 'value', 'group')
+      await setTimeout(500)
+
+      const expiresAtPre = await cache.getExpirationTimeFromGroup('key', 'group')
+      const timeLeftPre = expiresAtPre! - Date.now()
+
+      const result = await cache.resetTtlFromGroup('key', 'group')
+
+      const expiresAtPost = await cache.getExpirationTimeFromGroup('key', 'group')
+      const timeLeftPost = expiresAtPost! - Date.now()
+
+      expect(result).toBe(true)
+      expect(timeLeftPre < 530).toBe(true)
+      expect(timeLeftPost > 970).toBe(true)
+      // value was not rewritten
+      expect(await cache.getFromGroup('key', 'group')).toBe('value')
+    })
+
+    it('returns false for non-existent entry', async () => {
+      const cache = new RedisGroupCache(redis, { ttlInMsecs: TTL_IN_MSECS })
+      await cache.setForGroup('other-key', 'value', 'group')
+
+      const result = await cache.resetTtlFromGroup('dummy', 'group')
+
+      expect(result).toBe(false)
+    })
+
+    it('returns false if there is no dynamic group key registered in redis', async () => {
+      const cache = new RedisGroupCache(redis, { ttlInMsecs: TTL_IN_MSECS })
+
+      const result = await cache.resetTtlFromGroup('dummy', 'fake')
+
+      expect(result).toBe(false)
+    })
+
+    it('returns false after the group was invalidated', async () => {
+      const cache = new RedisGroupCache(redis, { ttlInMsecs: TTL_IN_MSECS })
+      await cache.setForGroup('key', 'value', 'group')
+      await cache.deleteGroup('group')
+
+      const result = await cache.resetTtlFromGroup('key', 'group')
+
+      expect(result).toBe(false)
+    })
+
+    it('returns false when no ttl is configured', async () => {
+      const cache = new RedisGroupCache(redis, { ttlInMsecs: undefined })
+      await cache.setForGroup('key', 'value', 'group')
+
+      const result = await cache.resetTtlFromGroup('key', 'group')
+
+      expect(result).toBe(false)
+    })
+  })
+
   describe('getFromGroup', () => {
     it('returns undefined if there is no dynamic group key registered in redis', async () => {
       const cache = new RedisGroupCache(redis)


### PR DESCRIPTION
When a cached entry enters the ttlLeftBeforeRefreshInMsecs window, a new
opt-in isEntryStillCurrentFn lets the loader run a lightweight freshness
check (e.g. comparing updatedAt/version) instead of unconditionally
refetching from the data sources. If the entry is still current, its TTL
is reset to the full ttlInMsecs in both the async and in-memory layers
via new optional resetTtl/resetTtlFromGroup cache methods (Redis PEXPIRE);
otherwise, or when the check throws or the entry vanished meanwhile, the
existing full background refresh runs as before.

Supported by both Loader and GroupLoader. No storage format change; the
check receives the cached value itself. Check errors are routed to
loadErrorHandler and treated as stale, ttl bump failures to
cacheUpdateErrorHandler, so the worst case degrades to today's behavior.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ux9azWit8MhWuKcFrYx7q7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conditional refresh behavior so cached data can be checked for staleness before a full reload.
  * Added support for refreshing cache expiration when data is still current, reducing unnecessary refetches.
  * Added a new way to update grouped cached values directly and keep cache layers in sync.

* **Bug Fixes**
  * Background refreshes now update the in-memory cache with the newly fetched value, preventing older data from lingering after refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->