### PR TITLE
Apply remaining #418 performance optimizations on top of #417

### DIFF
--- a/lib/AbstractFlatCache.ts
+++ b/lib/AbstractFlatCache.ts
@@ -20,11 +20,14 @@ export abstract class AbstractFlatCache<LoadedValue, LoadParams = string, LoadMa
   }
 
   public getInMemoryOnly(loadParams: LoadParams): LoadedValue | undefined | null {
-    const key = this.cacheKeyFromLoadParamsResolver(loadParams)
+    return this.getInMemoryOnlyResolved(this.cacheKeyFromLoadParamsResolver(loadParams), loadParams)
+  }
+
+  private getInMemoryOnlyResolved(key: string, loadParams: LoadParams): LoadedValue | undefined | null {
     if (this.inMemoryCache.ttlLeftBeforeRefreshInMsecs && !this.runningLoads.has(key)) {
       const expirationTime = this.inMemoryCache.getExpirationTime(key)
       if (expirationTime && expirationTime - Date.now() < this.inMemoryCache.ttlLeftBeforeRefreshInMsecs) {
-        void this.getAsyncOnly(loadParams)
+        void this.getAsyncOnlyResolved(key, loadParams)
       }
     }
 
@@ -37,7 +40,10 @@ export abstract class AbstractFlatCache<LoadedValue, LoadParams = string, LoadMa
   }
 
   public getAsyncOnly(loadParams: LoadParams): Promise<LoadedValue | undefined | null> {
-    const key = this.cacheKeyFromLoadParamsResolver(loadParams)
+    return this.getAsyncOnlyResolved(this.cacheKeyFromLoadParamsResolver(loadParams), loadParams)
+  }
+
+  private getAsyncOnlyResolved(key: string, loadParams: LoadParams): Promise<LoadedValue | undefined | null> {
     const existingLoad = this.runningLoads.get(key)
     if (existingLoad) {
       return existingLoad
@@ -86,12 +92,13 @@ export abstract class AbstractFlatCache<LoadedValue, LoadParams = string, LoadMa
   }
 
   public get(loadParams: LoadParams): Promise<LoadedValue | undefined | null> {
-    const inMemoryValue = this.getInMemoryOnly(loadParams)
+    const key = this.cacheKeyFromLoadParamsResolver(loadParams)
+    const inMemoryValue = this.getInMemoryOnlyResolved(key, loadParams)
     if (inMemoryValue !== undefined) {
       return Promise.resolve(inMemoryValue)
     }
 
-    return this.getAsyncOnly(loadParams)
+    return this.getAsyncOnlyResolved(key, loadParams)
   }
 
   public getMany(keys: string[], loadParams?: LoadManyParams): Promise<LoadedValue[]> {
@@ -103,7 +110,12 @@ export abstract class AbstractFlatCache<LoadedValue, LoadParams = string, LoadMa
     }
 
     return this.getManyAsyncOnly(inMemoryValues.unresolvedKeys, loadParams).then((asyncRetrievedValues) => {
-      return [...inMemoryValues.resolvedValues, ...asyncRetrievedValues.resolvedValues]
+      // in-memory caches always return a fresh array, so it is safe to append to it in place
+      const mergedValues = inMemoryValues.resolvedValues
+      for (let i = 0; i < asyncRetrievedValues.resolvedValues.length; i++) {
+        mergedValues.push(asyncRetrievedValues.resolvedValues[i])
+      }
+      return mergedValues
     })
   }
 

