### PR TITLE
ci: create GitHub releases for published versions

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,58 @@
+name: create-release
+
+# Manually create a GitHub release for a tag that already exists. The publish
+# workflow creates releases for the versions it publishes, so this is only
+# needed to backfill tags that were pushed before that step existed.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing git tag to create a release for (e.g. v15.0.0)'
+        required: true
+      previous_tag:
+        description: 'Tag to generate the commit list from (e.g. v14.5.3)'
+        required: false
+
+permissions: {}
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Tags are needed to verify the requested tag exists.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag }}
+          PREVIOUS_TAG: ${{ inputs.previous_tag }}
+        run: |
+          set -euo pipefail
+
+          if ! git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "::error::Tag $TAG does not exist"
+            exit 1
+          fi
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "::notice::Release $TAG already exists, nothing to do"
+            exit 0
+          fi
+
+          args=(--title "$TAG" --generate-notes)
+          if [ -n "$PREVIOUS_TAG" ]; then
+            args+=(--notes-start-tag "$PREVIOUS_TAG")
+          fi
+
+          gh release create "$TAG" "${args[@]}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -185,3 +185,42 @@ jobs:
         if: steps.changes.outputs.sqs == 'true'
         working-directory: packages/sqs
         run: pnpm publish --provenance --access public --no-git-checks
+
+      # Runs last, so a release only ever shows up for a version that actually
+      # made it to the registry. Notes are generated from the commits since the
+      # previous tag of the same package.
+      - name: Create GitHub releases
+        if: steps.changes.outputs.root == 'true' || steps.changes.outputs.sqs == 'true'
+        env:
+          ROOT_CHANGED: ${{ steps.changes.outputs.root }}
+          SQS_CHANGED: ${{ steps.changes.outputs.sqs }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Most recent tag matching a pattern, excluding the one just created.
+          previous_tag() {
+            git tag --list "$1" --sort=-creatordate | grep -vxF "$2" | head -n 1 || true
+          }
+
+          create_release() {
+            tag="$1"
+            previous="$2"
+
+            args=(--title "$tag" --generate-notes)
+            if [ -n "$previous" ]; then
+              args+=(--notes-start-tag "$previous")
+            fi
+
+            gh release create "$tag" "${args[@]}"
+          }
+
+          if [ "$ROOT_CHANGED" = "true" ]; then
+            v=$(node -p "require('./package.json').version")
+            create_release "v$v" "$(previous_tag 'v*' "v$v")"
+          fi
+          if [ "$SQS_CHANGED" = "true" ]; then
+            v=$(node -p "require('./packages/sqs/package.json').version")
+            create_release "@layered-loader/sqs@$v" "$(previous_tag '@layered-loader/sqs@*' "@layered-loader/sqs@$v")"
+          fi


### PR DESCRIPTION
15.0.0 published to npm fine, but the Releases page is still on 14.2.0 (Nov 2025): the publish workflow pushes a git tag for every version it releases and never creates a GitHub release. Everything from 14.2.1 through 15.0.0 exists as a tag and an npm version with no release entry.

## Changes

**`publish.yml`** — new final step that runs `gh release create` for each package it just published, titled with the tag (`v15.0.1`, `@layered-loader/sqs@1.3.2`) and with notes generated from the commits since that package's previous tag. It runs *after* the npm publish steps, so a release only ever appears for a version that actually reached the registry. Uses the `contents: write` permission the job already has, and the `gh` CLI preinstalled on the runner — no new action to pin.

**`create-release.yml`** — new manually dispatched workflow that creates a release for a tag that already exists, for backfilling tags pushed before the step above existed. Takes `tag` (required) and `previous_tag` (optional, sets where generated notes start). It exits cleanly if the release already exists and fails loudly if the tag doesn't. Inputs are passed via `env`, not interpolated into the script.

## Notes

- Neither file is in the publish workflow's changed-path allowlist (`lib/*`, `index.ts`, `package.json`, `README.md`, `LICENSE`, `tsconfig.json`), so merging this doesn't trigger a release — no release label needed on this PR.
- A tag pushed by a workflow using `GITHUB_TOKEN` doesn't trigger other workflows, which is why the release step lives inside `publish.yml` rather than in a `push: tags:` workflow.
- Once this is merged I'll dispatch `create-release` for `v15.0.0` with `previous_tag: v14.5.3`. The same workflow can backfill 14.2.1–14.5.3 if you want those entries too.
- Existing releases are tagged without the `v` prefix (`14.2.0`); the workflow-created tags have it (`v15.0.0`). This PR follows the tags as they actually exist rather than renaming anything.

---
_Generated by [Claude Code](https://claude.ai/code/session_018noqqA3KnpRCcqCRBw5PT9)_