### PR TITLE
Fix cache handling of null/falsy values and non-existent groups

### DIFF
--- a/lib/AbstractFlatCache.ts
+++ b/lib/AbstractFlatCache.ts
@@ -20,11 +20,14 @@ export abstract class AbstractFlatCache<LoadedValue, LoadParams = string, LoadMa
   }
 
   public getInMemoryOnly(loadParams: LoadParams): LoadedValue | undefined | null {
-    const key = this.cacheKeyFromLoadParamsResolver(loadParams)
+    return this.getInMemoryOnlyResolved(this.cacheKeyFromLoadParamsResolver(loadParams), loadParams)
+  }
+
+  private getInMemoryOnlyResolved(key: string, loadParams: LoadParams): LoadedValue | undefined | null {
     if (this.inMemoryCache.ttlLeftBeforeRefreshInMsecs && !this.runningLoads.has(key)) {
       const expirationTime = this.inMemoryCache.getExpirationTime(key)
       if (expirationTime && expirationTime - Date.now() < this.inMemoryCache.ttlLeftBeforeRefreshInMsecs) {
-        void this.getAsyncOnly(loadParams)
+        void this.getAsyncOnlyResolved(key, loadParams)
       }
     }
 
@@ -37,7 +40,10 @@ export abstract class AbstractFlatCache<LoadedValue, LoadParams = string, LoadMa
   }
 
   public getAsyncOnly(loadParams: LoadParams): Promise<LoadedValue | undefined | null> {
-    const key = this.cacheKeyFromLoadParamsResolver(loadParams)
+    return this.getAsyncOnlyResolved(this.cacheKeyFromLoadParamsResolver(loadParams), loadParams)
+  }
+
+  private getAsyncOnlyResolved(key: string, loadParams: LoadParams): Promise<LoadedValue | undefined | null> {
     const existingLoad = this.runningLoads.get(key)
     if (existingLoad) {
       return existingLoad
@@ -78,12 +84,13 @@ export abstract class AbstractFlatCache<LoadedValue, LoadParams = string, LoadMa
   }
 
   public get(loadParams: LoadParams): Promise<LoadedValue | undefined | null> {
-    const inMemoryValue = this.getInMemoryOnly(loadParams)
+    const key = this.cacheKeyFromLoadParamsResolver(loadParams)
+    const inMemoryValue = this.getInMemoryOnlyResolved(key, loadParams)
     if (inMemoryValue !== undefined) {
       return Promise.resolve(inMemoryValue)
     }
 
-    return this.getAsyncOnly(loadParams)
+    return this.getAsyncOnlyResolved(key, loadParams)
   }
 
   public getMany(keys: string[], loadParams?: LoadManyParams): Promise<LoadedValue[]> {
@@ -95,7 +102,12 @@ export abstract class AbstractFlatCache<LoadedValue, LoadParams = string, LoadMa
     }
 
     return this.getManyAsyncOnly(inMemoryValues.unresolvedKeys, loadParams).then((asyncRetrievedValues) => {
-      return [...inMemoryValues.resolvedValues, ...asyncRetrievedValues.resolvedValues]
+      // in-memory caches always return a fresh array, so it is safe to append to it in place
+      const mergedValues = inMemoryValues.resolvedValues
+      for (let i = 0; i < asyncRetrievedValues.resolvedValues.length; i++) {
+        mergedValues.push(asyncRetrievedValues.resolvedValues[i])
+      }
+      return mergedValues
     })
   }
 