--- a/lib/AbstractGroupCache.ts
+++ b/lib/AbstractGroupCache.ts
@@ -42,12 +42,19 @@ export abstract class AbstractGroupCache<LoadedValue, LoadParams = string, LoadM
   }
 
   public getInMemoryOnly(loadParams: LoadParams, group: string): LoadedValue | undefined | null {
-    const key = this.cacheKeyFromLoadParamsResolver(loadParams)
+    return this.getInMemoryOnlyResolved(this.cacheKeyFromLoadParamsResolver(loadParams), loadParams, group)
+  }
+
+  private getInMemoryOnlyResolved(
+    key: string,
+    loadParams: LoadParams,
+    group: string,
+  ): LoadedValue | undefined | null {
     if (this.inMemoryCache.ttlLeftBeforeRefreshInMsecs) {
       if (!this.runningLoads.get(group)?.has(key)) {
         const expirationTime = this.inMemoryCache.getExpirationTimeFromGroup(key, group)
         if (expirationTime && expirationTime - Date.now() < this.inMemoryCache.ttlLeftBeforeRefreshInMsecs) {
-          void this.getAsyncOnly(loadParams, group)
+          void this.getAsyncOnlyResolved(key, loadParams, group)
         }
       }
     }
@@ -61,7 +68,14 @@ export abstract class AbstractGroupCache<LoadedValue, LoadParams = string, LoadM
   }
 
   public getAsyncOnly(loadParams: LoadParams, group: string): Promise<LoadedValue | undefined | null> {
-    const key = this.cacheKeyFromLoadParamsResolver(loadParams)
+    return this.getAsyncOnlyResolved(this.cacheKeyFromLoadParamsResolver(loadParams), loadParams, group)
+  }
+
+  private getAsyncOnlyResolved(
+    key: string,
+    loadParams: LoadParams,
+    group: string,
+  ): Promise<LoadedValue | undefined | null> {
     const groupLoads = this.resolveGroupLoads(group)
     const existingLoad = groupLoads.get(key)
     if (existingLoad) {
@@ -111,12 +125,12 @@ export abstract class AbstractGroupCache<LoadedValue, LoadParams = string, LoadM
 
   public get(loadParams: LoadParams, group: string): Promise<LoadedValue | undefined | null> {
     const key = this.cacheKeyFromLoadParamsResolver(loadParams)
-    const inMemoryValue = this.getInMemoryOnly(loadParams, group)
+    const inMemoryValue = this.getInMemoryOnlyResolved(key, loadParams, group)
     if (inMemoryValue !== undefined) {
       return Promise.resolve(inMemoryValue)
     }
 
-    return this.getAsyncOnly(loadParams, group)
+    return this.getAsyncOnlyResolved(key, loadParams, group)
   }
 
   public getMany(
@@ -133,7 +147,12 @@ export abstract class AbstractGroupCache<LoadedValue, LoadParams = string, LoadM
 
     return this.getManyAsyncOnly(inMemoryValues.unresolvedKeys, group, loadParams).then(
       (asyncRetrievedValues) => {
-        return [...inMemoryValues.resolvedValues, ...asyncRetrievedValues.resolvedValues]
+        // in-memory caches always return a fresh array, so it is safe to append to it in place
+        const mergedValues = inMemoryValues.resolvedValues
+        for (let i = 0; i < asyncRetrievedValues.resolvedValues.length; i++) {
+          mergedValues.push(asyncRetrievedValues.resolvedValues[i])
+        }
+        return mergedValues
       },
     )
   }

--- a/lib/GroupLoader.ts
+++ b/lib/GroupLoader.ts
@@ -154,12 +154,13 @@ export class GroupLoader<LoadedValue, LoadParams = string, LoadManyParams = Load
     const loadValues = await this.loadManyFromLoaders(cachedValues.unresolvedKeys, group, loadParams)
 
     if (this.asyncCache) {
-      const cacheEntries: CacheEntry<LoadedValue>[] = loadValues.map((loadValue) => {
-        return {
-          key: this.cacheKeyFromValueResolver(loadValue),
-          value: loadValue,
-        }
-      })
+      const cacheEntries: CacheEntry<LoadedValue>[] = []
+      for (let i = 0; i < loadValues.length; i++) {
+        cacheEntries.push({
+          key: this.cacheKeyFromValueResolver(loadValues[i]),
+          value: loadValues[i],
+        })
+      }
 
       await this.asyncCache.setManyForGroup(cacheEntries, group).catch((err) => {
         this.cacheUpdateErrorHandler(
@@ -172,7 +173,8 @@ export class GroupLoader<LoadedValue, LoadParams = string, LoadManyParams = Load
     }
 
     return {
-      resolvedValues: [...cachedValues.resolvedValues, ...loadValues],
+      // concat instead of in-place push, as cachedValues may be owned by a user-implemented async cache
+      resolvedValues: cachedValues.resolvedValues.concat(loadValues),
 
       // there actually may still be some unresolved keys, but we no longer know that
       unresolvedKeys: [],
@@ -181,8 +183,9 @@ export class GroupLoader<LoadedValue, LoadParams = string, LoadManyParams = Load
 
   private async loadFromLoaders(key: string, group: string, loadParams: LoadParams) {
     for (let index = 0; index < this.dataSources.length; index++) {
-      const resolvedValue = await this.dataSources[index].getFromGroup(loadParams, group).catch((err) => {
-        this.loadErrorHandler(err, key, this.dataSources[index], this.logger)
+      const dataSource = this.dataSources[index]
+      const resolvedValue = await dataSource.getFromGroup(loadParams, group).catch((err) => {
+        this.loadErrorHandler(err, key, dataSource, this.logger)
         if (this.throwIfLoadError) {
           throw err
         }
@@ -209,8 +212,9 @@ export class GroupLoader<LoadedValue, LoadParams = string, LoadManyParams = Load
   private async loadManyFromLoaders(keys: string[], group: string, loadParams?: LoadManyParams) {
     let lastResolvedValues
     for (let index = 0; index < this.dataSources.length; index++) {
-      lastResolvedValues = await this.dataSources[index].getManyFromGroup(keys, group, loadParams).catch((err) => {
-        this.loadErrorHandler(err, keys.toString(), this.dataSources[index], this.logger)
+      const dataSource = this.dataSources[index]
+      lastResolvedValues = await dataSource.getManyFromGroup(keys, group, loadParams).catch((err) => {
+        this.loadErrorHandler(err, keys.toString(), dataSource, this.logger)
         if (this.throwIfLoadError) {
           throw err
         }

--- a/lib/Loader.ts
+++ b/lib/Loader.ts
@@ -182,8 +182,9 @@ export class Loader<LoadedValue, LoadParams = string, LoadManyParams = LoadParam
 
   private async loadFromLoaders(key: string, loadParams: LoadParams) {
     for (let index = 0; index < this.dataSources.length; index++) {
-      const resolvedValue = await this.dataSources[index].get(loadParams).catch((err) => {
-        this.loadErrorHandler(err, key, this.dataSources[index], this.logger)
+      const dataSource = this.dataSources[index]
+      const resolvedValue = await dataSource.get(loadParams).catch((err) => {
+        this.loadErrorHandler(err, key, dataSource, this.logger)
         if (this.throwIfLoadError) {
           throw err
         }
@@ -222,12 +223,13 @@ export class Loader<LoadedValue, LoadParams = string, LoadManyParams = LoadParam
     const loadValues = await this.loadManyFromLoaders(cachedValues.unresolvedKeys, loadParams)
 
     if (this.asyncCache) {
-      const cacheEntries: CacheEntry<LoadedValue>[] = loadValues.map((loadValue) => {
-        return {
-          key: this.cacheKeyFromValueResolver(loadValue),
-          value: loadValue,
-        }
-      })
+      const cacheEntries: CacheEntry<LoadedValue>[] = []
+      for (let i = 0; i < loadValues.length; i++) {
+        cacheEntries.push({
+          key: this.cacheKeyFromValueResolver(loadValues[i]),
+          value: loadValues[i],
+        })
+      }
 
       await this.asyncCache.setMany(cacheEntries).catch((err) => {
         this.cacheUpdateErrorHandler(
@@ -240,7 +242,8 @@ export class Loader<LoadedValue, LoadParams = string, LoadManyParams = LoadParam
     }
 
     return {
-      resolvedValues: [...cachedValues.resolvedValues, ...loadValues],
+      // concat instead of in-place push, as cachedValues may be owned by a user-implemented async cache
+      resolvedValues: cachedValues.resolvedValues.concat(loadValues),
 
       // there actually may still be some unresolved keys, but we no longer know that
       unresolvedKeys: [],
@@ -250,8 +253,9 @@ export class Loader<LoadedValue, LoadParams = string, LoadManyParams = LoadParam
   private async loadManyFromLoaders(keys: string[], loadParams: LoadManyParams) {
     let lastResolvedValues
     for (let index = 0; index < this.dataSources.length; index++) {
-      lastResolvedValues = await this.dataSources[index].getMany(keys, loadParams).catch((err) => {
-        this.loadErrorHandler(err, keys.toString(), this.dataSources[index], this.logger)
+      const dataSource = this.dataSources[index]
+      lastResolvedValues = await dataSource.getMany(keys, loadParams).catch((err) => {
+        this.loadErrorHandler(err, keys.toString(), dataSource, this.logger)
         if (this.throwIfLoadError) {
           throw err
         }

--- a/lib/redis/AbstractRedisCache.ts
+++ b/lib/redis/AbstractRedisCache.ts
@@ -18,6 +18,7 @@ export const DEFAULT_REDIS_CACHE_CONFIGURATION: RedisCacheConfiguration = {
 export abstract class AbstractRedisCache<ConfigType extends RedisCacheConfiguration, LoadedValue> {
   protected readonly redis: Redis
   protected readonly config: ConfigType
+  protected readonly keyPrefix: string
 
   constructor(redis: Redis, config: Partial<ConfigType>) {
     this.redis = redis
@@ -26,6 +27,7 @@ export abstract class AbstractRedisCache<ConfigType extends RedisCacheConfigurat
       ...DEFAULT_REDIS_CACHE_CONFIGURATION,
       ...config,
     }
+    this.keyPrefix = `${this.config.prefix}${this.config.separator}`
   }
 
   protected internalSet(resolvedKey: string, value: LoadedValue | null) {
@@ -64,10 +66,10 @@ export abstract class AbstractRedisCache<ConfigType extends RedisCacheConfigurat
   }
 
   resolveKey(key: string) {
-    return `${this.config.prefix}${this.config.separator}${key}`
+    return this.keyPrefix + key
   }
 
   resolveCachePattern() {
-    return `${this.config.prefix}${this.config.separator}*`
+    return `${this.keyPrefix}*`
   }
 }

--- a/lib/redis/RedisGroupCache.ts
+++ b/lib/redis/RedisGroupCache.ts
@@ -16,10 +16,13 @@ export interface RedisGroupCacheConfiguration extends RedisCacheConfiguration, G
 export class RedisGroupCache<T> extends AbstractRedisCache<RedisGroupCacheConfiguration, T> implements GroupCache<T> {
   public readonly expirationTimeLoadingGroupedOperation: GroupLoader<number>
   public ttlLeftBeforeRefreshInMsecs?: number
+  private readonly groupIndexPrefix: string
   name = 'Redis group cache'
 
   constructor(redis: Redis, config: Partial<RedisGroupCacheConfiguration> = {}) {
     super(redis, config)
+
+    this.groupIndexPrefix = `${this.keyPrefix}${GROUP_INDEX_KEY}${this.config.separator}`
 
     this.ttlLeftBeforeRefreshInMsecs = config.ttlLeftBeforeRefreshInMsecs
     this.redis.defineCommand('getOrSetZeroWithTtl', {
@@ -88,7 +91,8 @@ export class RedisGroupCache<T> extends AbstractRedisCache<RedisGroupCacheConfig
       }
     }
 
-    const transformedKeys = keys.map((key) => this.resolveKeyWithGroup(key, groupId, currentGroupKey))
+    const entryPrefix = this.resolveGroupEntryPrefix(groupId, currentGroupKey)
+    const transformedKeys = keys.map((key) => entryPrefix + key)
     const resolvedValues: T[] = []
     const unresolvedKeys: string[] = []
 
@@ -182,13 +186,14 @@ export class RedisGroupCache<T> extends AbstractRedisCache<RedisGroupCacheConfig
 
     const currentGroupKey = await getGroupKeyPromise
 
+    const entryPrefix = this.resolveGroupEntryPrefix(groupId, currentGroupKey)
     if (this.config.ttlInMsecs) {
       const setCommands = []
       for (let i = 0; i < entries.length; i++) {
         const entry = entries[i]
         setCommands.push([
           'set',
-          this.resolveKeyWithGroup(entry.key, groupId, currentGroupKey),
+          entryPrefix + entry.key,
           entry.value && this.config.json ? JSON.stringify(entry.value) : entry.value,
           'PX',
           this.config.ttlInMsecs,
@@ -202,18 +207,22 @@ export class RedisGroupCache<T> extends AbstractRedisCache<RedisGroupCacheConfig
     const commandParam = []
     for (let i = 0; i < entries.length; i++) {
       const entry = entries[i]
-      commandParam.push(this.resolveKeyWithGroup(entry.key, groupId, currentGroupKey))
+      commandParam.push(entryPrefix + entry.key)
       commandParam.push(entry.value && this.config.json ? JSON.stringify(entry.value) : entry.value)
     }
     return this.redis.mset(commandParam)
   }
 
   resolveKeyWithGroup(key: string, groupId: string, groupIndexKey: string) {
-    return `${this.config.prefix}${this.config.separator}${groupId}${this.config.separator}${groupIndexKey}${this.config.separator}${key}`
+    return this.resolveGroupEntryPrefix(groupId, groupIndexKey) + key
+  }
+
+  private resolveGroupEntryPrefix(groupId: string, groupIndexKey: string) {
+    return `${this.keyPrefix}${groupId}${this.config.separator}${groupIndexKey}${this.config.separator}`
   }
 
   resolveGroupIndexPrefix(groupId: string) {
-    return `${this.config.prefix}${this.config.separator}${GROUP_INDEX_KEY}${this.config.separator}${groupId}`
+    return this.groupIndexPrefix + groupId
   }
 
   async close() {

--- a/lib/util/unique.spec.ts
+++ b/lib/util/unique.spec.ts
@@ -2,6 +2,16 @@ import { describe, expect, it } from 'vitest'
 import { unique } from './unique'
 
 describe('unique', () => {
+  it('returns the same array reference for an empty array', () => {
+    const input: string[] = []
+    expect(unique(input)).toBe(input)
+  })
+
+  it('returns the same array reference for a single-element array', () => {
+    const input = ['key']
+    expect(unique(input)).toBe(input)
+  })
+
   it('returns the same array reference when there are no duplicates', () => {
     const input = [1, 2, 3, 'a', 'b']
     const result = unique(input)

--- a/lib/util/unique.ts
+++ b/lib/util/unique.ts
@@ -1,4 +1,7 @@
 export const unique = <T>(arr: T[]): T[] => {
+  if (arr.length <= 1) {
+    return arr
+  }
   const set = new Set(arr)
   return set.size === arr.length ? arr : Array.from(set)
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "homepage": "https://github.com/kibertoad/layered-loader",
   "dependencies": {
     "ioredis": "^5.10.1",
-    "toad-cache": "^3.7.1"
+    "toad-cache": "^3.7.4"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,8 +106,8 @@ importers:
         specifier: ^5.10.1
         version: 5.10.1
       toad-cache:
-        specifier: ^3.7.1
-        version: 3.7.1
+        specifier: ^3.7.4
+        version: 3.7.4
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.16
@@ -1568,12 +1568,12 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  toad-cache@3.7.0:
-    resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
-    engines: {node: '>=12'}
-
   toad-cache@3.7.1:
     resolution: {integrity: sha512-5DXWzE4Vz7xNHsv+xQ+MGfJYyC78Aok3tEr0MNwHoRf7vZnga1mQXZ4/Nsodld4VR6Wd+VhfmqnNrsRJyYPfrQ==}
+    engines: {node: '>=20'}
+
+  toad-cache@3.7.4:
+    resolution: {integrity: sha512-m1TdR/rvT7kgGJZhspNtXdsdYk0fddFpJJFlG5s+UkPFo6lkLoZ3YLOaovPYjq1R75NP5JfeTlSHaOsE09peCg==}
     engines: {node: '>=20'}
 
   tslib@2.8.1:
@@ -2549,7 +2549,7 @@ snapshots:
   '@fastify/cors@11.2.0':
     dependencies:
       fastify-plugin: 5.1.0
-      toad-cache: 3.7.0
+      toad-cache: 3.7.1
 
   '@fastify/error@4.2.0': {}
 
@@ -2598,7 +2598,7 @@ snapshots:
       fast-equals: 6.0.0
       json-stream-stringify: 3.1.6
       tmp: 0.2.5
-      toad-cache: 3.7.0
+      toad-cache: 3.7.1
       zod: 4.4.3
 
   '@message-queue-toolkit/schemas@7.1.0(zod@4.4.3)':
@@ -3197,7 +3197,7 @@ snapshots:
       rfdc: 1.4.1
       secure-json-parse: 4.1.0
       semver: 7.7.4
-      toad-cache: 3.7.0
+      toad-cache: 3.7.1
 
   fastq@1.20.1:
     dependencies:
@@ -3211,7 +3211,7 @@ snapshots:
       '@fastify/cors': 11.2.0
       '@smithy/node-http-handler': 4.7.0
       fastify: 5.8.5
-      toad-cache: 3.7.0
+      toad-cache: 3.7.1
       valibot: 1.4.0(typescript@6.0.3)
     transitivePeerDependencies:
       - aws-crt
@@ -3586,9 +3586,9 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  toad-cache@3.7.0: {}
-
   toad-cache@3.7.1: {}
+
+  toad-cache@3.7.4: {}
 
   tslib@2.8.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,8 @@
 packages:
   - 'packages/*'
 
+minimumReleaseAgeExclude:
+  - toad-cache@3.7.4
+
 onlyBuiltDependencies:
   - '@biomejs/biome'

--- a/test/GroupLoader-main.spec.ts
+++ b/test/GroupLoader-main.spec.ts
@@ -602,6 +602,28 @@ describe('GroupLoader Main', () => {
   })
 
   describe('getMany', () => {
+    it('serves cached null value without hitting the data source again', async () => {
+      const userValuesNull = {
+        [user1.companyId]: {
+          [user1.userId]: null,
+        },
+      }
+      const loader = new CountingGroupedLoader(userValuesNull as unknown as typeof userValues)
+      const operation = new GroupLoader<User>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        dataSources: [loader],
+        cacheKeyFromValueResolver: idResolver,
+      })
+
+      const value = await operation.get(user1.userId, user1.companyId)
+      expect(value).toBeNull()
+      expect(loader.counter).toBe(1)
+
+      const values = await operation.getMany([user1.userId], user1.companyId)
+      expect(values).toEqual([null])
+      expect(loader.counter).toBe(1)
+    })
+
     it('returns empty array when fails to resolve value', async () => {
       const operation = new GroupLoader<User>({
         cacheKeyFromValueResolver: idResolver,

--- a/test/Loader-main.spec.ts
+++ b/test/Loader-main.spec.ts
@@ -693,6 +693,23 @@ describe('Loader Main', () => {
   })
 
   describe('getMany', () => {
+    it('serves cached null value without hitting the data source again', async () => {
+      const dataSource = new CountingDataSource(null)
+      const operation = new Loader<string>({
+        inMemoryCache: IN_MEMORY_CACHE_CONFIG,
+        dataSources: [dataSource],
+        cacheKeyFromValueResolver: idResolver,
+      })
+
+      const value = await operation.get('key1')
+      expect(value).toBeNull()
+      expect(dataSource.counter).toBe(1)
+
+      const values = await operation.getMany(['key1'])
+      expect(values).toEqual([null])
+      expect(dataSource.counter).toBe(1)
+    })
+
     it('returns empty list when fails to resolve value', async () => {
       const operation = new Loader<string>({
         cacheKeyFromValueResolver: idResolver,


### PR DESCRIPTION
Rebases the still-relevant parts of #418 onto current `main`, which now includes #417.

The two bug fixes #418 originally carried already landed via #417:
- falsy value caching in `InMemoryCache.getMany` / `InMemoryGroupCache.getManyFromGroup` (`undefined` check instead of a truthy check)
- `InMemoryGroupCache` reads no longer inserting empty groups into the LRU

So this keeps only the performance and code-quality changes from #418:
- `AbstractFlatCache` / `AbstractGroupCache`: resolve the cache key once and reuse it across `getInMemoryOnly` / `getAsyncOnly` / `get` (new private `*Resolved` methods) instead of re-resolving per call. Layered on top of #417's write-back fencing.
- `getMany` merge appends async results into the in-memory result array in place (always freshly allocated) instead of spreading into a new array.
- `Loader` / `GroupLoader`: build cache entries with an explicit loop, merge cached and loaded values with `concat` (cachedValues may be owned by a user-implemented async cache), hoist the `dataSource` local.
- `AbstractRedisCache`: precompute `keyPrefix`. `RedisGroupCache`: precompute the group index prefix and per-group entry prefix.
- `unique()`: early return for arrays of 0-1 elements.

Regression tests added: falsy-caching path at the `Loader` / `GroupLoader` level, and the `unique()` early return.

`tsc --noEmit` is clean and the full suite (330 tests, Redis included) passes. Biome reports only the 8 formatting diagnostics already present on `main`; this change adds none.

Supersedes #418.