### PR TITLE
feat: support isEntryStillCurrentFn on in-memory-only loaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
   check instead of unconditionally refetching, and reset the entry's TTL when it is still current.
   Backed by new optional `resetTtl` / `resetTtlFromGroup` cache methods (implemented by `RedisCache`
   and `RedisGroupCache`). See the README section "Conditional refresh with a staleness check".
+- `isEntryStillCurrentFn` now also works on in-memory-only loaders: when no async cache is
+  configured, the check runs on the in-memory preemptive refresh path as long as the in-memory cache
+  has `ttlLeftBeforeRefreshInMsecs` set. `InMemoryCache` and `InMemoryGroupCache` gained `resetTtl` /
+  `resetTtlFromGroup` to support this. When both tiers have a refresh window, the async cache takes
+  precedence, so existing configurations are unaffected.
 - `GroupLoader.forceSetValueForGroup`, the group counterpart to `Loader.forceSetValue`.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -714,8 +714,10 @@ If refetching an entry is expensive, but *verifying* that it is still up-to-date
 
 When an entry enters the `ttlLeftBeforeRefreshInMsecs` window, the loader first invokes your check with the cached value instead of immediately starting a full background refresh:
 
-- if it resolves to `true`, the entry's TTL is reset to the full `ttlInMsecs` in both the async cache and the in-memory cache, and no data source call is made;
+- if it resolves to `true`, the entry's TTL is reset to the full `ttlInMsecs`, and no data source call is made;
 - if it resolves to `false` (or throws, or the entry disappeared in the meantime), the usual full background refresh from the data sources runs.
+
+The check works both with an async cache and with an in-memory-only loader. It only needs a preemptive refresh window (`ttlLeftBeforeRefreshInMsecs`) to fire inside: configure it on the `asyncCache`, or, for a loader that has no async tier, on the `inMemoryCache`. When both tiers have a refresh window, the async cache takes precedence and the check runs on its refresh path.
 
 ```ts
 const operation = new Loader<UserEntity>({
@@ -750,9 +752,26 @@ const operation = new GroupLoader<UserEntity>({
 })
 ```
 
+For a loader with no async cache, configure the refresh window on the in-memory cache instead - the check then runs against the in-memory value:
+
+```ts
+const operation = new Loader<UserEntity>({
+  inMemoryCache: {
+    ttlInMsecs: 1000 * 60,
+    ttlLeftBeforeRefreshInMsecs: 1000 * 20,
+  },
+  dataSources: [expensiveUserDataSource],
+  isEntryStillCurrentFn: async (cachedValue, loadParams) => {
+    // light query instead of refetching the whole entity
+    const updatedAt = await getUserUpdatedAt(loadParams)
+    return updatedAt.getTime() === new Date(cachedValue!.updatedAt).getTime()
+  },
+})
+```
+
 Things to keep in mind:
 
-- `isEntryStillCurrentFn` requires an `asyncCache` that has `ttlLeftBeforeRefreshInMsecs` configured (the check only runs inside that refresh window) and implements `resetTtl` (`resetTtlFromGroup` for group caches). `RedisCache` and `RedisGroupCache` implement the reset method; if you implement the `Cache` interface yourself, add the method to support conditional refresh. The loader throws at construction time if either requirement is missing.
+- `isEntryStillCurrentFn` requires a preemptive refresh window (`ttlLeftBeforeRefreshInMsecs`) to run inside, on either the `asyncCache` or the `inMemoryCache`. When it runs on the async path, the async cache must implement `resetTtl` (`resetTtlFromGroup` for group caches); `RedisCache` and `RedisGroupCache` implement it, and if you implement the `Cache` interface yourself, add the method to support conditional refresh. The in-memory caches implement the reset natively, so an in-memory-only loader needs no extra wiring. When both tiers have a refresh window, the async cache takes precedence. The loader throws at construction time if no refresh-capable tier is configured.
 - Errors thrown by the check are routed to `loadErrorHandler` and treated as "stale", so the worst case degrades to a regular full background refresh.
 - Staleness checks are deduplicated the same way background refreshes are - only one check runs per key at a time, and `ttlCacheTtl` limits how often expiration times are read from Redis.
 - No update notifications are published when a TTL is merely bumped, since the data has not changed; in-memory copies on other nodes expire on their own schedule and re-read the shared cache.

