### PR TITLE
release: layered-loader 15.0.0 (ESM-only, ioredis 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 # Changelog
 
-## Unreleased
+## 15.0.0
+
+### Breaking
+
+- The package is now **ESM-only**. `layered-loader` declares `"type": "module"`, ships an `exports`
+  map and no longer publishes a CommonJS build, so `require('layered-loader')` from CommonJS code no
+  longer resolves to the library on Node versions without `require(esm)` support. Import it from ESM,
+  or use a dynamic `await import('layered-loader')` from CommonJS.
+- Only `.` and `./package.json` are exported. Deep imports such as
+  `layered-loader/dist/lib/redis/RedisCache` no longer resolve; import everything from the package
+  root instead.
+- `ioredis` was upgraded from 5 to 6. Applications that also depend on `ioredis` directly should
+  upgrade with it, and should review the [ioredis 6 migration
+  notes](https://github.com/redis/ioredis/releases) for their own usage.
+- The published build no longer contains `*.spec.ts` sources or their compiled output.
+- The documented minimum Node version is now 22, matching the `engines` field the package has
+  declared since 14.x.
+
+## 14.5.0 – 14.5.3
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,12 @@ You can watch [NodeConf EU 2023 talk](https://www.youtube.com/watch?v=O0Nk3XhxxY
 
 ## Prerequisites
 
-Node: 16+
+Node: 22+
+
+`layered-loader` is an ESM-only package. It is published as ECMAScript modules with an `exports` map
+and has no CommonJS build, so it is consumed with `import` from ESM code (or with a dynamic
+`await import('layered-loader')` from CommonJS). Only the package root and `package.json` are
+exported — reaching into `layered-loader/dist/...` is not supported.
 
 ## Use-cases
 


### PR DESCRIPTION
Triggers the major release of `layered-loader` — merging this PR with the `major` label makes the publish workflow bump `14.5.3` → `15.0.0`, tag `v15.0.0`, and publish to npm.

## Why a major

Two breaking changes have landed on `main` since 14.5.3 and are unreleased:

- **ESM-only conversion** (#421) — `"type": "module"`, an `exports` map, no CommonJS build, `NodeNext` module resolution, and spec files excluded from the published output.
- **ioredis 5 → 6** (#426) — a major bump of a runtime dependency.

## Changes in this PR

Documentation only, but deliberately touching `README.md` so the publish workflow's changed-package detection sees a root-package change (its allowlist is `lib/*`, `index.ts`, `package.json`, `README.md`, `LICENSE`, `tsconfig.json` — a CHANGELOG-only PR would be labelled for release but publish nothing).

- `README.md` — prerequisites corrected from Node 16+ to Node 22+ (`engines` has said `>=22` since 14.x), plus a short note on consuming the package now that it is ESM-only with no deep imports.
- `CHANGELOG.md` — new `15.0.0` section listing the breaking changes; the stale `Unreleased` heading is retitled to `14.5.0 – 14.5.3`, which is what it actually describes.

## Scope

Root package only. `packages/sqs` is untouched, so `@layered-loader/sqs` is not bumped or republished by this merge; it stays on 1.3.1.

## Merge checklist

- [ ] `major` label applied (required — the workflow no-ops without `patch`/`minor`/`major`)
- [ ] merge into `main`

---
_Generated by [Claude Code](https://claude.ai/code/session_018noqqA3KnpRCcqCRBw5PT9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added release notes for version 15.0.0, including breaking changes and updated compatibility requirements.
  - Documented Node.js 22+ as the minimum supported runtime.
  - Clarified ESM-only usage, supported package entry points, and dynamic imports from CommonJS.
  - Noted the upgrade to `ioredis` 6 and removal of published specification sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->