--- a/lib/AbstractGroupCache.ts
+++ b/lib/AbstractGroupCache.ts
@@ -36,12 +36,19 @@ export abstract class AbstractGroupCache<LoadedValue, LoadParams = string, LoadM
   }
 
   public getInMemoryOnly(loadParams: LoadParams, group: string): LoadedValue | undefined | null {
-    const key = this.cacheKeyFromLoadParamsResolver(loadParams)
+    return this.getInMemoryOnlyResolved(this.cacheKeyFromLoadParamsResolver(loadParams), loadParams, group)
+  }
+
+  private getInMemoryOnlyResolved(
+    key: string,
+    loadParams: LoadParams,
+    group: string,
+  ): LoadedValue | undefined | null {
     if (this.inMemoryCache.ttlLeftBeforeRefreshInMsecs) {
       if (!this.runningLoads.get(group)?.has(key)) {
         const expirationTime = this.inMemoryCache.getExpirationTimeFromGroup(key, group)
         if (expirationTime && expirationTime - Date.now() < this.inMemoryCache.ttlLeftBeforeRefreshInMsecs) {
-          void this.getAsyncOnly(loadParams, group)
+          void this.getAsyncOnlyResolved(key, loadParams, group)
         }
       }
     }
@@ -55,7 +62,14 @@ export abstract class AbstractGroupCache<LoadedValue, LoadParams = string, LoadM
   }
 
   public getAsyncOnly(loadParams: LoadParams, group: string): Promise<LoadedValue | undefined | null> {
-    const key = this.cacheKeyFromLoadParamsResolver(loadParams)
+    return this.getAsyncOnlyResolved(this.cacheKeyFromLoadParamsResolver(loadParams), loadParams, group)
+  }
+
+  private getAsyncOnlyResolved(
+    key: string,
+    loadParams: LoadParams,
+    group: string,
+  ): Promise<LoadedValue | undefined | null> {
     const groupLoads = this.resolveGroupLoads(group)
     const existingLoad = groupLoads.get(key)
     if (existingLoad) {
@@ -97,12 +111,12 @@ export abstract class AbstractGroupCache<LoadedValue, LoadParams = string, LoadM
 
   public get(loadParams: LoadParams, group: string): Promise<LoadedValue | undefined | null> {
     const key = this.cacheKeyFromLoadParamsResolver(loadParams)
-    const inMemoryValue = this.getInMemoryOnly(loadParams, group)
+    const inMemoryValue = this.getInMemoryOnlyResolved(key, loadParams, group)
     if (inMemoryValue !== undefined) {
       return Promise.resolve(inMemoryValue)
     }
 
-    return this.getAsyncOnly(loadParams, group)
+    return this.getAsyncOnlyResolved(key, loadParams, group)
   }
 
   public getMany(
@@ -119,7 +133,12 @@ export abstract class AbstractGroupCache<LoadedValue, LoadParams = string, LoadM
 
     return this.getManyAsyncOnly(inMemoryValues.unresolvedKeys, group, loadParams).then(
       (asyncRetrievedValues) => {
-        return [...inMemoryValues.resolvedValues, ...asyncRetrievedValues.resolvedValues]
+        // in-memory caches always return a fresh array, so it is safe to append to it in place
+        const mergedValues = inMemoryValues.resolvedValues
+        for (let i = 0; i < asyncRetrievedValues.resolvedValues.length; i++) {
+          mergedValues.push(asyncRetrievedValues.resolvedValues[i])
+        }
+        return mergedValues
       },
     )
   }

--- a/lib/GroupLoader.ts
+++ b/lib/GroupLoader.ts
@@ -91,12 +91,13 @@ export class GroupLoader<LoadedValue, LoadParams = string, LoadManyParams = Load
     const loadValues = await this.loadManyFromLoaders(cachedValues.unresolvedKeys, group, loadParams)
 
     if (this.asyncCache) {
-      const cacheEntries: CacheEntry<LoadedValue>[] = loadValues.map((loadValue) => {
-        return {
-          key: this.cacheKeyFromValueResolver(loadValue),
-          value: loadValue,
-        }
-      })
+      const cacheEntries: CacheEntry<LoadedValue>[] = []
+      for (let i = 0; i < loadValues.length; i++) {
+        cacheEntries.push({
+          key: this.cacheKeyFromValueResolver(loadValues[i]),
+          value: loadValues[i],
+        })
+      }
 
       await this.asyncCache.setManyForGroup(cacheEntries, group).catch((err) => {
         this.cacheUpdateErrorHandler(
@@ -109,7 +110,8 @@ export class GroupLoader<LoadedValue, LoadParams = string, LoadManyParams = Load
     }
 
     return {
-      resolvedValues: [...cachedValues.resolvedValues, ...loadValues],
+      // concat instead of in-place push, as cachedValues may be owned by a user-implemented async cache
+      resolvedValues: cachedValues.resolvedValues.concat(loadValues),
 
       // there actually may still be some unresolved keys, but we no longer know that
       unresolvedKeys: [],
@@ -118,8 +120,9 @@ export class GroupLoader<LoadedValue, LoadParams = string, LoadManyParams = Load
 
   private async loadFromLoaders(key: string, group: string, loadParams: LoadParams) {
     for (let index = 0; index < this.dataSources.length; index++) {
-      const resolvedValue = await this.dataSources[index].getFromGroup(loadParams, group).catch((err) => {
-        this.loadErrorHandler(err, key, this.dataSources[index], this.logger)
+      const dataSource = this.dataSources[index]
+      const resolvedValue = await dataSource.getFromGroup(loadParams, group).catch((err) => {
+        this.loadErrorHandler(err, key, dataSource, this.logger)
         if (this.throwIfLoadError) {
           throw err
         }
@@ -146,8 +149,9 @@ export class GroupLoader<LoadedValue, LoadParams = string, LoadManyParams = Load
   private async loadManyFromLoaders(keys: string[], group: string, loadParams?: LoadManyParams) {
     let lastResolvedValues
     for (let index = 0; index < this.dataSources.length; index++) {
-      lastResolvedValues = await this.dataSources[index].getManyFromGroup(keys, group, loadParams).catch((err) => {
-        this.loadErrorHandler(err, keys.toString(), this.dataSources[index], this.logger)
+      const dataSource = this.dataSources[index]
+      lastResolvedValues = await dataSource.getManyFromGroup(keys, group, loadParams).catch((err) => {
+        this.loadErrorHandler(err, keys.toString(), dataSource, this.logger)
         if (this.throwIfLoadError) {
           throw err
         }

--- a/lib/Loader.ts
+++ b/lib/Loader.ts
@@ -152,8 +152,9 @@ export class Loader<LoadedValue, LoadParams = string, LoadManyParams = LoadParam
 
   private async loadFromLoaders(key: string, loadParams: LoadParams) {
     for (let index = 0; index < this.dataSources.length; index++) {
-      const resolvedValue = await this.dataSources[index].get(loadParams).catch((err) => {
-        this.loadErrorHandler(err, key, this.dataSources[index], this.logger)
+      const dataSource = this.dataSources[index]
+      const resolvedValue = await dataSource.get(loadParams).catch((err) => {
+        this.loadErrorHandler(err, key, dataSource, this.logger)
         if (this.throwIfLoadError) {
           throw err
         }
@@ -192,12 +193,13 @@ export class Loader<LoadedValue, LoadParams = string, LoadManyParams = LoadParam
     const loadValues = await this.loadManyFromLoaders(cachedValues.unresolvedKeys, loadParams)
 
     if (this.asyncCache) {
-      const cacheEntries: CacheEntry<LoadedValue>[] = loadValues.map((loadValue) => {
-        return {
-          key: this.cacheKeyFromValueResolver(loadValue),
-          value: loadValue,
-        }
-      })
+      const cacheEntries: CacheEntry<LoadedValue>[] = []
+      for (let i = 0; i < loadValues.length; i++) {
+        cacheEntries.push({
+          key: this.cacheKeyFromValueResolver(loadValues[i]),
+          value: loadValues[i],
+        })
+      }
 
       await this.asyncCache.setMany(cacheEntries).catch((err) => {
         this.cacheUpdateErrorHandler(
@@ -210,7 +212,8 @@ export class Loader<LoadedValue, LoadParams = string, LoadManyParams = LoadParam
     }
 
     return {
-      resolvedValues: [...cachedValues.resolvedValues, ...loadValues],
+      // concat instead of in-place push, as cachedValues may be owned by a user-implemented async cache
+      resolvedValues: cachedValues.resolvedValues.concat(loadValues),
 
       // there actually may still be some unresolved keys, but we no longer know that
       unresolvedKeys: [],
@@ -220,8 +223,9 @@ export class Loader<LoadedValue, LoadParams = string, LoadManyParams = LoadParam
   private async loadManyFromLoaders(keys: string[], loadParams: LoadManyParams) {
     let lastResolvedValues
     for (let index = 0; index < this.dataSources.length; index++) {
-      lastResolvedValues = await this.dataSources[index].getMany(keys, loadParams).catch((err) => {
-        this.loadErrorHandler(err, keys.toString(), this.dataSources[index], this.logger)
+      const dataSource = this.dataSources[index]
+      lastResolvedValues = await dataSource.getMany(keys, loadParams).catch((err) => {
+        this.loadErrorHandler(err, keys.toString(), dataSource, this.logger)
         if (this.throwIfLoadError) {
           throw err
         }

--- a/lib/memory/InMemoryCache.ts
+++ b/lib/memory/InMemoryCache.ts
@@ -60,8 +60,9 @@ export class InMemoryCache<T> implements SynchronousCache<T> {
 
     for (let i = 0; i < keys.length; i++) {
       const resolvedValue = this.cache.get(keys[i])
-      if (resolvedValue) {
-        resolvedValues.push(resolvedValue)
+      // null means "resolved to an empty value" and is served from cache, same as in single-key get
+      if (resolvedValue !== undefined) {
+        resolvedValues.push(resolvedValue as T)
       } else {
         unresolvedKeys.push(keys[i])
       }

--- a/lib/memory/InMemoryGroupCache.ts
+++ b/lib/memory/InMemoryGroupCache.ts
@@ -77,19 +77,26 @@ export class InMemoryGroupCache<T> implements SynchronousGroupCache<T> {
   }
 
   getFromGroup(key: string, groupId: string) {
-    const group = this.resolveGroup(groupId)
-    return group.get(key)
+    return this.groups.get(groupId)?.get(key)
   }
 
   getManyFromGroup(keys: string[], group: string): GetManyResult<T> {
+    const groupCache = this.groups.get(group)
+    if (!groupCache) {
+      return {
+        resolvedValues: [],
+        unresolvedKeys: keys,
+      }
+    }
+
     const resolvedValues: T[] = []
     const unresolvedKeys: string[] = []
-    const groupCache = this.resolveGroup(group)
 
     for (let i = 0; i < keys.length; i++) {
       const resolvedValue = groupCache.get(keys[i])
-      if (resolvedValue) {
-        resolvedValues.push(resolvedValue)
+      // null means "resolved to an empty value" and is served from cache, same as in single-key get
+      if (resolvedValue !== undefined) {
+        resolvedValues.push(resolvedValue as T)
       } else {
         unresolvedKeys.push(keys[i])
       }
@@ -107,8 +114,7 @@ export class InMemoryGroupCache<T> implements SynchronousGroupCache<T> {
   }
 
   deleteFromGroup(key: string, groupId: string): void {
-    const group = this.resolveGroup(groupId)
-    group.delete(key)
+    this.groups.get(groupId)?.delete(key)
   }
 
   clear(): void {
@@ -116,7 +122,6 @@ export class InMemoryGroupCache<T> implements SynchronousGroupCache<T> {
   }
 
   getExpirationTimeFromGroup(key: string, groupId: string): number | undefined {
-    const group = this.resolveGroup(groupId)
-    return group.expiresAt(key)
+    return this.groups.get(groupId)?.expiresAt(key)
   }
 }

--- a/lib/redis/AbstractRedisCache.ts
+++ b/lib/redis/AbstractRedisCache.ts
@@ -18,6 +18,7 @@ export const DEFAULT_REDIS_CACHE_CONFIGURATION: RedisCacheConfiguration = {
 export abstract class AbstractRedisCache<ConfigType extends RedisCacheConfiguration, LoadedValue> {
   protected readonly redis: Redis
   protected readonly config: ConfigType
+  protected readonly keyPrefix: string
 
   constructor(redis: Redis, config: Partial<ConfigType>) {
     this.redis = redis
@@ -26,6 +27,7 @@ export abstract class AbstractRedisCache<ConfigType extends RedisCacheConfigurat
       ...DEFAULT_REDIS_CACHE_CONFIGURATION,
       ...config,
     }
+    this.keyPrefix = `${this.config.prefix}${this.config.separator}`
   }
 
   protected internalSet(resolvedKey: string, value: LoadedValue | null) {
@@ -64,10 +66,10 @@ export abstract class AbstractRedisCache<ConfigType extends RedisCacheConfigurat
   }
 
   resolveKey(key: string) {
-    return `${this.config.prefix}${this.config.separator}${key}`
+    return this.keyPrefix + key
   }
 
   resolveCachePattern() {
-    return `${this.config.prefix}${this.config.separator}*`
+    return `${this.keyPrefix}*`
   }
 }

--- a/lib/redis/RedisGroupCache.ts
+++ b/lib/redis/RedisGroupCache.ts
@@ -16,10 +16,13 @@ export interface RedisGroupCacheConfiguration extends RedisCacheConfiguration, G
 export class RedisGroupCache<T> extends AbstractRedisCache<RedisGroupCacheConfiguration, T> implements GroupCache<T> {
   public readonly expirationTimeLoadingGroupedOperation: GroupLoader<number>
   public ttlLeftBeforeRefreshInMsecs?: number
+  private readonly groupIndexPrefix: string
   name = 'Redis group cache'
 
   constructor(redis: Redis, config: Partial<RedisGroupCacheConfiguration> = {}) {
     super(redis, config)
+
+    this.groupIndexPrefix = `${this.keyPrefix}${GROUP_INDEX_KEY}${this.config.separator}`
 
     this.ttlLeftBeforeRefreshInMsecs = config.ttlLeftBeforeRefreshInMsecs
     this.redis.defineCommand('getOrSetZeroWithTtl', {
@@ -85,7 +88,8 @@ export class RedisGroupCache<T> extends AbstractRedisCache<RedisGroupCacheConfig
       }
     }
 
-    const transformedKeys = keys.map((key) => this.resolveKeyWithGroup(key, groupId, currentGroupKey))
+    const entryPrefix = this.resolveGroupEntryPrefix(groupId, currentGroupKey)
+    const transformedKeys = keys.map((key) => entryPrefix + key)
     const resolvedValues: T[] = []
     const unresolvedKeys: string[] = []
 
@@ -148,13 +152,14 @@ export class RedisGroupCache<T> extends AbstractRedisCache<RedisGroupCacheConfig
 
     const currentGroupKey = await getGroupKeyPromise
 
+    const entryPrefix = this.resolveGroupEntryPrefix(groupId, currentGroupKey)
     if (this.config.ttlInMsecs) {
       const setCommands = []
       for (let i = 0; i < entries.length; i++) {
         const entry = entries[i]
         setCommands.push([
           'set',
-          this.resolveKeyWithGroup(entry.key, groupId, currentGroupKey),
+          entryPrefix + entry.key,
           entry.value && this.config.json ? JSON.stringify(entry.value) : entry.value,
           'PX',
           this.config.ttlInMsecs,
@@ -168,18 +173,22 @@ export class RedisGroupCache<T> extends AbstractRedisCache<RedisGroupCacheConfig
     const commandParam = []
     for (let i = 0; i < entries.length; i++) {
       const entry = entries[i]
-      commandParam.push(this.resolveKeyWithGroup(entry.key, groupId, currentGroupKey))
+      commandParam.push(entryPrefix + entry.key)
       commandParam.push(entry.value && this.config.json ? JSON.stringify(entry.value) : entry.value)
     }
     return this.redis.mset(commandParam)
   }
 
   resolveKeyWithGroup(key: string, groupId: string, groupIndexKey: string) {
-    return `${this.config.prefix}${this.config.separator}${groupId}${this.config.separator}${groupIndexKey}${this.config.separator}${key}`
+    return this.resolveGroupEntryPrefix(groupId, groupIndexKey) + key
+  }
+
+  private resolveGroupEntryPrefix(groupId: string, groupIndexKey: string) {
+    return `${this.keyPrefix}${groupId}${this.config.separator}${groupIndexKey}${this.config.separator}`
   }
 
   resolveGroupIndexPrefix(groupId: string) {
-    return `${this.config.prefix}${this.config.separator}${GROUP_INDEX_KEY}${this.config.separator}${groupId}`
+    return this.groupIndexPrefix + groupId
   }
 
   async close() {

--- a/lib/util/unique.spec.ts
+++ b/lib/util/unique.spec.ts
@@ -2,6 +2,16 @@ import { describe, expect, it } from 'vitest'
 import { unique } from './unique'
 
 describe('unique', () => {
+  it('returns the same array reference for an empty array', () => {
+    const input: string[] = []
+    expect(unique(input)).toBe(input)
+  })
+
+  it('returns the same array reference for a single-element array', () => {
+    const input = ['key']
+    expect(unique(input)).toBe(input)
+  })
+
   it('returns the same array reference when there are no duplicates', () => {
     const input = [1, 2, 3, 'a', 'b']
     const result = unique(input)

--- a/lib/util/unique.ts
+++ b/lib/util/unique.ts
@@ -1,4 +1,7 @@
 export const unique = <T>(arr: T[]): T[] => {
+  if (arr.length <= 1) {
+    return arr
+  }
   const set = new Set(arr)
   return set.size === arr.length ? arr : Array.from(set)
 }

--- a/test/GroupLoader-main.spec.ts
+++ b/test/GroupLoader-main.spec.ts
@@ -600,6 +600,28 @@ describe('GroupLoader Main', () => {
   })
 
   describe('getMany', () => {
+    it('serves cached null value without hitting the data source again', async () => {
+      const userValuesNull = {
+        [user1.companyId]: {
+          [user1.userId]: null,
+        },
+      }
+      const loader = new CountingGroupedLoader(userValuesNull as unknown as typeof userValues)
+      const operation = new GroupLoader<User>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        dataSources: [loader],
+        cacheKeyFromValueResolver: idResolver,
+      })
+
+      const value = await operation.get(user1.userId, user1.companyId)
+      expect(value).toBeNull()
+      expect(loader.counter).toBe(1)
+
+      const values = await operation.getMany([user1.userId], user1.companyId)
+      expect(values).toEqual([null])
+      expect(loader.counter).toBe(1)
+    })
+
     it('returns empty array when fails to resolve value', async () => {
       const operation = new GroupLoader<User>({
         cacheKeyFromValueResolver: idResolver,

--- a/test/Loader-main.spec.ts
+++ b/test/Loader-main.spec.ts
@@ -691,6 +691,23 @@ describe('Loader Main', () => {
   })
 
   describe('getMany', () => {
+    it('serves cached null value without hitting the data source again', async () => {
+      const dataSource = new CountingDataSource(null)
+      const operation = new Loader<string>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        dataSources: [dataSource],
+        cacheKeyFromValueResolver: idResolver,
+      })
+
+      const value = await operation.get('key1')
+      expect(value).toBeNull()
+      expect(dataSource.counter).toBe(1)
+
+      const values = await operation.getMany(['key1'])
+      expect(values).toEqual([null])
+      expect(dataSource.counter).toBe(1)
+    })
+
     it('returns empty list when fails to resolve value', async () => {
       const operation = new Loader<string>({
         cacheKeyFromValueResolver: idResolver,

--- a/test/memory/InMemoryCache.spec.ts
+++ b/test/memory/InMemoryCache.spec.ts
@@ -147,6 +147,25 @@ describe('InMemoryCache', () => {
         resolvedValues: ['value', 'value2'],
       })
     })
+
+    it('resolves cached null and falsy values', () => {
+      const cache = new InMemoryCache<string | number | boolean>({
+        cacheId: 'dummy',
+        cacheType: 'lru-map',
+        maxItems: 5,
+        ttlInMsecs: 999,
+      })
+      cache.set('key', null)
+      cache.set('key2', '')
+      cache.set('key3', 0)
+      cache.set('key4', false)
+
+      const values = cache.getMany(['key', 'key2', 'key3', 'key4', 'key5'])
+      expect(values).toEqual({
+        unresolvedKeys: ['key5'],
+        resolvedValues: [null, '', 0, false],
+      })
+    })
   })
 
   describe('getExpirationTime', () => {

--- a/test/memory/InMemoryGroupCache.spec.ts
+++ b/test/memory/InMemoryGroupCache.spec.ts
@@ -130,6 +130,77 @@ describe('InMemoryCache', () => {
         resolvedValues: ['value', 'value2'],
       })
     })
+
+    it('resolves cached null and falsy values', () => {
+      const cache = new InMemoryGroupCache<string | number | boolean>({
+        maxGroups: 2,
+        ttlInMsecs: 999,
+      })
+      cache.setForGroup('key', null, 'group')
+      cache.setForGroup('key2', '', 'group')
+      cache.setForGroup('key3', 0, 'group')
+      cache.setForGroup('key4', false, 'group')
+
+      const values = cache.getManyFromGroup(['key', 'key2', 'key3', 'key4', 'key5'], 'group')
+      expect(values).toEqual({
+        unresolvedKeys: ['key5'],
+        resolvedValues: [null, '', 0, false],
+      })
+    })
+
+    it('returns all keys as unresolved for a group that was never written to', () => {
+      const cache = new InMemoryGroupCache(IN_MEMORY_CACHE_CONFIG)
+
+      const values = cache.getManyFromGroup(['key', 'key2'], 'group')
+      expect(values).toEqual({
+        unresolvedKeys: ['key', 'key2'],
+        resolvedValues: [],
+      })
+    })
+  })
+
+  describe('reads on non-existent groups', () => {
+    it('getFromGroup does not create the group or evict existing groups', () => {
+      const cache = new InMemoryGroupCache({
+        maxGroups: 1,
+        ttlInMsecs: 999,
+      })
+      cache.setForGroup('key', 'value', 'group')
+
+      const missingValue = cache.getFromGroup('key', 'other-group')
+      expect(missingValue).toBeUndefined()
+
+      // reading an unknown group must not insert it into the bounded LRU and push the real group out
+      const existingValue = cache.getFromGroup('key', 'group')
+      expect(existingValue).toBe('value')
+    })
+
+    it('getExpirationTimeFromGroup does not create the group or evict existing groups', () => {
+      const cache = new InMemoryGroupCache({
+        maxGroups: 1,
+        ttlInMsecs: 999,
+      })
+      cache.setForGroup('key', 'value', 'group')
+
+      const expirationTime = cache.getExpirationTimeFromGroup('key', 'other-group')
+      expect(expirationTime).toBeUndefined()
+
+      const existingValue = cache.getFromGroup('key', 'group')
+      expect(existingValue).toBe('value')
+    })
+
+    it('deleteFromGroup is a no-op for a non-existent group', () => {
+      const cache = new InMemoryGroupCache({
+        maxGroups: 1,
+        ttlInMsecs: 999,
+      })
+      cache.setForGroup('key', 'value', 'group')
+
+      cache.deleteFromGroup('key', 'other-group')
+
+      const existingValue = cache.getFromGroup('key', 'group')
+      expect(existingValue).toBe('value')
+    })
   })
 
   describe('getExpirationTimeFromGroup', () => {


### PR DESCRIPTION
## Summary
This PR fixes critical bugs in cache handling where null and falsy values (empty strings, 0, false) were not being properly cached and served, and where reading from non-existent groups could evict existing cached groups in bounded caches.

## Key Changes

### Cache Value Handling
- **Fixed null/falsy value caching**: Changed condition from `if (resolvedValue)` to `if (resolvedValue !== undefined)` in `InMemoryCache.getMany()` and `InMemoryGroupCache.getManyFromGroup()` to properly distinguish between "not cached" (undefined) and "cached as null/falsy" (null, '', 0, false)
- **Added test coverage**: New tests verify that null, empty strings, 0, and false values are correctly cached and retrieved

### Non-Existent Group Handling
- **Prevent group creation on read**: Modified `InMemoryGroupCache.getFromGroup()`, `getExpirationTimeFromGroup()`, and `deleteFromGroup()` to use `this.groups.get(groupId)?.method()` instead of `this.resolveGroup(groupId)` which was creating empty groups
- **Prevent LRU eviction**: Reading from non-existent groups no longer creates entries in the bounded LRU cache, preventing legitimate cached groups from being evicted
- **Added test coverage**: New tests verify that read operations on non-existent groups don't affect existing cached groups

### Code Quality Improvements
- **Refactored key resolution**: Extracted `getInMemoryOnlyResolved()` and `getAsyncOnlyResolved()` private methods in `AbstractGroupCache` and `AbstractFlatCache` to avoid redundant key resolution
- **Optimized array operations**: Replaced spread operator array concatenation with `concat()` in `Loader` and `GroupLoader` to avoid unnecessary array copies when merging cached and async-loaded values
- **Improved loop efficiency**: Replaced `.map()` with explicit for-loops in cache entry creation for better performance
- **Optimized unique() utility**: Added early return for arrays with 0-1 elements to avoid Set creation overhead
- **Extracted Redis key prefix**: Added `keyPrefix` property to `AbstractRedisCache` and `groupIndexPrefix` to `RedisGroupCache` to avoid repeated string concatenation

## Notable Implementation Details
- The fix properly handles the semantic difference between "value not in cache" (undefined) and "value cached as null" (null), which is important for caching null responses from data sources
- Read operations on non-existent groups now safely return undefined without side effects on the LRU cache structure
- All changes maintain backward compatibility while fixing the underlying bugs

https://claude.ai/code/session_01V9a5hu7LRNBnK8ntskSHsV