--- a/lib/AbstractCache.ts
+++ b/lib/AbstractCache.ts
@@ -199,11 +199,13 @@ export abstract class AbstractCache<
 
   /**
    * Runs the staleness check for an entry entering its refresh window and, when the check reports
-   * the entry as still current, extends its async cache TTL instead of refetching. Returns true
-   * only when the entry was confirmed current AND its TTL was successfully bumped, so the caller
-   * can safely skip the full background refresh. A check that throws is routed to loadErrorHandler
-   * and treated as stale; a bump that rejects is routed to cacheUpdateErrorHandler and also treated
-   * as stale, so the worst case degrades to a normal full refresh.
+   * the entry as still current, extends the entry's TTL (via the caller-supplied runResetTtl, which
+   * targets whichever tier owns the refresh window - the async cache or the in-memory cache) instead
+   * of refetching. Returns true only when the entry was confirmed current AND its TTL was
+   * successfully bumped, so the caller can safely skip the full background refresh. A check that
+   * throws is routed to loadErrorHandler and treated as stale; a bump that rejects is routed to
+   * cacheUpdateErrorHandler and also treated as stale, so the worst case degrades to a normal full
+   * refresh.
    */
   protected async isCurrentEntryTtlBumped(
     key: string,

--- a/lib/AbstractCache.ts
+++ b/lib/AbstractCache.ts
@@ -163,10 +163,11 @@ export abstract class AbstractCache<
   }
 
   /**
-   * Validates that an isEntryStillCurrentFn can actually run: it needs an asyncCache that has a
-   * refresh window configured (the check only fires inside it) and exposes the TTL-reset method
-   * used to bump the entry. Throws otherwise, so misconfiguration fails fast instead of silently
-   * turning the feature into a no-op.
+   * Validates that an isEntryStillCurrentFn can actually run: it needs a preemptive refresh window
+   * to fire inside. That window can be provided by the async cache (in which case the entry is bumped
+   * via its resetTtl/resetTtlFromGroup method) or, for in-memory-only loaders, by the in-memory
+   * cache. Throws otherwise, so misconfiguration fails fast instead of silently turning the feature
+   * into a no-op.
    */
   protected assertStalenessCheckSupported(
     isEntryStillCurrentFn: unknown,
@@ -176,21 +177,24 @@ export abstract class AbstractCache<
     if (!isEntryStillCurrentFn) {
       return
     }
-    if (!this.asyncCache) {
-      throw new Error(
-        'isEntryStillCurrentFn requires an asyncCache - the staleness check only applies to the async cache preemptive refresh path.',
-      )
+    // The async path takes precedence: when the async cache has a refresh window, the check runs
+    // there and needs the async cache's TTL-reset method.
+    if (this.asyncCache?.ttlLeftBeforeRefreshInMsecs) {
+      if (typeof resetTtlMethod !== 'function') {
+        throw new Error(
+          `The configured asyncCache does not support ${resetTtlMethodName}, which is required by isEntryStillCurrentFn.`,
+        )
+      }
+      return
     }
-    if (typeof resetTtlMethod !== 'function') {
-      throw new Error(
-        `The configured asyncCache does not support ${resetTtlMethodName}, which is required by isEntryStillCurrentFn.`,
-      )
+    // Otherwise the check runs on the in-memory preemptive refresh path, which needs an in-memory
+    // refresh window (the in-memory cache always exposes resetTtl/resetTtlFromGroup).
+    if (this.inMemoryCache.ttlLeftBeforeRefreshInMsecs) {
+      return
     }
-    if (!this.asyncCache.ttlLeftBeforeRefreshInMsecs) {
-      throw new Error(
-        'isEntryStillCurrentFn requires the asyncCache to have ttlLeftBeforeRefreshInMsecs configured - the staleness check only runs inside the preemptive refresh window.',
-      )
-    }
+    throw new Error(
+      'isEntryStillCurrentFn requires a preemptive refresh window: either an asyncCache with ttlLeftBeforeRefreshInMsecs and resetTtl/resetTtlFromGroup, or an inMemoryCache with ttlLeftBeforeRefreshInMsecs.',
+    )
   }
 
   /**

--- a/lib/AbstractCache.ts
+++ b/lib/AbstractCache.ts
@@ -223,7 +223,10 @@ export abstract class AbstractCache<
     }
 
     return runResetTtl().catch((err) => {
-      this.cacheUpdateErrorHandler(err, key, this.asyncCache!, this.logger)
+      // The reset runs on whichever tier owns the refresh window: the async cache when it has one,
+      // otherwise the in-memory cache. Report against the tier that actually failed so the handler
+      // never dereferences an undefined asyncCache on the in-memory-only path.
+      this.cacheUpdateErrorHandler(err, key, this.asyncCache ?? this.inMemoryCache, this.logger)
       return false
     })
   }

--- a/lib/AbstractFlatCache.ts
+++ b/lib/AbstractFlatCache.ts
@@ -27,11 +27,20 @@ export abstract class AbstractFlatCache<LoadedValue, LoadParams = string, LoadMa
     if (this.inMemoryCache.ttlLeftBeforeRefreshInMsecs && !this.runningLoads.has(key)) {
       const expirationTime = this.inMemoryCache.getExpirationTime(key)
       if (expirationTime && expirationTime - Date.now() < this.inMemoryCache.ttlLeftBeforeRefreshInMsecs) {
-        void this.getAsyncOnlyResolved(key, loadParams)
+        this.scheduleInMemoryRefresh(key, loadParams)
       }
     }
 
     return this.inMemoryCache.get(key)
+  }
+
+  /**
+   * Kicks off a preemptive in-memory refresh for an entry entering its refresh window. The default
+   * runs the blind background reload; subclasses (Loader) may override to run a staleness probe
+   * against the in-memory value and merely bump its TTL when it is still current.
+   */
+  protected scheduleInMemoryRefresh(key: string, loadParams: LoadParams): void {
+    void this.getAsyncOnlyResolved(key, loadParams)
   }
 
   public getManyInMemoryOnly(keys: string[]): GetManyResult<LoadedValue> {

--- a/lib/AbstractFlatCache.ts
+++ b/lib/AbstractFlatCache.ts
@@ -52,7 +52,7 @@ export abstract class AbstractFlatCache<LoadedValue, LoadParams = string, LoadMa
     return this.getAsyncOnlyResolved(this.cacheKeyFromLoadParamsResolver(loadParams), loadParams)
   }
 
-  private getAsyncOnlyResolved(key: string, loadParams: LoadParams): Promise<LoadedValue | undefined | null> {
+  protected getAsyncOnlyResolved(key: string, loadParams: LoadParams): Promise<LoadedValue | undefined | null> {
     const existingLoad = this.runningLoads.get(key)
     if (existingLoad) {
       return existingLoad

--- a/lib/AbstractGroupCache.ts
+++ b/lib/AbstractGroupCache.ts
@@ -80,7 +80,7 @@ export abstract class AbstractGroupCache<LoadedValue, LoadParams = string, LoadM
     return this.getAsyncOnlyResolved(this.cacheKeyFromLoadParamsResolver(loadParams), loadParams, group)
   }
 
-  private getAsyncOnlyResolved(
+  protected getAsyncOnlyResolved(
     key: string,
     loadParams: LoadParams,
     group: string,

--- a/lib/AbstractGroupCache.ts
+++ b/lib/AbstractGroupCache.ts
@@ -54,12 +54,21 @@ export abstract class AbstractGroupCache<LoadedValue, LoadParams = string, LoadM
       if (!this.runningLoads.get(group)?.has(key)) {
         const expirationTime = this.inMemoryCache.getExpirationTimeFromGroup(key, group)
         if (expirationTime && expirationTime - Date.now() < this.inMemoryCache.ttlLeftBeforeRefreshInMsecs) {
-          void this.getAsyncOnlyResolved(key, loadParams, group)
+          this.scheduleInMemoryRefresh(key, loadParams, group)
         }
       }
     }
 
     return this.inMemoryCache.getFromGroup(key, group)
+  }
+
+  /**
+   * Kicks off a preemptive in-memory refresh for an entry entering its refresh window. The default
+   * runs the blind background reload; subclasses (GroupLoader) may override to run a staleness probe
+   * against the in-memory value and merely bump its TTL when it is still current.
+   */
+  protected scheduleInMemoryRefresh(key: string, loadParams: LoadParams, group: string): void {
+    void this.getAsyncOnlyResolved(key, loadParams, group)
   }
 
   public getManyInMemoryOnly(keys: string[], group: string) {

--- a/lib/GroupLoader.ts
+++ b/lib/GroupLoader.ts
@@ -92,6 +92,61 @@ export class GroupLoader<LoadedValue, LoadParams = string, LoadManyParams = Load
     })
   }
 
+  protected override scheduleInMemoryRefresh(key: string, loadParams: LoadParams, group: string): void {
+    // No probe configured, or the async cache owns the probe (async wins) - use the default blind
+    // background reload, exactly as before.
+    if (!this.isEntryStillCurrentFn || this.asyncCache?.ttlLeftBeforeRefreshInMsecs) {
+      super.scheduleInMemoryRefresh(key, loadParams, group)
+      return
+    }
+
+    // Reuse the per-(group, key) refresh guard so concurrent in-window hits schedule a single probe.
+    let groupSet = this.groupRefreshFlags.get(group)
+    if (groupSet?.has(key)) {
+      return
+    }
+    if (!groupSet) {
+      groupSet = new Set<string>()
+      this.groupRefreshFlags.set(group, groupSet)
+    }
+    groupSet.add(key)
+
+    this.refreshOrBumpInMemoryTtl(key, group, loadParams)
+      .catch((err) => {
+        this.logger.error(err.message)
+      })
+      .finally(() => {
+        groupSet!.delete(key)
+        if (groupSet!.size === 0) {
+          this.groupRefreshFlags.delete(group)
+        }
+      })
+  }
+
+  private async refreshOrBumpInMemoryTtl(key: string, group: string, loadParams: LoadParams): Promise<void> {
+    const cachedValue = this.inMemoryCache.getFromGroup(key, group)
+    if (
+      this.isEntryStillCurrentFn &&
+      // undefined means the entry vanished (expired/invalidated) between the read and the probe.
+      cachedValue !== undefined &&
+      (await this.isCurrentEntryTtlBumped(
+        key,
+        () => this.isEntryStillCurrentFn!(cachedValue, loadParams, group),
+        () => Promise.resolve(this.inMemoryCache.resetTtlFromGroup(key, group)),
+      ))
+    ) {
+      // Still current - the in-memory TTL was bumped, nothing else to do.
+      return
+    }
+
+    // The entry is stale, the check failed, or the bump failed (entry expired or the group was
+    // invalidated meanwhile), so run the full background refresh from the data sources.
+    const freshValue = await this.loadFromLoaders(key, group, loadParams)
+    if (freshValue !== undefined) {
+      this.inMemoryCache.setForGroup(key, freshValue, group)
+    }
+  }
+
   private async refreshOrBumpTtl(
     key: string,
     group: string,

--- a/lib/GroupLoader.ts
+++ b/lib/GroupLoader.ts
@@ -140,11 +140,13 @@ export class GroupLoader<LoadedValue, LoadParams = string, LoadManyParams = Load
     }
 
     // The entry is stale, the check failed, or the bump failed (entry expired or the group was
-    // invalidated meanwhile), so run the full background refresh from the data sources.
-    const freshValue = await this.loadFromLoaders(key, group, loadParams)
-    if (freshValue !== undefined) {
-      this.inMemoryCache.setForGroup(key, freshValue, group)
-    }
+    // invalidated meanwhile), so run the full background refresh. Route it through
+    // getAsyncOnlyResolved rather than calling loadFromLoaders + inMemoryCache.setForGroup directly:
+    // that registers the reload in the group's runningLoads, so it is deduplicated against a
+    // concurrent cache-miss load and, crucially, fenced by invalidateCacheFor / forceSetValueForGroup
+    // - an in-flight result whose entry was invalidated or force-set meanwhile is discarded instead
+    // of resurrecting or clobbering the entry.
+    await this.getAsyncOnlyResolved(key, loadParams, group)
   }
 
   private async refreshOrBumpTtl(

--- a/lib/Loader.ts
+++ b/lib/Loader.ts
@@ -153,6 +153,52 @@ export class Loader<LoadedValue, LoadParams = string, LoadManyParams = LoadParam
     })
   }
 
+  protected override scheduleInMemoryRefresh(key: string, loadParams: LoadParams): void {
+    // No probe configured, or the async cache owns the probe (async wins) - use the default blind
+    // background reload, exactly as before.
+    if (!this.isEntryStillCurrentFn || this.asyncCache?.ttlLeftBeforeRefreshInMsecs) {
+      super.scheduleInMemoryRefresh(key, loadParams)
+      return
+    }
+
+    // Reuse the flat refresh guard so concurrent in-window hits schedule a single probe.
+    if (this.isKeyRefreshing.has(key)) {
+      return
+    }
+    this.isKeyRefreshing.add(key)
+    this.refreshOrBumpInMemoryTtl(key, loadParams)
+      .catch((err) => {
+        this.logger.error(err.message)
+      })
+      .finally(() => {
+        this.isKeyRefreshing.delete(key)
+      })
+  }
+
+  private async refreshOrBumpInMemoryTtl(key: string, loadParams: LoadParams): Promise<void> {
+    const cachedValue = this.inMemoryCache.get(key)
+    if (
+      this.isEntryStillCurrentFn &&
+      // undefined means the entry vanished (expired/invalidated) between the read and the probe.
+      cachedValue !== undefined &&
+      (await this.isCurrentEntryTtlBumped(
+        key,
+        () => this.isEntryStillCurrentFn!(cachedValue, loadParams),
+        () => Promise.resolve(this.inMemoryCache.resetTtl(key)),
+      ))
+    ) {
+      // Still current - the in-memory TTL was bumped, nothing else to do.
+      return
+    }
+
+    // The entry is stale, the check failed, or the bump failed (entry expired/deleted meanwhile),
+    // so run the full background refresh from the data sources.
+    const freshValue = await this.loadFromLoaders(key, loadParams)
+    if (freshValue !== undefined) {
+      this.inMemoryCache.set(key, freshValue)
+    }
+  }
+
   private async refreshOrBumpTtl(key: string, loadParams: LoadParams, cachedValue: LoadedValue | null): Promise<void> {
     if (
       this.isEntryStillCurrentFn &&

--- a/lib/Loader.ts
+++ b/lib/Loader.ts
@@ -192,11 +192,12 @@ export class Loader<LoadedValue, LoadParams = string, LoadManyParams = LoadParam
     }
 
     // The entry is stale, the check failed, or the bump failed (entry expired/deleted meanwhile),
-    // so run the full background refresh from the data sources.
-    const freshValue = await this.loadFromLoaders(key, loadParams)
-    if (freshValue !== undefined) {
-      this.inMemoryCache.set(key, freshValue)
-    }
+    // so run the full background refresh. Route it through getAsyncOnlyResolved rather than calling
+    // loadFromLoaders + inMemoryCache.set directly: that registers the reload in runningLoads, so it
+    // is deduplicated against a concurrent cache-miss load and, crucially, fenced by
+    // invalidateCacheFor / forceSetValue - an in-flight result whose entry was invalidated or
+    // force-set meanwhile is discarded instead of resurrecting or clobbering the entry.
+    await this.getAsyncOnlyResolved(key, loadParams)
   }
 
   private async refreshOrBumpTtl(key: string, loadParams: LoadParams, cachedValue: LoadedValue | null): Promise<void> {

--- a/lib/memory/InMemoryCache.ts
+++ b/lib/memory/InMemoryCache.ts
@@ -81,4 +81,15 @@ export class InMemoryCache<T> implements SynchronousCache<T> {
   set(key: string, value: T | null): void {
     this.cache.set(key, value)
   }
+
+  resetTtl(key: string): boolean {
+    // null is a valid cached value ("resolved to empty"); only undefined means the entry is gone.
+    const value = this.cache.get(key)
+    if (value === undefined) {
+      return false
+    }
+    // Re-setting the same value slides toad-cache's expiry forward by a full ttlInMsecs.
+    this.cache.set(key, value)
+    return true
+  }
 }

--- a/lib/memory/InMemoryGroupCache.ts
+++ b/lib/memory/InMemoryGroupCache.ts
@@ -128,4 +128,20 @@ export class InMemoryGroupCache<T> implements SynchronousGroupCache<T> {
     // do not use resolveGroup here - reads must not insert empty groups into the LRU
     return this.groups.get(groupId)?.expiresAt(key)
   }
+
+  resetTtlFromGroup(key: string, groupId: string): boolean {
+    // do not use resolveGroup here - reads must not insert empty groups into the LRU
+    const group = this.groups.get(groupId)
+    if (!group) {
+      return false
+    }
+    // null is a valid cached value ("resolved to empty"); only undefined means the entry is gone.
+    const value = group.get(key)
+    if (value === undefined) {
+      return false
+    }
+    // Re-setting the same value slides toad-cache's expiry forward by a full ttlInMsecs.
+    group.set(key, value)
+    return true
+  }
 }

--- a/lib/memory/NoopCache.ts
+++ b/lib/memory/NoopCache.ts
@@ -46,4 +46,12 @@ export class NoopCache<T> implements SynchronousCache<T>, SynchronousGroupCache<
   }
 
   set(): void {}
+
+  resetTtl(): boolean {
+    return false
+  }
+
+  resetTtlFromGroup(): boolean {
+    return false
+  }
 }

--- a/lib/types/SyncDataSources.ts
+++ b/lib/types/SyncDataSources.ts
@@ -15,6 +15,13 @@ export interface SynchronousCache<LoadedValue> extends SynchronousWriteCache<Loa
   get: (key: string) => LoadedValue | undefined | null
   getMany: (keys: string[]) => GetManyResult<LoadedValue>
   getExpirationTime: (key: string) => number | undefined
+
+  /**
+   * Resets the entry's TTL back to the full configured ttlInMsecs without changing the value.
+   * Returns `true` if the entry existed and its TTL was extended, `false` if it had already
+   * vanished (expired or invalidated).
+   */
+  resetTtl: (key: string) => boolean
 }
 
 export interface SynchronousWriteGroupCache<T> {
@@ -29,4 +36,11 @@ export interface SynchronousGroupCache<T> extends SynchronousWriteGroupCache<T> 
   getFromGroup: (key: string, group: string) => T | undefined | null
   getManyFromGroup: (keys: string[], group: string) => GetManyResult<T>
   getExpirationTimeFromGroup: (key: string, group: string) => number | undefined
+
+  /**
+   * Resets the entry's TTL back to the full configured ttlInMsecs without changing the value.
+   * Returns `true` if the entry existed and its TTL was extended, `false` if it (or its group)
+   * had already vanished (expired or invalidated).
+   */
+  resetTtlFromGroup: (key: string, group: string) => boolean
 }

--- a/test/GroupLoader-in-memory-staleness-check.spec.ts
+++ b/test/GroupLoader-in-memory-staleness-check.spec.ts
@@ -239,4 +239,79 @@ describe('GroupLoader in-memory-only staleness check', () => {
     // The empty Set for the group should have been cleaned up
     expect(groupRefreshFlags.has(user1.companyId)).toBe(false)
   })
+
+  it('does not resurrect an entry invalidated while the fallback reload is in flight', async () => {
+    let releaseLoad: (value: User) => void
+    const secondLoad = new Promise<User>((resolve) => {
+      releaseLoad = resolve
+    })
+    let calls = 0
+    const dataSource = {
+      name: 'controlled',
+      getFromGroup: () => {
+        calls++
+        return calls === 1 ? Promise.resolve(user1) : secondLoad
+      },
+      getManyFromGroup: () => Promise.resolve([] as User[]),
+    }
+    const operation = new GroupLoader<User>({
+      inMemoryCache: { ttlInMsecs: 150, ttlLeftBeforeRefreshInMsecs: 75 },
+      dataSources: [dataSource],
+      isEntryStillCurrentFn: async () => false, // always stale, so the fallback reload runs
+    })
+    expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+
+    await setTimeout(100)
+    // kick off the check (stale) - the fallback reload is now in flight and hanging
+    expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+    for (let attempt = 0; attempt < 20 && calls < 2; attempt++) {
+      await setTimeout(10)
+    }
+    expect(calls).toBe(2)
+
+    // invalidate while the fallback reload is still in flight, then let it resolve
+    await operation.invalidateCacheFor(user1.userId, user1.companyId)
+    releaseLoad!(user3)
+    await setTimeout(10)
+
+    // the in-flight result must be fenced out - the entry stays evicted, not resurrected
+    expect(operation.getInMemoryOnly(user1.userId, user1.companyId)).toBeUndefined()
+  })
+
+  it('does not clobber a forceSetValueForGroup that lands while the fallback reload is in flight', async () => {
+    let releaseLoad: (value: User) => void
+    const secondLoad = new Promise<User>((resolve) => {
+      releaseLoad = resolve
+    })
+    let calls = 0
+    const dataSource = {
+      name: 'controlled',
+      getFromGroup: () => {
+        calls++
+        return calls === 1 ? Promise.resolve(user1) : secondLoad
+      },
+      getManyFromGroup: () => Promise.resolve([] as User[]),
+    }
+    const operation = new GroupLoader<User>({
+      inMemoryCache: { ttlInMsecs: 150, ttlLeftBeforeRefreshInMsecs: 75 },
+      dataSources: [dataSource],
+      isEntryStillCurrentFn: async () => false,
+    })
+    expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+
+    await setTimeout(100)
+    expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+    for (let attempt = 0; attempt < 20 && calls < 2; attempt++) {
+      await setTimeout(10)
+    }
+    expect(calls).toBe(2)
+
+    // an authoritative write lands while the stale reload is still in flight
+    await operation.forceSetValueForGroup(user1.userId, user3, user1.companyId)
+    releaseLoad!(user1)
+    await setTimeout(10)
+
+    // the forced value survives - the in-flight stale reload is discarded, not written over it
+    expect(operation.getInMemoryOnly(user1.userId, user1.companyId)).toEqual(user3)
+  })
 })

--- a/test/GroupLoader-in-memory-staleness-check.spec.ts
+++ b/test/GroupLoader-in-memory-staleness-check.spec.ts
@@ -1,0 +1,242 @@
+import { setTimeout } from 'node:timers/promises'
+import { beforeEach, describe, expect, it, vitest } from 'vitest'
+import { GroupLoader } from '../lib/GroupLoader'
+import { CountingGroupedLoader } from './fakes/CountingGroupedLoader'
+import type { User } from './types/testTypes'
+
+const user1: User = {
+  companyId: '1',
+  userId: '1',
+}
+
+const user3: User = {
+  companyId: '2',
+  userId: '3',
+}
+
+const userValues = {
+  [user1.companyId]: {
+    [user1.userId]: user1,
+  },
+  [user3.companyId]: {
+    [user3.userId]: user3,
+  },
+}
+
+// These tests exercise the staleness probe running on the in-memory-only refresh path - no async
+// cache is configured, so nothing here needs Redis.
+describe('GroupLoader in-memory-only staleness check', () => {
+  beforeEach(() => {
+    vitest.resetAllMocks()
+  })
+
+  it('bumps ttl without refetching when entry is still current', async () => {
+    const loader = new CountingGroupedLoader(userValues)
+    const isEntryStillCurrentFn = vitest.fn(async () => true)
+
+    const operation = new GroupLoader<User>({
+      inMemoryCache: { ttlInMsecs: 150, ttlLeftBeforeRefreshInMsecs: 75 },
+      dataSources: [loader],
+      isEntryStillCurrentFn,
+    })
+    expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+    expect(loader.counter).toBe(1)
+    // @ts-expect-error accessing the protected in-memory cache for assertions
+    const expirationTimePre = operation.inMemoryCache.getExpirationTimeFromGroup(
+      user1.userId,
+      user1.companyId,
+    )
+
+    await setTimeout(100)
+    // kick off the staleness check
+    expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+    for (let attempt = 0; attempt < 20 && isEntryStillCurrentFn.mock.calls.length < 1; attempt++) {
+      await setTimeout(10)
+    }
+    expect(isEntryStillCurrentFn).toHaveBeenCalledWith(user1, user1.userId, user1.companyId)
+    await setTimeout(10)
+
+    // no full refetch happened, and the in-memory ttl was extended
+    expect(loader.counter).toBe(1)
+    // @ts-expect-error accessing the protected in-memory cache for assertions
+    const expirationTimePost = operation.inMemoryCache.getExpirationTimeFromGroup(
+      user1.userId,
+      user1.companyId,
+    )
+    expect(expirationTimePre).toBeDefined()
+    expect(expirationTimePost).toBeDefined()
+    expect(expirationTimePost! > expirationTimePre!).toBe(true)
+  })
+
+  it('does not touch other groups when bumping ttl', async () => {
+    const loader = new CountingGroupedLoader(userValues)
+    const operation = new GroupLoader<User>({
+      inMemoryCache: { ttlInMsecs: 150, ttlLeftBeforeRefreshInMsecs: 75 },
+      dataSources: [loader],
+      isEntryStillCurrentFn: async () => true,
+    })
+    // prime both groups
+    expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+    expect(await operation.get(user3.userId, user3.companyId)).toEqual(user3)
+    expect(loader.counter).toBe(2)
+    // @ts-expect-error accessing the protected in-memory cache for assertions
+    const otherGroupExpirationPre = operation.inMemoryCache.getExpirationTimeFromGroup(
+      user3.userId,
+      user3.companyId,
+    )
+
+    await setTimeout(100)
+    // only bump group user1.companyId
+    expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+    await setTimeout(30)
+
+    expect(loader.counter).toBe(2)
+    // @ts-expect-error accessing the protected in-memory cache for assertions
+    const otherGroupExpirationPost = operation.inMemoryCache.getExpirationTimeFromGroup(
+      user3.userId,
+      user3.companyId,
+    )
+    // the untouched group's ttl was not extended by the bump on the other group
+    expect(otherGroupExpirationPost).toBe(otherGroupExpirationPre)
+  })
+
+  it('falls back to full background refetch when entry is stale', async () => {
+    const loader = new CountingGroupedLoader(userValues)
+    const operation = new GroupLoader<User>({
+      inMemoryCache: { ttlInMsecs: 150, ttlLeftBeforeRefreshInMsecs: 75 },
+      dataSources: [loader],
+      isEntryStillCurrentFn: async () => false,
+    })
+    expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+    expect(loader.counter).toBe(1)
+
+    await setTimeout(100)
+    // reads are never blocked - the stale-but-valid value is served while the refresh runs
+    expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+    for (let attempt = 0; attempt < 20 && loader.counter < 2; attempt++) {
+      await setTimeout(10)
+    }
+    expect(loader.counter).toBe(2)
+  })
+
+  it('treats a throwing staleness check as stale and refetches', async () => {
+    const loader = new CountingGroupedLoader(userValues)
+    const loadErrorHandler = vitest.fn()
+
+    const operation = new GroupLoader<User>({
+      inMemoryCache: { ttlInMsecs: 150, ttlLeftBeforeRefreshInMsecs: 75 },
+      dataSources: [loader],
+      isEntryStillCurrentFn: async () => {
+        throw new Error('check failed')
+      },
+      loadErrorHandler,
+    })
+    expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+    expect(loader.counter).toBe(1)
+
+    await setTimeout(100)
+    // kick off the check, which throws
+    expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+    for (let attempt = 0; attempt < 20 && loader.counter < 2; attempt++) {
+      await setTimeout(10)
+    }
+    expect(loader.counter).toBe(2)
+    expect(loadErrorHandler).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'check failed' }),
+      user1.userId,
+      expect.objectContaining({ name: 'isEntryStillCurrentFn' }),
+      expect.anything(),
+    )
+  })
+
+  it('refetches when the entry disappears between the read and the ttl bump', async () => {
+    const loader = new CountingGroupedLoader(userValues)
+    let finishCheck: (isCurrent: boolean) => void
+    const checkPromise = new Promise<boolean>((resolve) => {
+      finishCheck = resolve
+    })
+    const operation = new GroupLoader<User>({
+      inMemoryCache: { ttlInMsecs: 150, ttlLeftBeforeRefreshInMsecs: 75 },
+      dataSources: [loader],
+      isEntryStillCurrentFn: () => checkPromise,
+    })
+    expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+    expect(loader.counter).toBe(1)
+
+    await setTimeout(100)
+    // kick off the check, which hangs while we invalidate the entry concurrently
+    expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+    await setTimeout(10)
+    await operation.invalidateCacheFor(user1.userId, user1.companyId)
+    // the check now reports "still current", but the ttl bump fails because the entry is gone
+    finishCheck!(true)
+    for (let attempt = 0; attempt < 20 && loader.counter < 2; attempt++) {
+      await setTimeout(10)
+    }
+    expect(loader.counter).toBe(2)
+  })
+
+  it('logs and swallows an error thrown by the fallback reload', async () => {
+    let calls = 0
+    const dataSource = {
+      name: 'flaky',
+      getFromGroup: () => {
+        calls++
+        return calls === 1 ? Promise.resolve(user1) : Promise.reject(new Error('boom'))
+      },
+      getManyFromGroup: () => Promise.resolve([] as User[]),
+    }
+    const operation = new GroupLoader<User>({
+      inMemoryCache: { ttlInMsecs: 150, ttlLeftBeforeRefreshInMsecs: 75 },
+      dataSources: [dataSource],
+      isEntryStillCurrentFn: async () => false,
+    })
+    // @ts-expect-error spying on the protected logger
+    const errorSpy = vitest.spyOn(operation.logger, 'error').mockImplementation(() => {})
+
+    expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+
+    await setTimeout(100)
+    // kick off the check (stale), whose fallback reload rejects
+    expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+    for (let attempt = 0; attempt < 20 && errorSpy.mock.calls.length < 1; attempt++) {
+      await setTimeout(10)
+    }
+    expect(errorSpy).toHaveBeenCalledWith('boom')
+  })
+
+  it('only runs a single staleness check for concurrent gets', async () => {
+    const loader = new CountingGroupedLoader(userValues)
+
+    let finishCheck: (isCurrent: boolean) => void
+    const checkPromise = new Promise<boolean>((resolve) => {
+      finishCheck = resolve
+    })
+    const isEntryStillCurrentFn = vitest.fn(() => checkPromise)
+
+    const operation = new GroupLoader<User>({
+      inMemoryCache: { ttlInMsecs: 9999, ttlLeftBeforeRefreshInMsecs: 9925 },
+      dataSources: [loader],
+      isEntryStillCurrentFn,
+    })
+    expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+    expect(loader.counter).toBe(1)
+
+    await setTimeout(90)
+    // kick off the check and keep it hanging while more gets come in
+    expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+    expect(operation.getInMemoryOnly(user1.userId, user1.companyId)).toEqual(user1)
+    expect(operation.getInMemoryOnly(user1.userId, user1.companyId)).toEqual(user1)
+    await setTimeout(10)
+    finishCheck!(true)
+    await setTimeout(10)
+
+    expect(isEntryStillCurrentFn).toHaveBeenCalledTimes(1)
+    expect(loader.counter).toBe(1)
+
+    // @ts-expect-error accessing the private refresh guard for assertions
+    const groupRefreshFlags: Map<string, Set<string>> = operation.groupRefreshFlags
+    // The empty Set for the group should have been cleaned up
+    expect(groupRefreshFlags.has(user1.companyId)).toBe(false)
+  })
+})

--- a/test/GroupLoader-staleness-check.spec.ts
+++ b/test/GroupLoader-staleness-check.spec.ts
@@ -347,21 +347,35 @@ describe('GroupLoader staleness check', () => {
   })
 
   describe('constructor', () => {
-    it('throws when isEntryStillCurrentFn is set without an asyncCache', () => {
+    it('throws when isEntryStillCurrentFn is set without any refresh window', () => {
       expect(
         () =>
           new GroupLoader<User>({
             dataSources: [new CountingGroupedLoader(userValues)],
             isEntryStillCurrentFn: async () => true,
           }),
-      ).toThrow(/isEntryStillCurrentFn requires an asyncCache/)
+      ).toThrow(/requires a preemptive refresh window/)
     })
 
-    it('throws when the asyncCache does not support resetTtlFromGroup', () => {
+    it('accepts isEntryStillCurrentFn with an in-memory-only refresh window', () => {
       expect(
         () =>
           new GroupLoader<User>({
-            asyncCache: new DummyGroupedCache(userValues),
+            inMemoryCache: { ttlInMsecs: 150, ttlLeftBeforeRefreshInMsecs: 75 },
+            dataSources: [new CountingGroupedLoader(userValues)],
+            isEntryStillCurrentFn: async () => true,
+          }),
+      ).not.toThrow()
+    })
+
+    it('throws when the asyncCache does not support resetTtlFromGroup', () => {
+      const asyncCache = new DummyGroupedCache(userValues)
+      // give the fake a refresh window so the async probe path (which requires resetTtlFromGroup) is reached
+      asyncCache.ttlLeftBeforeRefreshInMsecs = 999999
+      expect(
+        () =>
+          new GroupLoader<User>({
+            asyncCache,
             dataSources: [new CountingGroupedLoader(userValues)],
             isEntryStillCurrentFn: async () => true,
           }),

--- a/test/Loader-in-memory-staleness-check.spec.ts
+++ b/test/Loader-in-memory-staleness-check.spec.ts
@@ -188,4 +188,79 @@ describe('Loader in-memory-only staleness check', () => {
     const isKeyRefreshing: Set<string> = operation.isKeyRefreshing
     expect(isKeyRefreshing.has('key')).toBe(false)
   })
+
+  it('does not resurrect an entry invalidated while the fallback reload is in flight', async () => {
+    let releaseLoad: (value: string) => void
+    const secondLoad = new Promise<string>((resolve) => {
+      releaseLoad = resolve
+    })
+    let calls = 0
+    const dataSource = {
+      name: 'controlled',
+      get: () => {
+        calls++
+        return calls === 1 ? Promise.resolve('value') : secondLoad
+      },
+      getMany: () => Promise.resolve([] as string[]),
+    }
+    const operation = new Loader<string>({
+      inMemoryCache: { ttlInMsecs: 150, ttlLeftBeforeRefreshInMsecs: 75 },
+      dataSources: [dataSource],
+      isEntryStillCurrentFn: async () => false, // always stale, so the fallback reload runs
+    })
+    expect(await operation.get('key')).toBe('value')
+
+    await setTimeout(100)
+    // kick off the check (stale) - the fallback reload is now in flight and hanging
+    expect(await operation.get('key')).toBe('value')
+    for (let attempt = 0; attempt < 20 && calls < 2; attempt++) {
+      await setTimeout(10)
+    }
+    expect(calls).toBe(2)
+
+    // invalidate while the fallback reload is still in flight, then let it resolve
+    await operation.invalidateCacheFor('key')
+    releaseLoad!('resurrected')
+    await setTimeout(10)
+
+    // the in-flight result must be fenced out - the entry stays evicted, not resurrected
+    expect(operation.getInMemoryOnly('key')).toBeUndefined()
+  })
+
+  it('does not clobber a forceSetValue that lands while the fallback reload is in flight', async () => {
+    let releaseLoad: (value: string) => void
+    const secondLoad = new Promise<string>((resolve) => {
+      releaseLoad = resolve
+    })
+    let calls = 0
+    const dataSource = {
+      name: 'controlled',
+      get: () => {
+        calls++
+        return calls === 1 ? Promise.resolve('value') : secondLoad
+      },
+      getMany: () => Promise.resolve([] as string[]),
+    }
+    const operation = new Loader<string>({
+      inMemoryCache: { ttlInMsecs: 150, ttlLeftBeforeRefreshInMsecs: 75 },
+      dataSources: [dataSource],
+      isEntryStillCurrentFn: async () => false,
+    })
+    expect(await operation.get('key')).toBe('value')
+
+    await setTimeout(100)
+    expect(await operation.get('key')).toBe('value')
+    for (let attempt = 0; attempt < 20 && calls < 2; attempt++) {
+      await setTimeout(10)
+    }
+    expect(calls).toBe(2)
+
+    // an authoritative write lands while the stale reload is still in flight
+    await operation.forceSetValue('key', 'forced')
+    releaseLoad!('stale')
+    await setTimeout(10)
+
+    // the forced value survives - the in-flight stale reload is discarded, not written over it
+    expect(operation.getInMemoryOnly('key')).toBe('forced')
+  })
 })

--- a/test/Loader-in-memory-staleness-check.spec.ts
+++ b/test/Loader-in-memory-staleness-check.spec.ts
@@ -1,0 +1,191 @@
+import { setTimeout } from 'node:timers/promises'
+import { beforeEach, describe, expect, it, vitest } from 'vitest'
+import { Loader } from '../lib/Loader'
+import { CountingDataSource } from './fakes/CountingDataSource'
+
+// These tests exercise the staleness probe running on the in-memory-only refresh path - no async
+// cache is configured, so nothing here needs Redis.
+describe('Loader in-memory-only staleness check', () => {
+  beforeEach(() => {
+    vitest.resetAllMocks()
+  })
+
+  it('bumps ttl without refetching when entry is still current', async () => {
+    const loader = new CountingDataSource('value')
+    const isEntryStillCurrentFn = vitest.fn(async () => true)
+
+    const operation = new Loader<string>({
+      inMemoryCache: { ttlInMsecs: 150, ttlLeftBeforeRefreshInMsecs: 75 },
+      dataSources: [loader],
+      isEntryStillCurrentFn,
+    })
+    expect(await operation.get('key')).toBe('value')
+    expect(loader.counter).toBe(1)
+    // @ts-expect-error accessing the protected in-memory cache for assertions
+    const expirationTimePre = operation.inMemoryCache.getExpirationTime('key')
+
+    await setTimeout(100)
+    // kick off the staleness check
+    expect(await operation.get('key')).toBe('value')
+    for (let attempt = 0; attempt < 20 && isEntryStillCurrentFn.mock.calls.length < 1; attempt++) {
+      await setTimeout(10)
+    }
+    expect(isEntryStillCurrentFn).toHaveBeenCalledWith('value', 'key')
+    await setTimeout(10)
+
+    // no full refetch happened, and the in-memory ttl was extended
+    expect(loader.counter).toBe(1)
+    // @ts-expect-error accessing the protected in-memory cache for assertions
+    const expirationTimePost = operation.inMemoryCache.getExpirationTime('key')
+    expect(expirationTimePre).toBeDefined()
+    expect(expirationTimePost).toBeDefined()
+    expect(expirationTimePost! > expirationTimePre!).toBe(true)
+
+    // the entry survives past its original expiry and is still served from memory
+    await setTimeout(80) // now beyond the original 150ms ttl
+    expect(operation.getInMemoryOnly('key')).toBe('value')
+  })
+
+  it('falls back to full background refetch when entry is stale', async () => {
+    const loader = new CountingDataSource('v1')
+    const operation = new Loader<string>({
+      inMemoryCache: { ttlInMsecs: 150, ttlLeftBeforeRefreshInMsecs: 75 },
+      dataSources: [loader],
+      isEntryStillCurrentFn: async () => false,
+    })
+    expect(await operation.get('key')).toBe('v1')
+    expect(loader.counter).toBe(1)
+
+    // the data source has moved on
+    loader.value = 'v2'
+    await setTimeout(100)
+    // reads are never blocked - the stale-but-valid value is served while the refresh runs
+    expect(await operation.get('key')).toBe('v1')
+    for (let attempt = 0; attempt < 20 && loader.counter < 2; attempt++) {
+      await setTimeout(10)
+    }
+    expect(loader.counter).toBe(2)
+    // the freshly loaded value is now in the in-memory cache
+    expect(operation.getInMemoryOnly('key')).toBe('v2')
+  })
+
+  it('treats a throwing staleness check as stale and refetches', async () => {
+    const loader = new CountingDataSource('value')
+    const loadErrorHandler = vitest.fn()
+
+    const operation = new Loader<string>({
+      inMemoryCache: { ttlInMsecs: 150, ttlLeftBeforeRefreshInMsecs: 75 },
+      dataSources: [loader],
+      isEntryStillCurrentFn: async () => {
+        throw new Error('check failed')
+      },
+      loadErrorHandler,
+    })
+    expect(await operation.get('key')).toBe('value')
+    expect(loader.counter).toBe(1)
+
+    await setTimeout(100)
+    // kick off the check, which throws
+    expect(await operation.get('key')).toBe('value')
+    for (let attempt = 0; attempt < 20 && loader.counter < 2; attempt++) {
+      await setTimeout(10)
+    }
+    expect(loader.counter).toBe(2)
+    expect(loadErrorHandler).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'check failed' }),
+      'key',
+      expect.objectContaining({ name: 'isEntryStillCurrentFn' }),
+      expect.anything(),
+    )
+  })
+
+  it('refetches when the entry disappears between the read and the ttl bump', async () => {
+    const loader = new CountingDataSource('value')
+    let finishCheck: (isCurrent: boolean) => void
+    const checkPromise = new Promise<boolean>((resolve) => {
+      finishCheck = resolve
+    })
+    const operation = new Loader<string>({
+      inMemoryCache: { ttlInMsecs: 150, ttlLeftBeforeRefreshInMsecs: 75 },
+      dataSources: [loader],
+      isEntryStillCurrentFn: () => checkPromise,
+    })
+    expect(await operation.get('key')).toBe('value')
+    expect(loader.counter).toBe(1)
+
+    await setTimeout(100)
+    // kick off the check, which hangs while we invalidate the entry concurrently
+    expect(await operation.get('key')).toBe('value')
+    await setTimeout(10)
+    await operation.invalidateCacheFor('key')
+    // the check now reports "still current", but the ttl bump fails because the entry is gone
+    finishCheck!(true)
+    for (let attempt = 0; attempt < 20 && loader.counter < 2; attempt++) {
+      await setTimeout(10)
+    }
+    expect(loader.counter).toBe(2)
+  })
+
+  it('logs and swallows an error thrown by the fallback reload', async () => {
+    let calls = 0
+    const dataSource = {
+      name: 'flaky',
+      get: () => {
+        calls++
+        return calls === 1 ? Promise.resolve('value') : Promise.reject(new Error('boom'))
+      },
+      getMany: () => Promise.resolve([] as string[]),
+    }
+    const operation = new Loader<string>({
+      inMemoryCache: { ttlInMsecs: 150, ttlLeftBeforeRefreshInMsecs: 75 },
+      dataSources: [dataSource],
+      isEntryStillCurrentFn: async () => false,
+    })
+    // @ts-expect-error spying on the protected logger
+    const errorSpy = vitest.spyOn(operation.logger, 'error').mockImplementation(() => {})
+
+    expect(await operation.get('key')).toBe('value')
+
+    await setTimeout(100)
+    // kick off the check (stale), whose fallback reload rejects
+    expect(await operation.get('key')).toBe('value')
+    for (let attempt = 0; attempt < 20 && errorSpy.mock.calls.length < 1; attempt++) {
+      await setTimeout(10)
+    }
+    expect(errorSpy).toHaveBeenCalledWith('boom')
+  })
+
+  it('only runs a single staleness check for concurrent gets', async () => {
+    const loader = new CountingDataSource('value')
+
+    let finishCheck: (isCurrent: boolean) => void
+    const checkPromise = new Promise<boolean>((resolve) => {
+      finishCheck = resolve
+    })
+    const isEntryStillCurrentFn = vitest.fn(() => checkPromise)
+
+    const operation = new Loader<string>({
+      inMemoryCache: { ttlInMsecs: 9999, ttlLeftBeforeRefreshInMsecs: 9925 },
+      dataSources: [loader],
+      isEntryStillCurrentFn,
+    })
+    expect(await operation.get('key')).toBe('value')
+    expect(loader.counter).toBe(1)
+
+    await setTimeout(90)
+    // kick off the check and keep it hanging while more gets come in
+    expect(await operation.get('key')).toBe('value')
+    expect(operation.getInMemoryOnly('key')).toBe('value')
+    expect(operation.getInMemoryOnly('key')).toBe('value')
+    await setTimeout(10)
+    finishCheck!(true)
+    await setTimeout(10)
+
+    expect(isEntryStillCurrentFn).toHaveBeenCalledTimes(1)
+    expect(loader.counter).toBe(1)
+
+    // @ts-expect-error accessing the private refresh guard for assertions
+    const isKeyRefreshing: Set<string> = operation.isKeyRefreshing
+    expect(isKeyRefreshing.has('key')).toBe(false)
+  })
+})

--- a/test/Loader-staleness-check.spec.ts
+++ b/test/Loader-staleness-check.spec.ts
@@ -330,14 +330,25 @@ describe('Loader staleness check', () => {
   })
 
   describe('constructor', () => {
-    it('throws when isEntryStillCurrentFn is set without an asyncCache', () => {
+    it('throws when isEntryStillCurrentFn is set without any refresh window', () => {
       expect(
         () =>
           new Loader<string>({
             dataSources: [new CountingDataSource('value')],
             isEntryStillCurrentFn: async () => true,
           }),
-      ).toThrow(/isEntryStillCurrentFn requires an asyncCache/)
+      ).toThrow(/requires a preemptive refresh window/)
+    })
+
+    it('accepts isEntryStillCurrentFn with an in-memory-only refresh window', () => {
+      expect(
+        () =>
+          new Loader<string>({
+            inMemoryCache: { ttlInMsecs: 150, ttlLeftBeforeRefreshInMsecs: 75 },
+            dataSources: [new CountingDataSource('value')],
+            isEntryStillCurrentFn: async () => true,
+          }),
+      ).not.toThrow()
     })
 
     it('throws when the asyncCache does not support resetTtl', () => {

--- a/test/fakes/DummyGroupedCache.ts
+++ b/test/fakes/DummyGroupedCache.ts
@@ -8,7 +8,7 @@ export class DummyGroupedCache implements GroupCache<User> {
   groupValues: GroupValues
   name = 'Dummy cache'
   readonly expirationTimeLoadingGroupedOperation: any = null
-  readonly ttlLeftBeforeRefreshInMsecs: any = null
+  ttlLeftBeforeRefreshInMsecs: any = null
 
   constructor(returnedValues: GroupValues) {
     this.groupValues = cloneDeep(returnedValues)

--- a/test/memory/InMemoryCache.spec.ts
+++ b/test/memory/InMemoryCache.spec.ts
@@ -279,4 +279,34 @@ describe('InMemoryCache', () => {
       expect(value3).toBeUndefined()
     })
   })
+
+  describe('resetTtl', () => {
+    it('extends the ttl of an existing entry', async () => {
+      const cache = new InMemoryCache({ cacheId: 'dummy', ttlInMsecs: 1000 })
+      cache.set('key', 'value')
+      await setTimeout(500)
+      const expiresAtPre = cache.getExpirationTime('key')
+
+      const result = cache.resetTtl('key')
+
+      expect(result).toBe(true)
+      expect(cache.getExpirationTime('key')! > expiresAtPre!).toBe(true)
+    })
+
+    it('resets the ttl of an explicitly cached null entry', () => {
+      const cache = new InMemoryCache<string>({ cacheId: 'dummy', ttlInMsecs: 1000 })
+      cache.set('key', null)
+
+      const result = cache.resetTtl('key')
+
+      expect(result).toBe(true)
+      expect(cache.get('key')).toBeNull()
+    })
+
+    it('returns false when the entry does not exist', () => {
+      const cache = new InMemoryCache(IN_MEMORY_CACHE_CONFIG)
+
+      expect(cache.resetTtl('missing')).toBe(false)
+    })
+  })
 })

--- a/test/memory/InMemoryGroupCache.spec.ts
+++ b/test/memory/InMemoryGroupCache.spec.ts
@@ -318,4 +318,31 @@ describe('InMemoryCache', () => {
       expect(value2group2).toBe('value2')
     })
   })
+
+  describe('resetTtlFromGroup', () => {
+    it('extends the ttl of an existing entry', async () => {
+      const cache = new InMemoryGroupCache({ ttlInMsecs: 1000 })
+      cache.setForGroup('key', 'value', 'group1')
+      await setTimeout(500)
+      const expiresAtPre = cache.getExpirationTimeFromGroup('key', 'group1')
+
+      const result = cache.resetTtlFromGroup('key', 'group1')
+
+      expect(result).toBe(true)
+      expect(cache.getExpirationTimeFromGroup('key', 'group1')! > expiresAtPre!).toBe(true)
+    })
+
+    it('returns false when the group does not exist', () => {
+      const cache = new InMemoryGroupCache({ ttlInMsecs: 1000 })
+
+      expect(cache.resetTtlFromGroup('key', 'missingGroup')).toBe(false)
+    })
+
+    it('returns false when the entry does not exist in an existing group', () => {
+      const cache = new InMemoryGroupCache({ ttlInMsecs: 1000 })
+      cache.setForGroup('other', 'value', 'group1')
+
+      expect(cache.resetTtlFromGroup('missing', 'group1')).toBe(false)
+    })
+  })
 })


### PR DESCRIPTION
The staleness probe was hard-gated on an async cache tier: it only fired in
Loader/GroupLoader's async-hit branch and bumped freshness via
asyncCache.resetTtl/resetTtlFromGroup, so an in-memory-only loader in the
refresh window always paid a full data-source reload even when a cheap probe
could prove the cached value still current.

Make the existing pair of inMemoryCache.ttlLeftBeforeRefreshInMsecs and
isEntryStillCurrentFn a supported combination:

- Relax assertStalenessCheckSupported to accept a probe when either the async
  cache has a refresh window (+ resetTtl, unchanged) or the in-memory cache has
  a refresh window.
- Route the in-memory refresh-ahead through the probe via a new overridable
  scheduleInMemoryRefresh seam on the abstract caches; the loaders run the probe
  against the in-memory value and bump its TTL when current, falling back to the
  full background reload otherwise.
- Add resetTtl/resetTtlFromGroup to the in-memory caches (and NoopCache) plus
  the SynchronousCache/SynchronousGroupCache interfaces.
- Reuse the existing isKeyRefreshing / groupRefreshFlags stampede guards.

Precedence is unchanged: when an async cache has a refresh window it keeps
owning the probe, so existing configurations behave identically. Non-breaking.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PYBYKbY1BJD9HFM1fXtFqW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled conditional refresh with staleness checks for in-memory-only caching, extending entry TTL when still current.
  * Added per-entry/group in-memory TTL reset support to support TTL “bumping” without reloading.
* **Bug Fixes**
  * When async and in-memory refresh windows are both configured, async refresh takes precedence.
  * Improved correctness and error handling for stale/missing/errored staleness probes, including safer refresh scheduling under concurrency.
* **Documentation**
  * Updated README and changelog with clarified TTL behavior and configuration rules.
* **Tests**
  * Added extensive coverage for in-memory staleness checks, concurrency, and race conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->