### PR TITLE
feat: apply-remote-invalidation primitives and a background-work hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,12 +27,11 @@ both. README's "Entrypoints" section documents what each one contains and what i
 
 - Add a new export to `core.ts` or `redis.ts`, never to `index.ts`.
 - Nothing reachable from `core.ts` may import `ioredis` or a `node:` builtin.
-- Nothing under `lib/` may import `ioredis` at all — not even `import type`, which lands in the emitted
-  `.d.ts` and breaks consumers who never installed the optional peer. Use the vendored structural types
-  in `lib/redis/RedisLike.ts`, and extend them when you start calling a command they do not cover.
-- Reach the `ioredis` value only through the lazy `createRequire` in `lib/redis/resolveRedisClient.ts`.
-  A static import anywhere would make `layered-loader/redis` fail to resolve for everyone who did not
-  install the peer.
+- Nothing under `lib/` may import `ioredis` at all — not even `import type`, which is not erased from
+  the emitted `.d.ts`. Use the vendored structural types in `lib/redis/RedisLike.ts`, and extend them
+  when you start calling a command they do not cover.
+- Reach the `ioredis` value only through the lazy `createRequire` in `lib/redis/resolveRedisClient.ts`,
+  and keep it lazy.
 - Constrain generics over Redis options to `object`, not to an all-optional shape. All-optional shapes
   are "weak types", so TypeScript rejects object literals like `enrichRedisConfig({ host, port })`;
   adding an index signature instead rejects interfaces such as `RedisOptions`.
@@ -42,26 +41,19 @@ both. README's "Entrypoints" section documents what each one contains and what i
   import; do not relax the test. Do not rewrite it to scan the TypeScript sources: pattern-matching
   `import type` is unreliable and previously let a broken invariant pass.
 
-The optional-peer arrangement rests on three independent things — the lazy runtime `require`, the
-vendored types, and the optional peer declaration in `package.json`. Each has its own guard in
-`test/entrypoints.spec.ts`; break one and the arrangement is gone.
+## Rules no test covers
 
-## Rules for code that does not exist yet
+These constrain call sites that do not exist yet. The rest of the invalidation and background-work
+behaviour is pinned by `test/remoteInvalidation.spec.ts`, `test/backgroundWork.spec.ts` and `tsc`, so
+do not restate it here.
 
-`test/remoteInvalidation.spec.ts` and `test/backgroundWork.spec.ts` pin the invalidation and
-background-work behaviour, and `tsc` pins the consumer typing, so those need nothing here. These three
-constrain call sites that have not been written, which no test can cover:
-
-- **A background path that writes into the in-memory tier outside `getAsyncOnlyResolved` holds no
-  `runningLoads` entry, so invalidation does not fence it.** Open a fence token
-  (`openBackgroundWriteFence` / `isBackgroundWriteFenceIntact` / `closeBackgroundWriteFence`) as
-  `refreshOrBumpTtl` does, and keep the map holding only keys with work in flight.
-- **Every fire-and-forget promise goes through `AbstractCache.runInBackground(work, reason)`**,
-  reports its own errors to the configured handlers first, and `return`s any inner chain rather than
-  detaching it. Detached elsewhere, an isolate host cannot adopt it; rejecting, it fails the request
-  that adopted it; dropping its continuation, it gets adopted only in part.
-- **Anything new that applies state originating elsewhere joins the `applyRemote*` family and stays
-  synchronous** — a pull-transport host calls these at request start and should not have to await.
+- Background work that writes into the in-memory tier outside `getAsyncOnlyResolved` must open a fence
+  token (`openBackgroundWriteFence` / `isBackgroundWriteFenceIntact` / `closeBackgroundWriteFence`) as
+  `refreshOrBumpTtl` does, and leave the map holding only keys with work in flight.
+- Fire-and-forget promises go through `AbstractCache.runInBackground(work, reason)`, report their
+  errors to the configured handlers before it, and `return` inner chains instead of detaching them.
+- New methods that apply state originating elsewhere join the `applyRemote*` family and stay
+  synchronous.
 
 ## Working in this repo
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,27 @@ That fencing is the whole point: before it existed, a `DELETE` that arrived whil
 key was in flight was silently undone when the load resolved and wrote its pre-invalidation snapshot
 back. `test/remoteInvalidation.spec.ts` pins both halves.
 
+"Fence" means two things, and both matter:
+
+- **Running loads.** Every invalidation path goes through `AbstractFlatCache.evictRunningLoad` /
+  `AbstractGroupCache.evictGroupRunningLoad` / `AbstractCache.evictAllRunningLoads` rather than
+  touching `runningLoads` directly. Do not reintroduce a bare `this.runningLoads.delete(key)` in an
+  invalidation path — the load-completion bookkeeping in `getAsyncOnlyResolved` is the one place that
+  legitimately deletes directly, because a load finishing normally must *not* cancel a concurrent
+  refresh.
+- **Background write fences.** The async-tier preemptive refresh (`Loader.refreshOrBumpTtl`,
+  `GroupLoader.refreshOrBumpTtl`) reloads straight from the data sources and writes into the
+  in-memory tier without holding a `runningLoads` entry, so `runningLoads` alone does not fence it.
+  It opens a per-key fence token instead, and skips its in-memory write if an invalidation broke the
+  fence meanwhile. Any new background path that writes in-memory outside `getAsyncOnlyResolved` needs
+  the same treatment. The fence map only holds keys with a refresh in flight, so it is bounded by
+  refresh concurrency, not by key cardinality — keep it that way.
+
+What the fence deliberately does not cover is the shared async tier: a refresh that already read from
+the data sources still writes that value to Redis. That is the ordinary read-through race (a plain
+cache miss has it too) and needs versioning at the store, not a local fence. README.md says so
+explicitly under "Applying invalidations from your own transport"; do not upgrade that claim.
+
 Consequences to preserve:
 
 - Consumers are typed over `SynchronousCache` / `SynchronousGroupCache`, never over the concrete
@@ -105,7 +126,10 @@ Two invariants:
 
 - **The promise handed over must settle fulfilled.** `runInBackground` wraps it, but the call site
   still owns reporting its own errors to the configured handlers first — `ctx.waitUntil()` on a
-  rejecting promise fails the request that adopted it.
+  rejecting promise fails the request that adopted it. "Reporting" means the configured handler, not
+  `logger.error`: swallowing a failure into the logger makes it invisible to a host that configured
+  `loadErrorHandler` / `cacheUpdateErrorHandler`. The expiration lookup that opens the async-tier
+  refresh goes through `loadErrorHandler` for exactly this reason (the default handler still logs).
 - **The promise must cover the whole operation.** Where a background chain kicks off further work
   (the expiration lookup that decides whether a refresh is due, then the refresh), the inner chain is
   `return`ed rather than detached, so the host adopts the refresh and not just the lookup. Nothing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,45 +46,22 @@ The optional-peer arrangement rests on three independent things — the lazy run
 vendored types, and the optional peer declaration in `package.json`. Each has its own guard in
 `test/entrypoints.spec.ts`; break one and the arrangement is gone.
 
-## Originating an invalidation vs applying one
+## Rules for code that does not exist yet
 
-`invalidateCache*` originates (async tier, fences, publishes); `applyRemote*` applies one that arrived
-from elsewhere (fences and deletes in-memory only). README's "Applying invalidations from your own
-transport" has the full matrix. `test/remoteInvalidation.spec.ts` pins the behaviour.
+`test/remoteInvalidation.spec.ts` and `test/backgroundWork.spec.ts` pin the invalidation and
+background-work behaviour, and `tsc` pins the consumer typing, so those need nothing here. These three
+constrain call sites that have not been written, which no test can cover:
 
-- Notification consumers must go through `applyRemote*`. `AbstractCache` hands them a facade over the
-  owning cache — do not "simplify" `createRemoteInvalidationTarget` back into returning
-  `this.inMemoryCache`.
-- Type consumers over `SynchronousCache` / `SynchronousGroupCache`, never over the concrete
-  `InMemoryCache` / `InMemoryGroupCache`: the facade is not one of those, and private fields defeat
-  structural assignment.
-- Anything new that applies remote state belongs in the `applyRemote*` family and must stay synchronous
-  — a pull-transport host calls these at request start and should not have to await.
-- Invalidation paths fence through `evictRunningLoad` / `evictGroupRunningLoad` / `evictAllRunningLoads`.
-  Do not reintroduce a bare `this.runningLoads.delete(key)` in one; the direct delete in
-  `getAsyncOnlyResolved` is load-completion bookkeeping and must not cancel a concurrent refresh.
-- A background path that writes in-memory outside `getAsyncOnlyResolved` holds no `runningLoads` entry
-  and is therefore not fenced by it. It needs a fence token
-  (`openBackgroundWriteFence` / `isBackgroundWriteFenceIntact` / `closeBackgroundWriteFence`), as
-  `refreshOrBumpTtl` uses. Keep the fence map holding only keys with work in flight, so it stays
-  bounded by refresh concurrency rather than by key cardinality.
-- The fence deliberately does not cover the shared async tier, and README says so explicitly. Do not
-  upgrade that claim.
-
-## Background work
-
-- Route every fire-and-forget promise through `AbstractCache.runInBackground(work, reason)`. A promise
-  detached anywhere else cannot be adopted by an isolate-runtime host.
-- The promise handed to the hook must settle fulfilled — `runInBackground` wraps it, but the call site
-  still owns reporting its own errors first, and to the configured handlers (`loadErrorHandler`,
-  `cacheUpdateErrorHandler`), not to `logger.error`, which hides the failure from a host that
-  configured one.
-- `return` inner chains rather than detaching them, so the host adopts the whole operation and not just
-  its first step. Nothing awaits these chains, so returning them changes no timing.
-- `BackgroundWorkReason` is a closed union that hosts branch on: adding a member is a `minor` bump,
-  renaming one is `major`.
-
-`test/backgroundWork.spec.ts` pins all of the above, including that omitting the hook changes nothing.
+- **A background path that writes into the in-memory tier outside `getAsyncOnlyResolved` holds no
+  `runningLoads` entry, so invalidation does not fence it.** Open a fence token
+  (`openBackgroundWriteFence` / `isBackgroundWriteFenceIntact` / `closeBackgroundWriteFence`) as
+  `refreshOrBumpTtl` does, and keep the map holding only keys with work in flight.
+- **Every fire-and-forget promise goes through `AbstractCache.runInBackground(work, reason)`**,
+  reports its own errors to the configured handlers first, and `return`s any inner chain rather than
+  detaching it. Detached elsewhere, an isolate host cannot adopt it; rejecting, it fails the request
+  that adopted it; dropping its continuation, it gets adopted only in part.
+- **Anything new that applies state originating elsewhere joins the `applyRemote*` family and stays
+  synchronous** — a pull-transport host calls these at request start and should not have to await.
 
 ## Working in this repo
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,165 +1,90 @@
 # CLAUDE.md
 
-Guidance for Claude Code when working in this repository.
+Guidance for Claude Code when working in this repository. Behaviour that consumers need to know is
+documented in `README.md` — keep it there, and keep this file to instructions that only matter to
+someone changing the code.
 
 ## Pull requests
 
-**Every PR must carry exactly one semver label: `patch`, `minor`, or `major`.**
+**Every PR must carry exactly one semver label: `patch`, `minor`, or `major`.** The release pipeline
+(`.github/workflows/publish.yml`) derives the version bump from that label, so a PR merged without one
+publishes nothing.
 
-The release pipeline (`.github/workflows/publish.yml`) only runs when a merged PR carries one of
-those three labels, and it derives the version bump directly from the label. A PR merged without a
-semver label publishes nothing, so the change silently never reaches npm.
-
-Pick the label from the effect on the published API:
+Pick it from the effect on the published API:
 
 - `patch` — bug fixes, docs, internal refactors, dependency bumps with no API impact.
-- `minor` — new exports, new entrypoints, new optional config options; anything additive that
-  existing consumers keep working through unchanged.
-- `major` — removed or renamed exports, changed defaults, raised `engines` floor, or any change
-  that requires consumers to touch their code.
+- `minor` — new exports, new entrypoints, new optional config; anything additive.
+- `major` — removed or renamed exports, changed defaults, a raised `engines` floor, moving a runtime
+  dependency to a peer, or anything else that requires consumers to touch their code.
 
-Changes confined to non-publishable paths (`benchmark/`, `.github/`, `test/`) still want a `patch`
-label; the workflow detects that no publishable source changed and skips the release on its own.
+Changes confined to `benchmark/`, `.github/` or `test/` still want a `patch` label; the workflow
+detects that nothing publishable changed and skips the release on its own.
 
 ## Package entrypoints
 
-The package exposes three entrypoints, and the split between them is load-bearing — not just
-organisational:
+`core.ts` → `layered-loader/core`, `redis.ts` → `layered-loader/redis`, `index.ts` → `export *` of
+both. README's "Entrypoints" section documents what each one contains and what it guarantees.
 
-- `layered-loader/core` (`core.ts`) — loaders, manual caches, in-memory caches, the notification
-  base class and publisher interfaces, key resolvers, and all types. **Nothing reachable from this
-  file may import `ioredis`, or any `node:` builtin.** This is the entrypoint that consumers on
-  Cloudflare Workers and other edge runtimes import.
-- `layered-loader/redis` (`redis.ts`) — the Redis caches, notification factories, publishers and
-  consumers. The only entrypoint whose exports may reach `ioredis`.
-- `layered-loader` (`index.ts`) — `export *` of both, so the root stays a superset of the two.
+- Add a new export to `core.ts` or `redis.ts`, never to `index.ts`.
+- Nothing reachable from `core.ts` may import `ioredis` or a `node:` builtin.
+- Nothing under `lib/` may import `ioredis` at all — not even `import type`, which lands in the emitted
+  `.d.ts` and breaks consumers who never installed the optional peer. Use the vendored structural types
+  in `lib/redis/RedisLike.ts`, and extend them when you start calling a command they do not cover.
+- Reach the `ioredis` value only through the lazy `createRequire` in `lib/redis/resolveRedisClient.ts`.
+  A static import anywhere would make `layered-loader/redis` fail to resolve for everyone who did not
+  install the peer.
+- Constrain generics over Redis options to `object`, not to an all-optional shape. All-optional shapes
+  are "weak types", so TypeScript rejects object literals like `enrichRedisConfig({ host, port })`;
+  adding an index signature instead rejects interfaces such as `RedisOptions`.
+- `pnpm run lint:redis-compat` type-checks the vendored declarations against the real `ioredis` types.
+  Match what `ioredis` declares — never widen a vendored signature to silence it.
+- `test/entrypoints.spec.ts` builds the package and checks the emitted output. When it fails, move the
+  import; do not relax the test. Do not rewrite it to scan the TypeScript sources: pattern-matching
+  `import type` is unreliable and previously let a broken invariant pass.
 
-Rules that follow from that:
-
-- A new export goes into `core.ts` or `redis.ts`, never into `index.ts` directly.
-- **Nothing under `lib/` may import `ioredis` at all** — not even with `import type`, which would
-  land in the emitted `.d.ts` and break consumers who never installed the optional peer. Use the
-  vendored structural types in `lib/redis/RedisLike.ts` instead, and extend those if you start
-  calling a Redis command they do not cover.
-- `test/ioredisCompat.type-test.ts` type-checks the vendored declarations against the real `ioredis`
-  types; `pnpm run lint:redis-compat` runs it and is part of `pnpm run lint`. Widening a vendored
-  signature to silence it is wrong — match what `ioredis` actually declares.
-- Constrain generics over Redis options to `object`, not to an all-optional shape. All-optional
-  shapes are "weak types" and TypeScript then rejects object literals like
-  `enrichRedisConfig({ host, port })`; adding an index signature instead rejects interfaces such as
-  `RedisOptions`, which never get an implicit one.
-- The value of `ioredis` is only ever reached through `lib/redis/resolveRedisClient.ts`, which
-  resolves it lazily via `createRequire` and throws an actionable error when it is not installed.
-  Keep it lazy: a static import would make `layered-loader/redis` fail to resolve for everyone who
-  did not install the optional peer, which is the whole point of the arrangement. The cost is that
-  bundlers cannot see through `createRequire` and will not inline `ioredis` — that is the correct
-  trade-off for a peer dependency, and README.md documents it under "Bundling" so consumers are not
-  surprised by it.
-- `test/entrypoints.spec.ts` enforces the above against a real compilation: it builds the package
-  into `node_modules/.cache`, imports each entrypoint in a child process with a resolve hook
-  installed, and scans the emitted output. That covers what Node actually loads (static imports,
-  dynamic `import()` and `require()` alike), plus `ioredis` leaking into an emitted `.d.ts`. If it
-  fails, the fix is to move the import, not to relax the test.
-
-  Do not rewrite it to scan the TypeScript sources. It used to, and telling `import type` from a
-  value import by pattern-matching TypeScript is not reliable — `export type Foo = ...` on the line
-  above an import made the guard swallow that import and mark it type-only, so it could pass while
-  the invariant was broken. Checking emitted output has no such ambiguity: the compiler has already
-  erased the type-only imports.
+The optional-peer arrangement rests on three independent things — the lazy runtime `require`, the
+vendored types, and the optional peer declaration in `package.json`. Each has its own guard in
+`test/entrypoints.spec.ts`; break one and the arrangement is gone.
 
 ## Originating an invalidation vs applying one
 
-These are two different operations and the distinction is load-bearing, not cosmetic:
+`invalidateCache*` originates (async tier, fences, publishes); `applyRemote*` applies one that arrived
+from elsewhere (fences and deletes in-memory only). README's "Applying invalidations from your own
+transport" has the full matrix. `test/remoteInvalidation.spec.ts` pins the behaviour.
 
-- `invalidateCacheFor` / `invalidateCacheForGroup` / `invalidateCache` **originate** one: they delete
-  from the async tier, fence running loads, delete in-memory, and **publish**.
-- `applyRemoteInvalidationFor` / `applyRemoteInvalidationForGroup` / `applyRemoteValue` /
-  `applyRemoteInvalidation` **apply** one that came from somewhere else: they fence running loads and
-  delete in-memory, and deliberately do **not** touch the async tier (the origin already did, it is
-  shared) and do **not** publish (the origin already broadcast it — re-publishing echoes it back onto
-  the bus).
-
-Notification consumers must go through the second set. `AbstractCache` hands the consumer a facade
-over the owning cache — not `this.inMemoryCache` — so `targetCache.delete(key)` fences running loads.
-That fencing is the whole point: before it existed, a `DELETE` that arrived while a load for the same
-key was in flight was silently undone when the load resolved and wrote its pre-invalidation snapshot
-back. `test/remoteInvalidation.spec.ts` pins both halves.
-
-"Fence" means two things, and both matter:
-
-- **Running loads.** Every invalidation path goes through `AbstractFlatCache.evictRunningLoad` /
-  `AbstractGroupCache.evictGroupRunningLoad` / `AbstractCache.evictAllRunningLoads` rather than
-  touching `runningLoads` directly. Do not reintroduce a bare `this.runningLoads.delete(key)` in an
-  invalidation path — the load-completion bookkeeping in `getAsyncOnlyResolved` is the one place that
-  legitimately deletes directly, because a load finishing normally must *not* cancel a concurrent
-  refresh.
-- **Background write fences.** The async-tier preemptive refresh (`Loader.refreshOrBumpTtl`,
-  `GroupLoader.refreshOrBumpTtl`) reloads straight from the data sources and writes into the
-  in-memory tier without holding a `runningLoads` entry, so `runningLoads` alone does not fence it.
-  It opens a per-key fence token instead, and skips its in-memory write if an invalidation broke the
-  fence meanwhile. Any new background path that writes in-memory outside `getAsyncOnlyResolved` needs
-  the same treatment. The fence map only holds keys with a refresh in flight, so it is bounded by
-  refresh concurrency, not by key cardinality — keep it that way.
-
-What the fence deliberately does not cover is the shared async tier: a refresh that already read from
-the data sources still writes that value to Redis. That is the ordinary read-through race (a plain
-cache miss has it too) and needs versioning at the store, not a local fence. README.md says so
-explicitly under "Applying invalidations from your own transport"; do not upgrade that claim.
-
-Consequences to preserve:
-
-- Consumers are typed over `SynchronousCache` / `SynchronousGroupCache`, never over the concrete
-  `InMemoryCache` / `InMemoryGroupCache` — the facade is not one of those, and a concrete class type
-  would not accept it (private fields defeat structural assignment).
-- Do not "simplify" `createRemoteInvalidationTarget` back into passing `this.inMemoryCache`.
-- Anything new that applies remote state belongs in the `applyRemote*` family, and must stay
-  synchronous: a pull-transport host calls these at request start and should not have to await.
+- Notification consumers must go through `applyRemote*`. `AbstractCache` hands them a facade over the
+  owning cache — do not "simplify" `createRemoteInvalidationTarget` back into returning
+  `this.inMemoryCache`.
+- Type consumers over `SynchronousCache` / `SynchronousGroupCache`, never over the concrete
+  `InMemoryCache` / `InMemoryGroupCache`: the facade is not one of those, and private fields defeat
+  structural assignment.
+- Anything new that applies remote state belongs in the `applyRemote*` family and must stay synchronous
+  — a pull-transport host calls these at request start and should not have to await.
+- Invalidation paths fence through `evictRunningLoad` / `evictGroupRunningLoad` / `evictAllRunningLoads`.
+  Do not reintroduce a bare `this.runningLoads.delete(key)` in one; the direct delete in
+  `getAsyncOnlyResolved` is load-completion bookkeeping and must not cancel a concurrent refresh.
+- A background path that writes in-memory outside `getAsyncOnlyResolved` holds no `runningLoads` entry
+  and is therefore not fenced by it. It needs a fence token
+  (`openBackgroundWriteFence` / `isBackgroundWriteFenceIntact` / `closeBackgroundWriteFence`), as
+  `refreshOrBumpTtl` uses. Keep the fence map holding only keys with work in flight, so it stays
+  bounded by refresh concurrency rather than by key cardinality.
+- The fence deliberately does not cover the shared async tier, and README says so explicitly. Do not
+  upgrade that claim.
 
 ## Background work
 
-Every fire-and-forget promise goes through `AbstractCache.runInBackground(work, reason)`, which hands
-it to the optional `scheduleBackgroundWork` config hook or leaves it detached when there is none.
-New fire-and-forget call sites must route through it too, or an isolate-runtime host loses the
-ability to adopt them with `ctx.waitUntil()`.
+- Route every fire-and-forget promise through `AbstractCache.runInBackground(work, reason)`. A promise
+  detached anywhere else cannot be adopted by an isolate-runtime host.
+- The promise handed to the hook must settle fulfilled — `runInBackground` wraps it, but the call site
+  still owns reporting its own errors first, and to the configured handlers (`loadErrorHandler`,
+  `cacheUpdateErrorHandler`), not to `logger.error`, which hides the failure from a host that
+  configured one.
+- `return` inner chains rather than detaching them, so the host adopts the whole operation and not just
+  its first step. Nothing awaits these chains, so returning them changes no timing.
+- `BackgroundWorkReason` is a closed union that hosts branch on: adding a member is a `minor` bump,
+  renaming one is `major`.
 
-Two invariants:
-
-- **The promise handed over must settle fulfilled.** `runInBackground` wraps it, but the call site
-  still owns reporting its own errors to the configured handlers first — `ctx.waitUntil()` on a
-  rejecting promise fails the request that adopted it. "Reporting" means the configured handler, not
-  `logger.error`: swallowing a failure into the logger makes it invisible to a host that configured
-  `loadErrorHandler` / `cacheUpdateErrorHandler`. The expiration lookup that opens the async-tier
-  refresh goes through `loadErrorHandler` for exactly this reason (the default handler still logs).
-- **The promise must cover the whole operation.** Where a background chain kicks off further work
-  (the expiration lookup that decides whether a refresh is due, then the refresh), the inner chain is
-  `return`ed rather than detached, so the host adopts the refresh and not just the lookup. Nothing
-  awaits these chains otherwise, so returning them changes no timing.
-
-`BackgroundWorkReason` is a closed union. Hosts branch on it, so adding a member is a minor bump and
-renaming one is a major.
-
-## Why `ioredis` is an optional peer dependency
-
-Recorded here so the trade-off is not re-litigated. `ioredis` is not a `dependency`; it is a
-`peerDependency` with `peerDependenciesMeta.ioredis.optional`. Consumers who use Redis declare it
-themselves — which most already do, since `RedisCache` takes a client they construct.
-
-What makes it work is that three separate things all avoid `ioredis`:
-
-- **Runtime** — reached only through the lazy `require` in `resolveRedisClient`, so every entrypoint
-  imports cleanly when it is absent.
-- **Types** — vendored structurally in `RedisLike.ts`, so no emitted `.d.ts` mentions it and
-  consumers type-check without it.
-- **Install** — an optional peer is not installed unless asked for.
-
-Remove any one of the three and the arrangement collapses, which is why each has its own guard in
-`test/entrypoints.spec.ts`.
-
-Note the release consequence: moving `ioredis` out of `dependencies` breaks any consumer who relied
-on it being installed transitively, so it is a **major** version bump, never a patch or minor.
-
-Also worth knowing: `@layered-loader/sqs` gives consumers cross-instance invalidation with no Redis
-at all, and imports from `layered-loader/core`. Point people there before they reach for Redis.
+`test/backgroundWork.spec.ts` pins all of the above, including that omitting the hook changes nothing.
 
 ## Working in this repo
 
@@ -167,5 +92,5 @@ at all, and imports from `layered-loader/core`. Point people there before they r
 - `pnpm run test` needs a local Redis for `test/redis/**`: `pnpm run docker:start` first.
 - Coverage thresholds are enforced (100% lines/statements); new `lib/` code needs tests.
 - `pnpm run lint:packaging` runs `publint` and `attw` — run it after touching the `exports` map.
-- New root-level source files must be added to the changed-path `case` in `publish.yml`, otherwise
-  the release pipeline will not consider them a publishable change.
+- New root-level source files must be added to the changed-path `case` in `publish.yml`, otherwise the
+  release pipeline will not consider them a publishable change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,53 @@ Rules that follow from that:
   the invariant was broken. Checking emitted output has no such ambiguity: the compiler has already
   erased the type-only imports.
 
+## Originating an invalidation vs applying one
+
+These are two different operations and the distinction is load-bearing, not cosmetic:
+
+- `invalidateCacheFor` / `invalidateCacheForGroup` / `invalidateCache` **originate** one: they delete
+  from the async tier, fence running loads, delete in-memory, and **publish**.
+- `applyRemoteInvalidationFor` / `applyRemoteInvalidationForGroup` / `applyRemoteValue` /
+  `applyRemoteInvalidation` **apply** one that came from somewhere else: they fence running loads and
+  delete in-memory, and deliberately do **not** touch the async tier (the origin already did, it is
+  shared) and do **not** publish (the origin already broadcast it — re-publishing echoes it back onto
+  the bus).
+
+Notification consumers must go through the second set. `AbstractCache` hands the consumer a facade
+over the owning cache — not `this.inMemoryCache` — so `targetCache.delete(key)` fences running loads.
+That fencing is the whole point: before it existed, a `DELETE` that arrived while a load for the same
+key was in flight was silently undone when the load resolved and wrote its pre-invalidation snapshot
+back. `test/remoteInvalidation.spec.ts` pins both halves.
+
+Consequences to preserve:
+
+- Consumers are typed over `SynchronousCache` / `SynchronousGroupCache`, never over the concrete
+  `InMemoryCache` / `InMemoryGroupCache` — the facade is not one of those, and a concrete class type
+  would not accept it (private fields defeat structural assignment).
+- Do not "simplify" `createRemoteInvalidationTarget` back into passing `this.inMemoryCache`.
+- Anything new that applies remote state belongs in the `applyRemote*` family, and must stay
+  synchronous: a pull-transport host calls these at request start and should not have to await.
+
+## Background work
+
+Every fire-and-forget promise goes through `AbstractCache.runInBackground(work, reason)`, which hands
+it to the optional `scheduleBackgroundWork` config hook or leaves it detached when there is none.
+New fire-and-forget call sites must route through it too, or an isolate-runtime host loses the
+ability to adopt them with `ctx.waitUntil()`.
+
+Two invariants:
+
+- **The promise handed over must settle fulfilled.** `runInBackground` wraps it, but the call site
+  still owns reporting its own errors to the configured handlers first — `ctx.waitUntil()` on a
+  rejecting promise fails the request that adopted it.
+- **The promise must cover the whole operation.** Where a background chain kicks off further work
+  (the expiration lookup that decides whether a refresh is due, then the refresh), the inner chain is
+  `return`ed rather than detached, so the host adopts the refresh and not just the lookup. Nothing
+  awaits these chains otherwise, so returning them changes no timing.
+
+`BackgroundWorkReason` is a closed union. Hosts branch on it, so adding a member is a minor bump and
+renaming one is a major.
+
 ## Why `ioredis` is an optional peer dependency
 
 Recorded here so the trade-off is not re-litigated. `ioredis` is not a `dependency`; it is a

--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ You can watch [NodeConf EU 2023 talk](https://www.youtube.com/watch?v=O0Nk3XhxxY
 - [Flexible invalidation triggers](#flexible-invalidation-triggers)
   - [Recommended pattern: Redis fanout + SQS trigger](#recommended-pattern-redis-fanout--sqs-trigger)
   - [SNS/SQS adapter](#snssqs-adapter)
+- [Applying invalidations from your own transport](#applying-invalidations-from-your-own-transport)
+- [Background work](#background-work)
+- [Isolate runtimes with no invalidation bus](#isolate-runtimes-with-no-invalidation-bus)
+  - [Hoist the loader to isolate scope](#hoist-the-loader-to-isolate-scope)
+  - [Pull invalidations instead of pushing them](#pull-invalidations-instead-of-pushing-them)
+  - [Hand background work to the request](#hand-background-work-to-the-request)
+  - [Validating on every read](#validating-on-every-read)
+  - [What the library does not do](#what-the-library-does-not-do)
 - [Cache statistics](#cache-statistics)
 - [Cache-only operations](#cache-only-operations)
   - [Forcing an update](#forcing-an-update)
@@ -93,7 +101,11 @@ const loader = new Loader<string>({
 ```
 
 Nothing reachable from `layered-loader/core` imports `ioredis`, or even a `node:` builtin — its
-only runtime dependency is `toad-cache`.
+only runtime dependency is `toad-cache`. Importing cleanly is necessary but not sufficient on an
+isolate runtime, though: see
+[Isolate runtimes with no invalidation bus](#isolate-runtimes-with-no-invalidation-bus) for how to
+keep the cache alive across invocations, invalidate it without a bus, and stop background work from
+outliving its request.
 
 Redis usage keeps its own entrypoint:
 
@@ -376,12 +388,14 @@ Loader has the following config parameters:
 - `cacheKeyFromLoadParamsResolver: CacheKeyResolver<LoadParams>` - mapper from LoadParams to a cache key. Defaults to a simple string passthrough when LoadParams are just a string key to begin with (which is the default)
 - `cacheKeyFromValueResolver: CacheKeyResolver<LoadParams>` - mapper from entity to be cached to a cache key. Defaults to a dummy resolver which throws an error when methods that depend on it are used. Make sure to provide a real resolver if you are using the bulk API (getMany/getManyFromGroup)
 - `isEntryStillCurrentFn` - optional lightweight staleness check that lets an entry entering the refresh window bump its TTL instead of refetching. See [Conditional refresh with a staleness check](#conditional-refresh-with-a-staleness-check).
+- `scheduleBackgroundWork: BackgroundWorkScheduler` - optional hook for work the loader starts and does not await (background refreshes, staleness probes, notification publishes). Defaults to leaving that work detached. See [Background work](#background-work).
 
 Loader provides following methods:
 
 - `invalidateCacheFor(key: string): Promise<void>` - expunge all entries for given key from all caches of this Loader;
 - `invalidateCacheForMany(keys: string[]): Promise<void>` - expunge all entries for given keys from all caches of this Loader;
 - `invalidateCache(): Promise<void>` - expunge all entries from all caches of this Loader;
+- `applyRemoteInvalidationFor(key: string): void`, `applyRemoteInvalidationForMany(keys: string[]): void`, `applyRemoteValue(key: string, value: T | null): void`, `applyRemoteInvalidation(): void` - apply an invalidation (or a value) that originated on another node, without re-publishing it. See [Applying invalidations from your own transport](#applying-invalidations-from-your-own-transport);
 - `get(loadParams: LoadParams = string): Promise<T>` - sequentially attempt to retrieve data for specified key from all caches and loaders, in an order in which those data sources passed to the Loader constructor.
 - `getMany(keys: string[], loadManyParams?: LoadManyParams = LoadParams): Promise<T>` - sequentially attempt to retrieve data for specified keys from all caches and data sources, in an order in which those data sources were passed to the Loader constructor. Duplicate keys in the input array are automatically deduplicated to optimize performance and prevent redundant data source calls. Note that this retrieval mode doesn't support preemptive background refresh. Note that you need to manually resolve all keys upfront for this retrieval method (e. g. by using cacheKeyFromLoadParamsResolver from the Loader).
 
@@ -674,6 +688,223 @@ Each trigger takes a single `dependencies` block and an array of `sources` (queu
 
 Future adapters (RabbitMQ, Kafka, Google Pub/Sub, ...) reuse the same `InvalidationAction` / resolver primitives — only the consumer wiring changes. See the [package README](packages/sqs/README.md#flexible-invalidation-triggers) for the full reference, including group triggers, multi-source / multi-binding configuration, mixing source kinds via `composeTriggers`, and error handling.
 
+## Applying invalidations from your own transport
+
+Applying an invalidation that arrived from somewhere else is **not** the same operation as
+originating one, and the library has separate methods for the two:
+
+| | originating (`invalidateCacheFor`, `invalidateCacheForGroup`, ...) | applying (`applyRemoteInvalidationFor`, ...) |
+| --- | --- | --- |
+| in-memory cache | deletes | deletes |
+| running loads | fences | fences |
+| async cache (Redis) | deletes | leaves alone — the origin already deleted it from the shared tier |
+| notification publisher | publishes | publishes nothing — the origin already broadcast it |
+| return type | `Promise<void>` (awaits the async tier) | `void` (purely local, synchronous) |
+
+Do not reach for `invalidateCacheFor` to apply an invalidation you received. It re-publishes, so on a
+node that also has a publisher configured it echoes the invalidation straight back onto the bus.
+
+The `applyRemote*` methods exist for transports the library does not ship, and in particular for
+**pull-based** ones: a host that reads "what changed since cursor N" at the start of a request and
+applies the result, because the runtime cannot hold a subscription open (see
+[Isolate runtimes with no invalidation bus](#isolate-runtimes-with-no-invalidation-bus)).
+
+```ts
+// at the start of a request, on a runtime where nothing can hold a subscription
+const { keys, cursor } = await readInvalidationsSince(lastCursor)
+for (const key of keys) {
+  loader.applyRemoteInvalidationFor(key)
+}
+lastCursor = cursor
+```
+
+Flat caches (`Loader`, `ManualCache`):
+
+- `applyRemoteInvalidationFor(key)`
+- `applyRemoteInvalidationForMany(keys)`
+- `applyRemoteValue(key, value)` — a value that was set on another node and broadcast here
+- `applyRemoteInvalidation()` — a cache-wide clear
+
+Group caches (`GroupLoader`, `ManualGroupCache`):
+
+- `applyRemoteInvalidationFor(key, group)`
+- `applyRemoteInvalidationForGroup(group)`
+- `applyRemoteValue(key, value, group)`
+- `applyRemoteInvalidation()`
+
+All of them fence the running load for the affected key, so a load that started *before* the
+invalidation arrived cannot write its pre-invalidation snapshot back into the cache when it resolves.
+A caller that was already awaiting that load still receives its value — exactly as for a locally
+originated invalidation.
+
+If you implement `AbstractNotificationConsumer` yourself you get this behaviour for free: the target
+cache handed to `setTargetCache` is a facade over the owning loader that routes deletions and sets
+through these methods, so `this.targetCache.delete(key)` fences running loads too.
+
+## Background work
+
+The loader starts some work it does not await: preemptive background refreshes, staleness probes, and
+notification publishes. By default those promises are simply left detached, which is the right
+behaviour on Node.
+
+`scheduleBackgroundWork` hands each of them to you instead:
+
+```ts
+const loader = new Loader<User>({
+  inMemoryCache: { ttlInMsecs: 60_000, ttlLeftBeforeRefreshInMsecs: 20_000, cacheId: 'users' },
+  dataSources: [userDataSource],
+
+  scheduleBackgroundWork: (work, meta) => {
+    // meta is { cacheId: 'users', reason: 'refresh' | 'notification' }
+    pending.add(work)
+    void work.finally(() => pending.delete(work))
+  },
+})
+```
+
+`meta.reason` is a closed set (`'refresh' | 'notification'`) rather than a free-form string, because
+hosts branch on it in practice. `meta.cacheId` is the `cacheId` configured on `inMemoryCache`, so work
+from several loaders can be told apart in logs.
+
+The promise you are given is guaranteed to settle **fulfilled**. The loader has already routed any
+error to `loadErrorHandler` / `cacheUpdateErrorHandler` / the publisher's error handler and attached
+its own handler before handing it over. That matters on runtimes where these promises get adopted by
+a request: `ctx.waitUntil()` on a rejecting promise fails the request that adopted it.
+
+Three things this is useful for:
+
+- **Isolate runtimes**, where a promise that outlives its request faults rather than merely leaking.
+  See [Hand background work to the request](#hand-background-work-to-the-request).
+- **Tests**, which can await quiescence instead of sleeping and hoping.
+- **Graceful shutdown**, which can drain in-flight refreshes before closing Redis connections.
+
+## Isolate runtimes with no invalidation bus
+
+Cloudflare Workers — and by extension any target made of many short-lived, mutually unreachable
+instances (Deno Deploy, Vercel edge, Lambda@Edge, aggressively-scaled serverless Node) — break three
+assumptions that the notification pair is built on:
+
+- there is no pub/sub any instance can reach;
+- nothing can hold a subscription open between requests, so push is structurally unavailable and the
+  answer has to be pull;
+- I/O is scoped to the request that created it, so a promise that outlives its request faults with
+  *"Cannot perform I/O on behalf of a different request"* unless it was handed to `ctx.waitUntil()`.
+
+`layered-loader/core` imports cleanly on those runtimes, and everything below is runtime-neutral — the
+library never learns what a Worker is. What follows is the deployment shape that works.
+
+### Hoist the loader to isolate scope
+
+Construct the loader at module scope, once per isolate, not per request. A cache rebuilt on every
+invocation is a memo, not a cache — it can only ever serve the request that filled it.
+
+This is also a *correctness* requirement once `scheduleBackgroundWork` is in play, not just a
+performance one: see below.
+
+### Pull invalidations instead of pushing them
+
+`notificationConsumer` cannot be implemented where nothing can hold a subscription. Read what changed
+at the start of a request and apply it with
+[`applyRemoteInvalidationFor` and friends](#applying-invalidations-from-your-own-transport). That is a
+supported use of the public API, and the `applyRemote*` methods exist precisely for it.
+
+For a scope-wide generation counter — one row, or one Durable Object read, per tenant — the whole
+mechanism is a counter comparison plus one `applyRemoteInvalidationForGroup` when it moved:
+
+```ts
+const generation = await readTenantGeneration(tenantId)   // once per request, memoised
+if (generation !== lastSeenGeneration.get(tenantId)) {
+  loader.applyRemoteInvalidationForGroup(tenantId)
+  lastSeenGeneration.set(tenantId, generation)
+}
+```
+
+This is O(1) reads per request regardless of how many keys the request touches, and it needs nothing
+from the library beyond the methods above. Reach for it before reaching for a per-entry probe.
+
+### Hand background work to the request
+
+Supply [`scheduleBackgroundWork`](#background-work) so detached promises get adopted by the request
+that spawned them:
+
+```ts
+import { AsyncLocalStorage } from 'node:async_hooks'   // available on workerd
+
+const requestCtx = new AsyncLocalStorage<ExecutionContext>()
+
+// module scope: one loader per isolate, NOT one per request
+const loader = new Loader<User>({
+  inMemoryCache: { ttlInMsecs: 60_000 },
+  dataSources: [userDataSource],
+  scheduleBackgroundWork: (work) => {
+    const ctx = requestCtx.getStore()
+    if (ctx) {
+      ctx.waitUntil(work)
+    } else {
+      void work
+    }
+  },
+})
+
+export default {
+  fetch: (request, env, ctx) => requestCtx.run(ctx, () => handle(request, env)),
+}
+```
+
+The hook **must** resolve the context at call time, as above. Closing over a `ctx` at construction is
+wrong: the loader lives at isolate scope, so that `ctx` belongs to whichever request happened to build
+it, and using it from a later request reintroduces the exact fault the hook exists to avoid.
+
+### Validating on every read
+
+If you have a cheap per-entry version token (a document version, a branch head sha, a JWKS key id),
+`isEntryStillCurrentFn` can validate against it on *every* read rather than only near expiry — set
+`ttlLeftBeforeRefreshInMsecs` equal to `ttlInMsecs`, which puts every entry permanently inside the
+refresh window:
+
+```ts
+const loader = new Loader<Doc>({
+  inMemoryCache: { ttlInMsecs: 60_000, ttlLeftBeforeRefreshInMsecs: 60_000 },
+  dataSources: [docDataSource],
+  isEntryStillCurrentFn: async (cachedValue, loadParams) =>
+    (await readDocVersion(loadParams)) === cachedValue!.version,
+})
+```
+
+Note what this does and does not give you. The probe runs on every hit, but it does **not** block the
+read: the cached value is served immediately and the probe decides what the *next* read sees. This is
+stale-while-revalidate, not `must-revalidate`. It shrinks the staleness window from `ttlInMsecs` to
+roughly one read, which is enough for most content, and is not enough where serving one stale answer
+is itself the bug (an authorization decision, say). For those, either do not cache, or invalidate on
+the write path via a generation counter as [above](#pull-invalidations-instead-of-pushing-them).
+
+Two properties of the probe worth knowing before you build on it:
+
+- Concurrent reads of the **same key** share a single probe — the loader deduplicates them the same
+  way it deduplicates loads, so you do not need to memoise on your side.
+- Reads of **different keys** do not. `isEntryStillCurrentFn` is per entry, so a token shared across
+  many keys (one branch head sha covering many files) is read once per key. If that is your shape, a
+  scope-wide generation counter is the better fit, for the reason given above.
+
+### What the library does not do
+
+- **Nothing runs on a timer.** There is no eviction sweep and no refresh tick; in-memory entries
+  expire lazily when they are read. An in-memory-only loader schedules no periodic work at all, so
+  there is nothing here that behaves differently under `workerd`'s timer restrictions.
+- **There is no blocking (`must-revalidate`) read mode.** A cache hit is never delayed by a probe.
+  Adding one is not simply an extra option: `getInMemoryOnly` is synchronous and cannot await
+  anything, and `getMany` serves an all-hit batch straight from memory without entering the refresh
+  path at all — so a "no hit is ever served unvalidated" guarantee would be quietly false for two of
+  the three read methods. If you need that guarantee today, use a generation counter on the write
+  path rather than a per-read probe.
+- **No async cache tier is provided for edge KV stores.** That is deliberate rather than missing:
+  Redis in this library is an invalidation bus, not a data tier, and a store whose writes propagate
+  eventually would be a weaker coherence story than the primary database it is meant to protect.
+
+If your deployment *can* reach a message bus but you would rather not run Redis,
+[`@layered-loader/sqs`](packages/sqs/README.md) gives you cross-instance invalidation over SNS/SQS and
+imports from `layered-loader/core`.
+
 ## Cache statistics
 
 You can keep track of your in-memory cache usage is by using special cache type - `lru-object-statistics`:
@@ -832,7 +1063,9 @@ const asyncCache = new RedisCache<string>(redis, {
 ```
 
 Note that there is overhead involved in performing refresh checks (especially for Redis). Always measure performance before and after enabling preemptive refresh in order to determine, whether it improves or worsens the performance of your system.
-Bulk operations (`getMany()`) do not support preemptive background refresh.
+Bulk operations (`getMany()`) do not support preemptive background refresh — when every requested key hits in memory, the batch is served without entering the refresh path at all.
+
+The refresh itself is fire-and-forget: nothing schedules it on a timer, and the read that triggers it is not delayed by it. If your runtime needs those promises tracked rather than detached, supply [`scheduleBackgroundWork`](#background-work).
 
 ### Conditional refresh with a staleness check
 
@@ -842,6 +1075,8 @@ When an entry enters the `ttlLeftBeforeRefreshInMsecs` window, the loader first 
 
 - if it resolves to `true`, the entry's TTL is reset to the full `ttlInMsecs`, and no data source call is made;
 - if it resolves to `false` (or throws, or the entry disappeared in the meantime), the usual full background refresh from the data sources runs.
+
+The check never delays the read that triggered it. That read is served the cached value either way, and the check decides what the *next* read sees — this is stale-while-revalidate, not `must-revalidate`. There is no blocking read mode; see [What the library does not do](#what-the-library-does-not-do) for why.
 
 The check works both with an async cache and with an in-memory-only loader. It only needs a preemptive refresh window (`ttlLeftBeforeRefreshInMsecs`) to fire inside: configure it on the `asyncCache`, or, for a loader that has no async tier, on the `inMemoryCache`. When both tiers have a refresh window, the async cache takes precedence and the check runs on its refresh path.
 
@@ -899,7 +1134,9 @@ Things to keep in mind:
 
 - `isEntryStillCurrentFn` requires a preemptive refresh window (`ttlLeftBeforeRefreshInMsecs`) to run inside, on either the `asyncCache` or the `inMemoryCache`. When it runs on the async path, the async cache must implement `resetTtl` (`resetTtlFromGroup` for group caches); `RedisCache` and `RedisGroupCache` implement it, and if you implement the `Cache` interface yourself, add the method to support conditional refresh. The in-memory caches implement the reset natively, so an in-memory-only loader needs no extra wiring. When both tiers have a refresh window, the async cache takes precedence. The loader throws at construction time if no refresh-capable tier is configured.
 - Errors thrown by the check are routed to `loadErrorHandler` and treated as "stale", so the worst case degrades to a regular full background refresh.
-- Staleness checks are deduplicated the same way background refreshes are - only one check runs per key at a time, and `ttlCacheTtl` limits how often expiration times are read from Redis.
+- Staleness checks are deduplicated the same way background refreshes are - only one check runs per key at a time, and `ttlCacheTtl` limits how often expiration times are read from Redis. Deduplication is per key: the check is a per-entry function, so a version token shared across many keys (one branch head sha covering many files, say) is still read once per key. If that is your shape, prefer a scope-wide generation counter and [`applyRemoteInvalidationForGroup`](#applying-invalidations-from-your-own-transport) over a per-entry probe.
+- To validate on *every* hit rather than only near expiry, set `ttlLeftBeforeRefreshInMsecs` equal to `ttlInMsecs`. That keeps every entry permanently inside the refresh window, so every read runs the check. It is still non-blocking - see [Validating on every read](#validating-on-every-read).
+- The check runs as background work, so it is handed to [`scheduleBackgroundWork`](#background-work) if you configured one.
 - No update notifications are published when a TTL is merely bumped, since the data has not changed; in-memory copies on other nodes expire on their own schedule and re-read the shared cache.
 - The check receives the value exactly as the async cache returns it. `RedisCache` / `RedisGroupCache` with `json: true` store an explicitly cached `null` as an empty string, so a null entry is passed to the check as `''`, not `null`. If you cache null values, handle that representation in your check.
 - A successful TTL bump extends only the entry, not the group index. Like adding entries to a group, it does not reset `groupTtlInMsecs`, so a bumped entry still becomes inaccessible once its group index expires and is reloaded from the data sources on the next read.
@@ -1038,7 +1275,7 @@ It has following configuration options:
 - `json: boolean` - if false, all passed data will be sent to Redis and returned from it as-is. If true, it will be serialized using `JSON.stringify` and deserialized, using `JSON.parse`;
 - `timeoutInMsecs?: number` - if set, Redis operations will automatically fail after specified execution threshold in milliseconds is exceeded. Next data source in the sequence will be used instead.
 - `separator?: number` - What text should be used between different parts of the key prefix. Default is `':'`
-- `ttlLeftBeforeRefreshInMsecs?: number` - if set within a Loader or GroupLoader, when remaining ttl is equal or lower to specified value, loading will be started in background, and all caches will be updated. It is recommended to set this value for heavy loaded system, to prevent requests from stalling while cache refresh is happening.
+- `ttlLeftBeforeRefreshInMsecs?: number` - if set within a Loader or GroupLoader, when remaining ttl is equal or lower to specified value, loading will be started in background, and all caches will be updated. It is recommended to set this value for heavy loaded system, to prevent requests from stalling while cache refresh is happening. Setting it equal to `ttlInMsecs` keeps every entry permanently inside the refresh window, which is how you get a check on every read - see [Validating on every read](#validating-on-every-read).
 
 ## Redis connection safety
 

--- a/README.md
+++ b/README.md
@@ -697,6 +697,7 @@ originating one, and the library has separate methods for the two:
 | --- | --- | --- |
 | in-memory cache | deletes | deletes |
 | running loads | fences | fences |
+| background refreshes | fences | fences |
 | async cache (Redis) | deletes | leaves alone — the origin already deleted it from the shared tier |
 | notification publisher | publishes | publishes nothing — the origin already broadcast it |
 | return type | `Promise<void>` (awaits the async tier) | `void` (purely local, synchronous) |
@@ -732,14 +733,21 @@ Group caches (`GroupLoader`, `ManualGroupCache`):
 - `applyRemoteValue(key, value, group)`
 - `applyRemoteInvalidation()`
 
-All of them fence the running load for the affected key, so a load that started *before* the
-invalidation arrived cannot write its pre-invalidation snapshot back into the cache when it resolves.
-A caller that was already awaiting that load still receives its value — exactly as for a locally
-originated invalidation.
+All of them fence the affected key, so nothing that was already in flight when the invalidation
+arrived can write its pre-invalidation snapshot back into the in-memory cache when it resolves. That
+covers both a running load and a preemptive background refresh. A caller that was already awaiting
+that load still receives its value — exactly as for a locally originated invalidation.
 
 If you implement `AbstractNotificationConsumer` yourself you get this behaviour for free: the target
 cache handed to `setTargetCache` is a facade over the owning loader that routes deletions and sets
 through these methods, so `this.targetCache.delete(key)` fences running loads too.
+
+One thing the fence does not — and cannot — cover: the **shared async tier**. A background refresh
+that has already read from your data sources still writes the value it read into Redis, even if an
+invalidation arrives in between. That is the ordinary read-through race that any cache in front of a
+mutable store has (a plain cache miss has it too), and closing it needs versioning at the store, not
+a local fence. The fence is about this instance's in-memory tier: an invalidated entry stays
+invalidated locally instead of being resurrected, and the async tier converges on its own TTL.
 
 ## Background work
 

--- a/core.ts
+++ b/core.ts
@@ -45,6 +45,11 @@ export type {
   IsEntryStillCurrentFn,
   IsGroupEntryStillCurrentFn,
 } from './lib/types/DataSources.js'
+export type {
+  BackgroundWorkMeta,
+  BackgroundWorkReason,
+  BackgroundWorkScheduler,
+} from './lib/types/BackgroundWork.js'
 export type { Logger, LogFn } from './lib/util/Logger.js'
 
 export { HitStatisticsRecord } from 'toad-cache'

--- a/lib/AbstractCache.ts
+++ b/lib/AbstractCache.ts
@@ -104,6 +104,21 @@ export abstract class AbstractCache<
   private readonly notificationConsumer?: AbstractNotificationConsumer<LoadedValue, InMemoryCacheType>
   protected readonly notificationPublisher?: NotificationPublisherType
 
+  /**
+   * Fence tokens for background work that writes into the in-memory tier without holding a
+   * `runningLoads` entry - specifically the async-tier preemptive refresh, which reloads straight
+   * from the data sources instead of going through the fenced `getAsyncOnlyResolved` path.
+   *
+   * An invalidation - originated locally or applied from elsewhere - breaks the fence for the
+   * affected key, so a refresh that started before it arrived can tell that its result is a
+   * pre-invalidation snapshot and skip the write instead of resurrecting the entry.
+   *
+   * Only keys with a refresh in flight are ever present, so the map is bounded by refresh
+   * concurrency rather than by key cardinality.
+   */
+  private readonly backgroundWriteFences: Map<string, number>
+  private backgroundWriteFenceCounter: number
+
   private readonly backgroundWorkScheduler?: BackgroundWorkScheduler
   private readonly cacheId?: string
 
@@ -154,8 +169,10 @@ export abstract class AbstractCache<
     this.cacheId = config.inMemoryCache ? config.inMemoryCache.cacheId : undefined
 
     // Must exist before the notification consumer is wired up: the target cache handed to the
-    // consumer fences running loads, so it needs the map to already be there.
+    // consumer fences running loads and background writes, so both need to already be there.
     this.runningLoads = new Map()
+    this.backgroundWriteFences = new Map()
+    this.backgroundWriteFenceCounter = 0
 
     if (config.notificationConsumer) {
       if (!config.inMemoryCache) {
@@ -206,6 +223,60 @@ export abstract class AbstractCache<
       return
     }
     void guarded
+  }
+
+  /**
+   * Opens a fence for a background operation that will write into the in-memory tier once it
+   * completes. See {@link backgroundWriteFences}. The returned token is what
+   * {@link isBackgroundWriteFenceIntact} and {@link closeBackgroundWriteFence} are called back with.
+   */
+  protected openBackgroundWriteFence(fenceKey: string): number {
+    const token = ++this.backgroundWriteFenceCounter
+    this.backgroundWriteFences.set(fenceKey, token)
+    return token
+  }
+
+  /**
+   * Whether the fence opened under this token is still standing - i.e. no invalidation touched the
+   * key while the background operation was running, so its result is safe to write.
+   */
+  protected isBackgroundWriteFenceIntact(fenceKey: string, token: number): boolean {
+    return this.backgroundWriteFences.get(fenceKey) === token
+  }
+
+  /**
+   * Releases the fence, unless it was already broken (or re-opened by a newer operation).
+   */
+  protected closeBackgroundWriteFence(fenceKey: string, token: number): void {
+    if (this.backgroundWriteFences.get(fenceKey) === token) {
+      this.backgroundWriteFences.delete(fenceKey)
+    }
+  }
+
+  protected breakBackgroundWriteFence(fenceKey: string): void {
+    this.backgroundWriteFences.delete(fenceKey)
+  }
+
+  /**
+   * Breaks every fence whose key starts with the given prefix, for invalidations that span a whole
+   * scope (a group) rather than a single entry. Iterating is cheap: the map only ever holds the keys
+   * currently being refreshed.
+   */
+  protected breakBackgroundWriteFencesWithPrefix(prefix: string): void {
+    for (const fenceKey of this.backgroundWriteFences.keys()) {
+      if (fenceKey.startsWith(prefix)) {
+        this.backgroundWriteFences.delete(fenceKey)
+      }
+    }
+  }
+
+  /**
+   * Evicts every running load and breaks every background write fence, so nothing in flight can
+   * repopulate the cache after a cache-wide invalidation.
+   */
+  protected evictAllRunningLoads(): void {
+    this.runningLoads.clear()
+    this.backgroundWriteFences.clear()
   }
 
   /**
@@ -281,7 +352,7 @@ export abstract class AbstractCache<
 
   public async invalidateCache() {
     // Evict the running loads first so in-flight results are fenced out of the caches.
-    this.runningLoads.clear()
+    this.evictAllRunningLoads()
     if (this.asyncCache) {
       await this.asyncCache.clear().catch((err) => {
         this.cacheUpdateErrorHandler(err, undefined, this.asyncCache!, this.logger)
@@ -292,7 +363,7 @@ export abstract class AbstractCache<
     // read a not-yet-deleted async value; fencing it out here stops it from
     // repopulating the caches after this invalidation resolves. The in-memory clear
     // comes last for the same reason.
-    this.runningLoads.clear()
+    this.evictAllRunningLoads()
     this.inMemoryCache.clear()
 
     if (this.notificationPublisher) {
@@ -312,7 +383,7 @@ export abstract class AbstractCache<
    * invalidation is a different operation from originating one.
    */
   public applyRemoteInvalidation(): void {
-    this.runningLoads.clear()
+    this.evictAllRunningLoads()
     this.inMemoryCache.clear()
   }
 

--- a/lib/AbstractCache.ts
+++ b/lib/AbstractCache.ts
@@ -6,6 +6,7 @@ import { NoopCache } from './memory/NoopCache.js'
 import type { AbstractNotificationConsumer } from './notifications/AbstractNotificationConsumer.js'
 import type { GroupNotificationPublisher } from './notifications/GroupNotificationPublisher.js'
 import type { NotificationPublisher } from './notifications/NotificationPublisher.js'
+import type { BackgroundWorkReason, BackgroundWorkScheduler } from './types/BackgroundWork.js'
 import type { Cache, GroupCache } from './types/DataSources.js'
 import type { SynchronousCache, SynchronousGroupCache } from './types/SyncDataSources.js'
 import type { Logger } from './util/Logger.js'
@@ -63,7 +64,17 @@ export type CommonCacheConfig<
   notificationPublisher?: NotificationPublisherType
   cacheKeyFromLoadParamsResolver?: CacheKeyResolver<LoadParams>
   cacheKeyFromValueResolver?: CacheKeyResolver<LoadedValue>
+
+  /**
+   * Optional hook for work the loader starts and does not await (background refreshes, staleness
+   * probes, notification publishes). Defaults to leaving the work detached, which is today's
+   * behaviour. See {@link BackgroundWorkScheduler} - in particular the note on resolving the request
+   * context at call time rather than closing over one.
+   */
+  scheduleBackgroundWork?: BackgroundWorkScheduler
 }
+
+const NOOP = () => {}
 
 export abstract class AbstractCache<
   LoadedValue,
@@ -93,7 +104,17 @@ export abstract class AbstractCache<
   private readonly notificationConsumer?: AbstractNotificationConsumer<LoadedValue, InMemoryCacheType>
   protected readonly notificationPublisher?: NotificationPublisherType
 
+  private readonly backgroundWorkScheduler?: BackgroundWorkScheduler
+  private readonly cacheId?: string
+
   abstract isGroupCache(): boolean
+
+  /**
+   * Builds the cache-shaped facade that received (as opposed to originated) invalidations are
+   * applied through. Reads delegate straight to the in-memory cache; writes and deletions go through
+   * the `applyRemote*` methods, so they fence running loads and publish nothing.
+   */
+  protected abstract createRemoteInvalidationTarget(): InMemoryCacheType
 
   private initPromises: Promise<unknown>[]
 
@@ -129,13 +150,22 @@ export abstract class AbstractCache<
     this.logger = config.logger ?? defaultLogger
     this.cacheUpdateErrorHandler = config.cacheUpdateErrorHandler ?? DEFAULT_CACHE_ERROR_HANDLER
     this.loadErrorHandler = config.loadErrorHandler ?? DEFAULT_LOAD_ERROR_HANDLER
+    this.backgroundWorkScheduler = config.scheduleBackgroundWork
+    this.cacheId = config.inMemoryCache ? config.inMemoryCache.cacheId : undefined
+
+    // Must exist before the notification consumer is wired up: the target cache handed to the
+    // consumer fences running loads, so it needs the map to already be there.
+    this.runningLoads = new Map()
 
     if (config.notificationConsumer) {
       if (!config.inMemoryCache) {
         throw new Error('Cannot set notificationConsumer when InMemoryCache is disabled')
       }
       this.notificationConsumer = config.notificationConsumer
-      this.notificationConsumer.setTargetCache(this.inMemoryCache)
+      // Deliberately not `this.inMemoryCache`: a consumer applies invalidations that originated
+      // elsewhere, and doing that correctly means fencing running loads as well as deleting the
+      // entry. Routing every existing consumer through the facade gives them that for free.
+      this.notificationConsumer.setTargetCache(this.createRemoteInvalidationTarget())
       this.initPromises.push(
         this.notificationConsumer.subscribe().catch((err) => {
           /* v8 ignore next -- @preserve */
@@ -153,13 +183,29 @@ export abstract class AbstractCache<
         }),
       )
     }
-
-    this.runningLoads = new Map()
   }
 
   public async init() {
     await Promise.all(this.initPromises)
     this.initPromises = []
+  }
+
+  /**
+   * Hands a piece of fire-and-forget work to the configured `scheduleBackgroundWork` hook, or leaves
+   * it detached when there is none (the default, and what the library has always done).
+   *
+   * The promise is wrapped before it is handed over so that it always settles fulfilled. Every call
+   * site has already routed its own errors to the configured handlers, so nothing is lost by
+   * swallowing here - and a rejecting promise would be actively harmful, since `ctx.waitUntil()`
+   * on one fails the request that adopted it.
+   */
+  protected runInBackground(work: Promise<unknown>, reason: BackgroundWorkReason): void {
+    const guarded = work.then(NOOP, NOOP)
+    if (this.backgroundWorkScheduler) {
+      this.backgroundWorkScheduler(guarded, { cacheId: this.cacheId, reason })
+      return
+    }
+    void guarded
   }
 
   /**
@@ -250,10 +296,24 @@ export abstract class AbstractCache<
     this.inMemoryCache.clear()
 
     if (this.notificationPublisher) {
-      this.notificationPublisher.clear().catch((err) => {
-        this.notificationPublisher!.errorHandler(err, this.notificationPublisher!.channel, this.logger)
-      })
+      this.runInBackground(
+        this.notificationPublisher.clear().catch((err) => {
+          this.notificationPublisher!.errorHandler(err, this.notificationPublisher!.channel, this.logger)
+        }),
+        'notification',
+      )
     }
+  }
+
+  /**
+   * Applies a cache-wide clear that originated elsewhere (another node, another isolate).
+   *
+   * See {@link AbstractFlatCache.applyRemoteInvalidationFor} for why applying a received
+   * invalidation is a different operation from originating one.
+   */
+  public applyRemoteInvalidation(): void {
+    this.runningLoads.clear()
+    this.inMemoryCache.clear()
   }
 
   public async close() {

--- a/lib/AbstractFlatCache.ts
+++ b/lib/AbstractFlatCache.ts
@@ -20,6 +20,19 @@ export abstract class AbstractFlatCache<LoadedValue, LoadParams = string, LoadMa
   }
 
   /**
+   * Fences everything in flight for a key: the running load, and any background work that is going
+   * to write into the in-memory tier without holding a running load (the async-tier preemptive
+   * refresh). Every invalidation path - originating and applying alike - goes through here.
+   *
+   * Deliberately not used by the load-completion bookkeeping in {@link getAsyncOnlyResolved}: a load
+   * finishing normally must not cancel a concurrent refresh that is about to write a fresher value.
+   */
+  protected evictRunningLoad(key: string): void {
+    this.runningLoads.delete(key)
+    this.breakBackgroundWriteFence(key)
+  }
+
+  /**
    * Applies an invalidation that originated elsewhere - another node on a notification bus, or a
    * pull-based transport that read "what changed since cursor N" at the start of a request.
    *
@@ -29,16 +42,16 @@ export abstract class AbstractFlatCache<LoadedValue, LoadParams = string, LoadMa
    *   would echo it back onto the bus;
    * - it does not touch the async cache, because that tier is shared and the origin already deleted
    *   the entry there;
-   * - it does evict the running load for the key, so a load that started before the invalidation
-   *   arrived cannot write its pre-invalidation snapshot back into the in-memory cache when it
-   *   resolves. Callers already awaiting that load still receive its value, exactly as they do for a
-   *   locally originated invalidation.
+   * - it does evict the running load for the key, and breaks the fence of an async-tier preemptive
+   *   refresh in flight for it, so neither can write its pre-invalidation snapshot back into the
+   *   in-memory cache when it resolves. Callers already awaiting that load still receive its value,
+   *   exactly as they do for a locally originated invalidation.
    *
    * Notification consumers get this behaviour without doing anything: the target cache they are
    * handed routes deletions through here.
    */
   public applyRemoteInvalidationFor(key: string): void {
-    this.runningLoads.delete(key)
+    this.evictRunningLoad(key)
     this.inMemoryCache.delete(key)
   }
 
@@ -47,7 +60,7 @@ export abstract class AbstractFlatCache<LoadedValue, LoadParams = string, LoadMa
    */
   public applyRemoteInvalidationForMany(keys: string[]): void {
     for (let i = 0; i < keys.length; i++) {
-      this.runningLoads.delete(keys[i])
+      this.evictRunningLoad(keys[i])
     }
     this.inMemoryCache.deleteMany(keys)
   }
@@ -58,7 +71,7 @@ export abstract class AbstractFlatCache<LoadedValue, LoadParams = string, LoadMa
    * overwrite the newer value that just arrived.
    */
   public applyRemoteValue(key: string, value: LoadedValue | null): void {
-    this.runningLoads.delete(key)
+    this.evictRunningLoad(key)
     this.inMemoryCache.set(key, value)
   }
 
@@ -219,7 +232,7 @@ export abstract class AbstractFlatCache<LoadedValue, LoadParams = string, LoadMa
 
   public async invalidateCacheFor(key: string) {
     // Evict the running load first so an in-flight result is fenced out of the caches.
-    this.runningLoads.delete(key)
+    this.evictRunningLoad(key)
     if (this.asyncCache) {
       await this.asyncCache.delete(key).catch((err) => {
         this.cacheUpdateErrorHandler(err, undefined, this.asyncCache!, this.logger)
@@ -230,7 +243,7 @@ export abstract class AbstractFlatCache<LoadedValue, LoadParams = string, LoadMa
     // read the not-yet-deleted async value; fencing it out here stops it from
     // repopulating the caches after this invalidation resolves. The in-memory delete
     // comes last for the same reason.
-    this.runningLoads.delete(key)
+    this.evictRunningLoad(key)
     this.inMemoryCache.delete(key)
     if (this.notificationPublisher) {
       this.runInBackground(
@@ -245,7 +258,7 @@ export abstract class AbstractFlatCache<LoadedValue, LoadParams = string, LoadMa
   public async invalidateCacheForMany(keys: string[]) {
     // Evict the running loads first so in-flight results are fenced out of the caches.
     for (let i = 0; i < keys.length; i++) {
-      this.runningLoads.delete(keys[i])
+      this.evictRunningLoad(keys[i])
     }
     if (this.asyncCache) {
       await this.asyncCache.deleteMany(keys).catch((err) => {
@@ -256,7 +269,7 @@ export abstract class AbstractFlatCache<LoadedValue, LoadParams = string, LoadMa
 
     for (let i = 0; i < keys.length; i++) {
       this.inMemoryCache.delete(keys[i])
-      this.runningLoads.delete(keys[i])
+      this.evictRunningLoad(keys[i])
     }
 
     if (this.notificationPublisher) {

--- a/lib/AbstractFlatCache.ts
+++ b/lib/AbstractFlatCache.ts
@@ -19,6 +19,64 @@ export abstract class AbstractFlatCache<LoadedValue, LoadParams = string, LoadMa
     return false
   }
 
+  /**
+   * Applies an invalidation that originated elsewhere - another node on a notification bus, or a
+   * pull-based transport that read "what changed since cursor N" at the start of a request.
+   *
+   * This is deliberately not the same operation as {@link invalidateCacheFor}:
+   *
+   * - it publishes nothing, because the origin already broadcast the invalidation; re-publishing it
+   *   would echo it back onto the bus;
+   * - it does not touch the async cache, because that tier is shared and the origin already deleted
+   *   the entry there;
+   * - it does evict the running load for the key, so a load that started before the invalidation
+   *   arrived cannot write its pre-invalidation snapshot back into the in-memory cache when it
+   *   resolves. Callers already awaiting that load still receive its value, exactly as they do for a
+   *   locally originated invalidation.
+   *
+   * Notification consumers get this behaviour without doing anything: the target cache they are
+   * handed routes deletions through here.
+   */
+  public applyRemoteInvalidationFor(key: string): void {
+    this.runningLoads.delete(key)
+    this.inMemoryCache.delete(key)
+  }
+
+  /**
+   * Batch form of {@link applyRemoteInvalidationFor}.
+   */
+  public applyRemoteInvalidationForMany(keys: string[]): void {
+    for (let i = 0; i < keys.length; i++) {
+      this.runningLoads.delete(keys[i])
+    }
+    this.inMemoryCache.deleteMany(keys)
+  }
+
+  /**
+   * Applies a value that was set elsewhere and broadcast to this node. Fences the running load for
+   * the same reason {@link applyRemoteInvalidationFor} does: an older in-flight load must not
+   * overwrite the newer value that just arrived.
+   */
+  public applyRemoteValue(key: string, value: LoadedValue | null): void {
+    this.runningLoads.delete(key)
+    this.inMemoryCache.set(key, value)
+  }
+
+  protected override createRemoteInvalidationTarget(): SynchronousCache<LoadedValue> {
+    const inMemoryCache = this.inMemoryCache
+    return {
+      ttlLeftBeforeRefreshInMsecs: inMemoryCache.ttlLeftBeforeRefreshInMsecs,
+      get: (key) => inMemoryCache.get(key),
+      getMany: (keys) => inMemoryCache.getMany(keys),
+      getExpirationTime: (key) => inMemoryCache.getExpirationTime(key),
+      resetTtl: (key) => inMemoryCache.resetTtl(key),
+      set: (key, value) => this.applyRemoteValue(key, value),
+      delete: (key) => this.applyRemoteInvalidationFor(key),
+      deleteMany: (keys) => this.applyRemoteInvalidationForMany(keys),
+      clear: () => this.applyRemoteInvalidation(),
+    }
+  }
+
   public getInMemoryOnly(loadParams: LoadParams): LoadedValue | undefined | null {
     return this.getInMemoryOnlyResolved(this.cacheKeyFromLoadParamsResolver(loadParams), loadParams)
   }
@@ -40,7 +98,7 @@ export abstract class AbstractFlatCache<LoadedValue, LoadParams = string, LoadMa
    * against the in-memory value and merely bump its TTL when it is still current.
    */
   protected scheduleInMemoryRefresh(key: string, loadParams: LoadParams): void {
-    void this.getAsyncOnlyResolved(key, loadParams)
+    this.runInBackground(this.getAsyncOnlyResolved(key, loadParams), 'refresh')
   }
 
   public getManyInMemoryOnly(keys: string[]): GetManyResult<LoadedValue> {
@@ -175,9 +233,12 @@ export abstract class AbstractFlatCache<LoadedValue, LoadParams = string, LoadMa
     this.runningLoads.delete(key)
     this.inMemoryCache.delete(key)
     if (this.notificationPublisher) {
-      this.notificationPublisher.delete(key).catch((err) => {
-        this.notificationPublisher!.errorHandler(err, this.notificationPublisher!.channel, this.logger)
-      })
+      this.runInBackground(
+        this.notificationPublisher.delete(key).catch((err) => {
+          this.notificationPublisher!.errorHandler(err, this.notificationPublisher!.channel, this.logger)
+        }),
+        'notification',
+      )
     }
   }
 
@@ -199,10 +260,13 @@ export abstract class AbstractFlatCache<LoadedValue, LoadParams = string, LoadMa
     }
 
     if (this.notificationPublisher) {
-      this.notificationPublisher.deleteMany(keys).catch((err) => {
-        /* v8 ignore next -- @preserve */
-        this.notificationPublisher!.errorHandler(err, this.notificationPublisher!.channel, this.logger)
-      })
+      this.runInBackground(
+        this.notificationPublisher.deleteMany(keys).catch((err) => {
+          /* v8 ignore next -- @preserve */
+          this.notificationPublisher!.errorHandler(err, this.notificationPublisher!.channel, this.logger)
+        }),
+        'notification',
+      )
     }
   }
 }

--- a/lib/AbstractGroupCache.ts
+++ b/lib/AbstractGroupCache.ts
@@ -18,6 +18,57 @@ export abstract class AbstractGroupCache<LoadedValue, LoadParams = string, LoadM
     return true
   }
 
+  /**
+   * Applies an entry invalidation that originated elsewhere - another node on a notification bus, or
+   * a pull-based transport that read "what changed since cursor N" at the start of a request.
+   *
+   * This is deliberately not the same operation as {@link invalidateCacheFor}: it publishes nothing
+   * (the origin already broadcast it, and re-publishing would echo it back onto the bus) and does
+   * not touch the shared async cache (the origin already deleted the entry there), but it does evict
+   * the running load, so a load that started before the invalidation arrived cannot write its
+   * pre-invalidation snapshot back into the in-memory cache when it resolves.
+   *
+   * Notification consumers get this behaviour without doing anything: the target cache they are
+   * handed routes deletions through here.
+   */
+  public applyRemoteInvalidationFor(key: string, group: string): void {
+    this.evictGroupRunningLoad(group, key)
+    this.inMemoryCache.deleteFromGroup(key, group)
+  }
+
+  /**
+   * Group-wide form of {@link applyRemoteInvalidationFor}.
+   */
+  public applyRemoteInvalidationForGroup(group: string): void {
+    this.runningLoads.delete(group)
+    this.inMemoryCache.deleteGroup(group)
+  }
+
+  /**
+   * Applies a value that was set elsewhere and broadcast to this node. Fences the running load for
+   * the same reason {@link applyRemoteInvalidationFor} does: an older in-flight load must not
+   * overwrite the newer value that just arrived.
+   */
+  public applyRemoteValue(key: string, value: LoadedValue | null, group: string): void {
+    this.evictGroupRunningLoad(group, key)
+    this.inMemoryCache.setForGroup(key, value, group)
+  }
+
+  protected override createRemoteInvalidationTarget(): SynchronousGroupCache<LoadedValue> {
+    const inMemoryCache = this.inMemoryCache
+    return {
+      ttlLeftBeforeRefreshInMsecs: inMemoryCache.ttlLeftBeforeRefreshInMsecs,
+      getFromGroup: (key, group) => inMemoryCache.getFromGroup(key, group),
+      getManyFromGroup: (keys, group) => inMemoryCache.getManyFromGroup(keys, group),
+      getExpirationTimeFromGroup: (key, group) => inMemoryCache.getExpirationTimeFromGroup(key, group),
+      resetTtlFromGroup: (key, group) => inMemoryCache.resetTtlFromGroup(key, group),
+      setForGroup: (key, value, group) => this.applyRemoteValue(key, value, group),
+      deleteFromGroup: (key, group) => this.applyRemoteInvalidationFor(key, group),
+      deleteGroup: (group) => this.applyRemoteInvalidationForGroup(group),
+      clear: () => this.applyRemoteInvalidation(),
+    }
+  }
+
   public async invalidateCacheForGroup(group: string) {
     // Evict the running loads first so in-flight results are fenced out of the caches.
     this.runningLoads.delete(group)
@@ -35,9 +86,12 @@ export abstract class AbstractGroupCache<LoadedValue, LoadParams = string, LoadM
     this.inMemoryCache.deleteGroup(group)
 
     if (this.notificationPublisher) {
-      void this.notificationPublisher.deleteGroup(group).catch((err) => {
-        this.notificationPublisher!.errorHandler(err, this.notificationPublisher!.channel, this.logger)
-      })
+      this.runInBackground(
+        this.notificationPublisher.deleteGroup(group).catch((err) => {
+          this.notificationPublisher!.errorHandler(err, this.notificationPublisher!.channel, this.logger)
+        }),
+        'notification',
+      )
     }
   }
 
@@ -68,7 +122,7 @@ export abstract class AbstractGroupCache<LoadedValue, LoadParams = string, LoadM
    * against the in-memory value and merely bump its TTL when it is still current.
    */
   protected scheduleInMemoryRefresh(key: string, loadParams: LoadParams, group: string): void {
-    void this.getAsyncOnlyResolved(key, loadParams, group)
+    this.runInBackground(this.getAsyncOnlyResolved(key, loadParams, group), 'refresh')
   }
 
   public getManyInMemoryOnly(keys: string[], group: string) {
@@ -183,9 +237,12 @@ export abstract class AbstractGroupCache<LoadedValue, LoadParams = string, LoadM
     this.inMemoryCache.deleteFromGroup(key, group)
 
     if (this.notificationPublisher) {
-      void this.notificationPublisher.deleteFromGroup(key, group).catch((err) => {
-        this.notificationPublisher!.errorHandler(err, this.notificationPublisher!.channel, this.logger)
-      })
+      this.runInBackground(
+        this.notificationPublisher.deleteFromGroup(key, group).catch((err) => {
+          this.notificationPublisher!.errorHandler(err, this.notificationPublisher!.channel, this.logger)
+        }),
+        'notification',
+      )
     }
   }
 

--- a/lib/AbstractGroupCache.ts
+++ b/lib/AbstractGroupCache.ts
@@ -19,14 +19,65 @@ export abstract class AbstractGroupCache<LoadedValue, LoadParams = string, LoadM
   }
 
   /**
+   * Background write fences are keyed by a single string, so a grouped entry needs its group and key
+   * flattened into one. Group names and keys are arbitrary strings, so the group is length-prefixed:
+   * that makes toGroupFencePrefix an exact group match, rather than one that could also catch a
+   * different group whose name happens to start the same way.
+   */
+  private static toFenceKey(key: string, group: string): string {
+    return `${AbstractGroupCache.toGroupFencePrefix(group)}${key}`
+  }
+
+  private static toGroupFencePrefix(group: string): string {
+    return `${group.length}:${group}:`
+  }
+
+  /**
+   * Fences everything in flight for a grouped entry: the running load, and any background work that
+   * is going to write into the in-memory tier without holding one (the async-tier preemptive
+   * refresh). Every invalidation path - originating and applying alike - goes through here.
+   */
+  protected evictGroupRunningLoad(group: string, key: string): void {
+    const groupLoads = this.runningLoads.get(group)
+    if (groupLoads) {
+      this.deleteGroupRunningLoad(groupLoads, group, key)
+    }
+    this.breakBackgroundWriteFence(AbstractGroupCache.toFenceKey(key, group))
+  }
+
+  /**
+   * Group-wide form of evictGroupRunningLoad.
+   */
+  protected evictGroupRunningLoads(group: string): void {
+    this.runningLoads.delete(group)
+    this.breakBackgroundWriteFencesWithPrefix(AbstractGroupCache.toGroupFencePrefix(group))
+  }
+
+  /**
+   * Grouped forms of the background write fence primitives on AbstractCache.
+   */
+  protected openGroupBackgroundWriteFence(key: string, group: string): number {
+    return this.openBackgroundWriteFence(AbstractGroupCache.toFenceKey(key, group))
+  }
+
+  protected isGroupBackgroundWriteFenceIntact(key: string, group: string, token: number): boolean {
+    return this.isBackgroundWriteFenceIntact(AbstractGroupCache.toFenceKey(key, group), token)
+  }
+
+  protected closeGroupBackgroundWriteFence(key: string, group: string, token: number): void {
+    this.closeBackgroundWriteFence(AbstractGroupCache.toFenceKey(key, group), token)
+  }
+
+  /**
    * Applies an entry invalidation that originated elsewhere - another node on a notification bus, or
    * a pull-based transport that read "what changed since cursor N" at the start of a request.
    *
    * This is deliberately not the same operation as {@link invalidateCacheFor}: it publishes nothing
    * (the origin already broadcast it, and re-publishing would echo it back onto the bus) and does
    * not touch the shared async cache (the origin already deleted the entry there), but it does evict
-   * the running load, so a load that started before the invalidation arrived cannot write its
-   * pre-invalidation snapshot back into the in-memory cache when it resolves.
+   * the running load and break the fence of an async-tier preemptive refresh in flight for the
+   * entry, so neither can write its pre-invalidation snapshot back into the in-memory cache when it
+   * resolves.
    *
    * Notification consumers get this behaviour without doing anything: the target cache they are
    * handed routes deletions through here.
@@ -40,7 +91,7 @@ export abstract class AbstractGroupCache<LoadedValue, LoadParams = string, LoadM
    * Group-wide form of {@link applyRemoteInvalidationFor}.
    */
   public applyRemoteInvalidationForGroup(group: string): void {
-    this.runningLoads.delete(group)
+    this.evictGroupRunningLoads(group)
     this.inMemoryCache.deleteGroup(group)
   }
 
@@ -71,7 +122,7 @@ export abstract class AbstractGroupCache<LoadedValue, LoadParams = string, LoadM
 
   public async invalidateCacheForGroup(group: string) {
     // Evict the running loads first so in-flight results are fenced out of the caches.
-    this.runningLoads.delete(group)
+    this.evictGroupRunningLoads(group)
     if (this.asyncCache) {
       await this.asyncCache.deleteGroup(group).catch((err) => {
         this.cacheUpdateErrorHandler(err, `group: ${group}`, this.asyncCache!, this.logger)
@@ -82,7 +133,7 @@ export abstract class AbstractGroupCache<LoadedValue, LoadParams = string, LoadM
     // read the not-yet-deleted async value; fencing it out here stops it from
     // repopulating the caches after this invalidation resolves. The in-memory delete
     // comes last for the same reason.
-    this.runningLoads.delete(group)
+    this.evictGroupRunningLoads(group)
     this.inMemoryCache.deleteGroup(group)
 
     if (this.notificationPublisher) {
@@ -279,13 +330,6 @@ export abstract class AbstractGroupCache<LoadedValue, LoadParams = string, LoadM
     return {
       unresolvedKeys: keys,
       resolvedValues: [],
-    }
-  }
-
-  private evictGroupRunningLoad(group: string, key: string) {
-    const groupLoads = this.runningLoads.get(group)
-    if (groupLoads) {
-      this.deleteGroupRunningLoad(groupLoads, group, key)
     }
   }
 

--- a/lib/GroupLoader.ts
+++ b/lib/GroupLoader.ts
@@ -84,9 +84,12 @@ export class GroupLoader<LoadedValue, LoadParams = string, LoadManyParams = Load
                   return undefined
                 })
                 .catch((err) => {
-                  // expiration lookup is fire-and-forget; a rejection here must not become
-                  // an unhandled promise rejection
-                  this.logger.error(err.message)
+                  // The expiration lookup is a read against the async cache, so report it the same
+                  // way resolveGroupValue reports a failed read: through loadErrorHandler, so a
+                  // configured handler can observe it (the default one still logs). It is
+                  // fire-and-forget, so swallowing after reporting also keeps it from becoming an
+                  // unhandled promise rejection.
+                  this.loadErrorHandler(err, key, this.asyncCache!, this.logger)
                 }),
               'refresh',
             )
@@ -165,35 +168,45 @@ export class GroupLoader<LoadedValue, LoadParams = string, LoadManyParams = Load
     loadParams: LoadParams,
     cachedValue: LoadedValue | null,
   ): Promise<void> {
-    if (
-      this.isEntryStillCurrentFn &&
-      (await this.isCurrentEntryTtlBumped(
-        key,
-        () => this.isEntryStillCurrentFn!(cachedValue, loadParams, group),
-        () => this.asyncCache!.resetTtlFromGroup!(key, group),
-      ))
-    ) {
-      // getAsyncOnly already re-set the in-memory entry to this same value when resolveGroupValue
-      // resolved, which reset its TTL; the value is unchanged on a bump, so nothing else to do.
-      return
-    }
+    // This refresh writes into the in-memory tier without holding a runningLoads entry (it reloads
+    // straight from the data sources rather than through getAsyncOnlyResolved), so it needs its own
+    // fence. Without it, an invalidation arriving mid-refresh - locally originated or applied from
+    // another node, per entry or per group - deletes the entry and is then silently undone when this
+    // refresh completes and writes its pre-invalidation snapshot back.
+    const fenceToken = this.openGroupBackgroundWriteFence(key, group)
+    try {
+      if (
+        this.isEntryStillCurrentFn &&
+        (await this.isCurrentEntryTtlBumped(
+          key,
+          () => this.isEntryStillCurrentFn!(cachedValue, loadParams, group),
+          () => this.asyncCache!.resetTtlFromGroup!(key, group),
+        ))
+      ) {
+        // getAsyncOnly already re-set the in-memory entry to this same value when resolveGroupValue
+        // resolved, which reset its TTL; the value is unchanged on a bump, so nothing else to do.
+        return
+      }
 
-    // The entry is stale, the check failed, or the bump failed (entry expired or the group was
-    // invalidated meanwhile), so run the full background refresh from the data sources.
-    const freshValue = await this.loadFromLoaders(key, group, loadParams)
-    // Propagate the freshly loaded value to the in-memory group cache as well.
-    // Without this, the in-memory layer keeps serving the stale value that
-    // was read from the async cache before this background refresh started,
-    // and its TTL is reset on the next read, so subsequent reads stay stale
-    // for another full ttlInMsecs window even though the async cache is fresh.
-    if (freshValue !== undefined) {
-      this.inMemoryCache.setForGroup(key, freshValue, group)
+      // The entry is stale, the check failed, or the bump failed (entry expired or the group was
+      // invalidated meanwhile), so run the full background refresh from the data sources.
+      const freshValue = await this.loadFromLoaders(key, group, loadParams)
+      // Propagate the freshly loaded value to the in-memory group cache as well.
+      // Without this, the in-memory layer keeps serving the stale value that
+      // was read from the async cache before this background refresh started,
+      // and its TTL is reset on the next read, so subsequent reads stay stale
+      // for another full ttlInMsecs window even though the async cache is fresh.
+      if (freshValue !== undefined && this.isGroupBackgroundWriteFenceIntact(key, group, fenceToken)) {
+        this.inMemoryCache.setForGroup(key, freshValue, group)
+      }
+    } finally {
+      this.closeGroupBackgroundWriteFence(key, group, fenceToken)
     }
   }
 
   public async forceSetValueForGroup(key: string, newValue: LoadedValue | null, group: string) {
     this.inMemoryCache.setForGroup(key, newValue, group)
-    this.deleteGroupRunningLoad(this.resolveGroupLoads(group), group, key)
+    this.evictGroupRunningLoad(group, key)
 
     if (this.asyncCache) {
       await this.asyncCache.setForGroup(key, newValue, group).catch((err) => {

--- a/lib/GroupLoader.ts
+++ b/lib/GroupLoader.ts
@@ -1,9 +1,9 @@
 import { AbstractGroupCache } from './AbstractGroupCache.js'
 import type { LoaderConfig } from './Loader.js'
-import type { InMemoryGroupCache, InMemoryGroupCacheConfiguration } from './memory/InMemoryGroupCache.js'
+import type { InMemoryGroupCacheConfiguration } from './memory/InMemoryGroupCache.js'
 import type { GroupNotificationPublisher } from './notifications/GroupNotificationPublisher.js'
 import type { CacheEntry, GroupCache, GroupDataSource, IsGroupEntryStillCurrentFn } from './types/DataSources.js'
-import type { GetManyResult } from './types/SyncDataSources.js'
+import type { GetManyResult, SynchronousGroupCache } from './types/SyncDataSources.js'
 
 export type GroupLoaderConfig<LoadedValue, LoadParams = string, LoadManyParams = LoadParams> = LoaderConfig<
   LoadedValue,
@@ -12,7 +12,7 @@ export type GroupLoaderConfig<LoadedValue, LoadParams = string, LoadManyParams =
   GroupCache<LoadedValue>,
   GroupDataSource<LoadedValue, LoadParams, LoadManyParams>,
   InMemoryGroupCacheConfiguration,
-  InMemoryGroupCache<LoadedValue>,
+  SynchronousGroupCache<LoadedValue>,
   GroupNotificationPublisher<LoadedValue>,
   IsGroupEntryStillCurrentFn<LoadedValue, LoadParams>
 >

--- a/lib/GroupLoader.ts
+++ b/lib/GroupLoader.ts
@@ -51,38 +51,45 @@ export class GroupLoader<LoadedValue, LoadParams = string, LoadManyParams = Load
           let isAlreadyRefreshing = groupSet?.has(key)
 
           if (!isAlreadyRefreshing) {
-            this.asyncCache.expirationTimeLoadingGroupedOperation
-              .get(key, group)
-              .then((expirationTime) => {
-                if (expirationTime && expirationTime - Date.now() < this.asyncCache!.ttlLeftBeforeRefreshInMsecs!) {
-                  // Check if someone else didn't start refreshing while we were checking expiration time
-                  groupSet = this.groupRefreshFlags.get(group)
-                  isAlreadyRefreshing = groupSet?.has(key)
-                  if (!isAlreadyRefreshing) {
-                    if (!groupSet) {
-                      groupSet = new Set<string>()
-                      this.groupRefreshFlags.set(group, groupSet)
-                    }
-                    groupSet.add(key)
+            this.runInBackground(
+              this.asyncCache.expirationTimeLoadingGroupedOperation
+                .get(key, group)
+                .then((expirationTime) => {
+                  if (expirationTime && expirationTime - Date.now() < this.asyncCache!.ttlLeftBeforeRefreshInMsecs!) {
+                    // Check if someone else didn't start refreshing while we were checking expiration time
+                    groupSet = this.groupRefreshFlags.get(group)
+                    isAlreadyRefreshing = groupSet?.has(key)
+                    if (!isAlreadyRefreshing) {
+                      if (!groupSet) {
+                        groupSet = new Set<string>()
+                        this.groupRefreshFlags.set(group, groupSet)
+                      }
+                      groupSet.add(key)
 
-                    this.refreshOrBumpTtl(key, group, loadParams, cachedValue)
-                      .catch((err) => {
-                        this.logger.error(err.message)
-                      })
-                      .finally(() => {
-                        groupSet!.delete(key)
-                        if (groupSet!.size === 0) {
-                          this.groupRefreshFlags.delete(group)
-                        }
-                      })
+                      // Returned, not detached: the promise handed to scheduleBackgroundWork has to
+                      // cover the refresh itself, not just the expiration lookup that decided it was
+                      // due. Nothing awaits this chain otherwise, so returning it changes no timing.
+                      return this.refreshOrBumpTtl(key, group, loadParams, cachedValue)
+                        .catch((err) => {
+                          this.logger.error(err.message)
+                        })
+                        .finally(() => {
+                          groupSet!.delete(key)
+                          if (groupSet!.size === 0) {
+                            this.groupRefreshFlags.delete(group)
+                          }
+                        })
+                    }
                   }
-                }
-              })
-              .catch((err) => {
-                // expiration lookup is fire-and-forget; a rejection here must not become
-                // an unhandled promise rejection
-                this.logger.error(err.message)
-              })
+                  return undefined
+                })
+                .catch((err) => {
+                  // expiration lookup is fire-and-forget; a rejection here must not become
+                  // an unhandled promise rejection
+                  this.logger.error(err.message)
+                }),
+              'refresh',
+            )
           }
         }
         return cachedValue
@@ -111,16 +118,19 @@ export class GroupLoader<LoadedValue, LoadParams = string, LoadManyParams = Load
     }
     groupSet.add(key)
 
-    this.refreshOrBumpInMemoryTtl(key, group, loadParams)
-      .catch((err) => {
-        this.logger.error(err.message)
-      })
-      .finally(() => {
-        groupSet!.delete(key)
-        if (groupSet!.size === 0) {
-          this.groupRefreshFlags.delete(group)
-        }
-      })
+    this.runInBackground(
+      this.refreshOrBumpInMemoryTtl(key, group, loadParams)
+        .catch((err) => {
+          this.logger.error(err.message)
+        })
+        .finally(() => {
+          groupSet!.delete(key)
+          if (groupSet!.size === 0) {
+            this.groupRefreshFlags.delete(group)
+          }
+        }),
+      'refresh',
+    )
   }
 
   private async refreshOrBumpInMemoryTtl(key: string, group: string, loadParams: LoadParams): Promise<void> {

--- a/lib/Loader.ts
+++ b/lib/Loader.ts
@@ -88,9 +88,12 @@ export class Loader<LoadedValue, LoadParams = string, LoadManyParams = LoadParam
 
     /* v8 ignore next -- @preserve */
     if (this.notificationPublisher) {
-      this.notificationPublisher.set(key, newValue).catch((err) => {
-        this.notificationPublisher!.errorHandler(err, this.notificationPublisher!.channel, this.logger)
-      })
+      this.runInBackground(
+        this.notificationPublisher.set(key, newValue).catch((err) => {
+          this.notificationPublisher!.errorHandler(err, this.notificationPublisher!.channel, this.logger)
+        }),
+        'notification',
+      )
     }
   }
 
@@ -105,9 +108,12 @@ export class Loader<LoadedValue, LoadParams = string, LoadManyParams = LoadParam
       // In order to keep other cluster nodes in-sync with potentially changed entry, we force them to refresh too
       /* v8 ignore next -- @preserve */
       if (this.notificationPublisher) {
-        this.notificationPublisher.delete(key).catch((err) => {
-          this.notificationPublisher!.errorHandler(err, this.notificationPublisher!.channel, this.logger)
-        })
+        this.runInBackground(
+          this.notificationPublisher.delete(key).catch((err) => {
+            this.notificationPublisher!.errorHandler(err, this.notificationPublisher!.channel, this.logger)
+          }),
+          'notification',
+        )
       }
 
       return finalValue
@@ -120,28 +126,35 @@ export class Loader<LoadedValue, LoadParams = string, LoadManyParams = LoadParam
       if (cachedValue !== undefined) {
         if (this.asyncCache?.ttlLeftBeforeRefreshInMsecs) {
           if (!this.isKeyRefreshing.has(key)) {
-            this.asyncCache.expirationTimeLoadingOperation
-              .get(key)
-              .then((expirationTime) => {
-                if (expirationTime && expirationTime - Date.now() < this.asyncCache!.ttlLeftBeforeRefreshInMsecs!) {
-                  // check second time, maybe someone obtained the lock while we were checking the expiration date
-                  if (!this.isKeyRefreshing.has(key)) {
-                    this.isKeyRefreshing.add(key)
-                    this.refreshOrBumpTtl(key, loadParams, cachedValue)
-                      .catch((err) => {
-                        this.logger.error(err.message)
-                      })
-                      .finally(() => {
-                        this.isKeyRefreshing.delete(key)
-                      })
+            this.runInBackground(
+              this.asyncCache.expirationTimeLoadingOperation
+                .get(key)
+                .then((expirationTime) => {
+                  if (expirationTime && expirationTime - Date.now() < this.asyncCache!.ttlLeftBeforeRefreshInMsecs!) {
+                    // check second time, maybe someone obtained the lock while we were checking the expiration date
+                    if (!this.isKeyRefreshing.has(key)) {
+                      this.isKeyRefreshing.add(key)
+                      // Returned, not detached: the promise handed to scheduleBackgroundWork has to
+                      // cover the refresh itself, not just the expiration lookup that decided it was
+                      // due. Nothing awaits this chain otherwise, so returning it changes no timing.
+                      return this.refreshOrBumpTtl(key, loadParams, cachedValue)
+                        .catch((err) => {
+                          this.logger.error(err.message)
+                        })
+                        .finally(() => {
+                          this.isKeyRefreshing.delete(key)
+                        })
+                    }
                   }
-                }
-              })
-              .catch((err) => {
-                // expiration lookup is fire-and-forget; a rejection here must not become
-                // an unhandled promise rejection
-                this.logger.error(err.message)
-              })
+                  return undefined
+                })
+                .catch((err) => {
+                  // expiration lookup is fire-and-forget; a rejection here must not become
+                  // an unhandled promise rejection
+                  this.logger.error(err.message)
+                }),
+              'refresh',
+            )
           }
         }
 
@@ -166,13 +179,16 @@ export class Loader<LoadedValue, LoadParams = string, LoadManyParams = LoadParam
       return
     }
     this.isKeyRefreshing.add(key)
-    this.refreshOrBumpInMemoryTtl(key, loadParams)
-      .catch((err) => {
-        this.logger.error(err.message)
-      })
-      .finally(() => {
-        this.isKeyRefreshing.delete(key)
-      })
+    this.runInBackground(
+      this.refreshOrBumpInMemoryTtl(key, loadParams)
+        .catch((err) => {
+          this.logger.error(err.message)
+        })
+        .finally(() => {
+          this.isKeyRefreshing.delete(key)
+        }),
+      'refresh',
+    )
   }
 
   private async refreshOrBumpInMemoryTtl(key: string, loadParams: LoadParams): Promise<void> {

--- a/lib/Loader.ts
+++ b/lib/Loader.ts
@@ -77,7 +77,7 @@ export class Loader<LoadedValue, LoadParams = string, LoadManyParams = LoadParam
 
   public async forceSetValue(key: string, newValue: LoadedValue | null) {
     this.inMemoryCache.set(key, newValue)
-    this.runningLoads.delete(key)
+    this.evictRunningLoad(key)
 
     if (this.asyncCache) {
       await this.asyncCache.set(key, newValue).catch((err) => {
@@ -102,7 +102,7 @@ export class Loader<LoadedValue, LoadParams = string, LoadManyParams = LoadParam
     return this.loadFromLoaders(key, loadParams).then((finalValue) => {
       if (finalValue !== undefined) {
         this.inMemoryCache.set(key, finalValue)
-        this.runningLoads.delete(key)
+        this.evictRunningLoad(key)
       }
 
       // In order to keep other cluster nodes in-sync with potentially changed entry, we force them to refresh too
@@ -149,9 +149,12 @@ export class Loader<LoadedValue, LoadParams = string, LoadManyParams = LoadParam
                   return undefined
                 })
                 .catch((err) => {
-                  // expiration lookup is fire-and-forget; a rejection here must not become
-                  // an unhandled promise rejection
-                  this.logger.error(err.message)
+                  // The expiration lookup is a read against the async cache, so report it the same
+                  // way resolveValue reports a failed read: through loadErrorHandler, so a
+                  // configured handler can observe it (the default one still logs). It is
+                  // fire-and-forget, so swallowing after reporting also keeps it from becoming an
+                  // unhandled promise rejection.
+                  this.loadErrorHandler(err, key, this.asyncCache!, this.logger)
                 }),
               'refresh',
             )
@@ -217,29 +220,39 @@ export class Loader<LoadedValue, LoadParams = string, LoadManyParams = LoadParam
   }
 
   private async refreshOrBumpTtl(key: string, loadParams: LoadParams, cachedValue: LoadedValue | null): Promise<void> {
-    if (
-      this.isEntryStillCurrentFn &&
-      (await this.isCurrentEntryTtlBumped(
-        key,
-        () => this.isEntryStillCurrentFn!(cachedValue, loadParams),
-        () => this.asyncCache!.resetTtl!(key),
-      ))
-    ) {
-      // getAsyncOnly already re-set the in-memory entry to this same value when resolveValue
-      // resolved, which reset its TTL; the value is unchanged on a bump, so nothing else to do.
-      return
-    }
+    // This refresh writes into the in-memory tier without holding a runningLoads entry (it reloads
+    // straight from the data sources rather than through getAsyncOnlyResolved), so it needs its own
+    // fence. Without it, an invalidation arriving mid-refresh - locally originated or applied from
+    // another node - deletes the entry and is then silently undone when this refresh completes and
+    // writes its pre-invalidation snapshot back.
+    const fenceToken = this.openBackgroundWriteFence(key)
+    try {
+      if (
+        this.isEntryStillCurrentFn &&
+        (await this.isCurrentEntryTtlBumped(
+          key,
+          () => this.isEntryStillCurrentFn!(cachedValue, loadParams),
+          () => this.asyncCache!.resetTtl!(key),
+        ))
+      ) {
+        // getAsyncOnly already re-set the in-memory entry to this same value when resolveValue
+        // resolved, which reset its TTL; the value is unchanged on a bump, so nothing else to do.
+        return
+      }
 
-    // The entry is stale, the check failed, or the bump failed (entry expired/deleted meanwhile),
-    // so run the full background refresh from the data sources.
-    const freshValue = await this.loadFromLoaders(key, loadParams)
-    // Propagate the freshly loaded value to the in-memory cache as well.
-    // Without this, the in-memory layer keeps serving the stale value that
-    // was read from the async cache before this background refresh started,
-    // and its TTL is reset on the next read, so subsequent reads stay stale
-    // for another full ttlInMsecs window even though the async cache is fresh.
-    if (freshValue !== undefined) {
-      this.inMemoryCache.set(key, freshValue)
+      // The entry is stale, the check failed, or the bump failed (entry expired/deleted meanwhile),
+      // so run the full background refresh from the data sources.
+      const freshValue = await this.loadFromLoaders(key, loadParams)
+      // Propagate the freshly loaded value to the in-memory cache as well.
+      // Without this, the in-memory layer keeps serving the stale value that
+      // was read from the async cache before this background refresh started,
+      // and its TTL is reset on the next read, so subsequent reads stay stale
+      // for another full ttlInMsecs window even though the async cache is fresh.
+      if (freshValue !== undefined && this.isBackgroundWriteFenceIntact(key, fenceToken)) {
+        this.inMemoryCache.set(key, freshValue)
+      }
+    } finally {
+      this.closeBackgroundWriteFence(key, fenceToken)
     }
   }
 

--- a/lib/ManualCache.ts
+++ b/lib/ManualCache.ts
@@ -3,7 +3,7 @@ import { AbstractFlatCache } from './AbstractFlatCache.js'
 export class ManualCache<LoadedValue> extends AbstractFlatCache<LoadedValue> {
     public async set(key: string, newValue: LoadedValue): Promise<void> {
         this.inMemoryCache.set(key, newValue)
-        this.runningLoads.delete(key)
+        this.evictRunningLoad(key)
         if (this.asyncCache) {
             await this.asyncCache.set(key, newValue).catch((err) => {
                 this.cacheUpdateErrorHandler(err, key, this.asyncCache!, this.logger)

--- a/lib/ManualGroupCache.ts
+++ b/lib/ManualGroupCache.ts
@@ -20,8 +20,7 @@ export class ManualGroupCache<LoadedValue> extends AbstractGroupCache<LoadedValu
 
   public async set(key: string, resolvedValue: LoadedValue, group: string): Promise<void> {
     this.inMemoryCache.setForGroup(key, resolvedValue, group)
-    const groupLoads = this.resolveGroupLoads(group)
-    this.deleteGroupRunningLoad(groupLoads, group, key)
+    this.evictGroupRunningLoad(group, key)
     if (this.asyncCache) {
       return this.asyncCache.setForGroup(key, resolvedValue, group).catch((err) => {
         this.cacheUpdateErrorHandler(err, key, this.asyncCache!, this.logger)

--- a/lib/ManualGroupCache.ts
+++ b/lib/ManualGroupCache.ts
@@ -1,14 +1,15 @@
 import type { CommonCacheConfig } from './AbstractCache.js'
 import { AbstractGroupCache } from './AbstractGroupCache.js'
-import type { InMemoryGroupCache, InMemoryGroupCacheConfiguration } from './memory/InMemoryGroupCache.js'
+import type { InMemoryGroupCacheConfiguration } from './memory/InMemoryGroupCache.js'
 import type { GroupNotificationPublisher } from './notifications/GroupNotificationPublisher.js'
 import type { GroupCache } from './types/DataSources.js'
+import type { SynchronousGroupCache } from './types/SyncDataSources.js'
 
 export type ManualGroupCacheConfig<LoadedValue> = CommonCacheConfig<
   LoadedValue,
   GroupCache<LoadedValue>,
   InMemoryGroupCacheConfiguration,
-  InMemoryGroupCache<LoadedValue>,
+  SynchronousGroupCache<LoadedValue>,
   GroupNotificationPublisher<LoadedValue>
 >
 

--- a/lib/redis/RedisGroupNotificationConsumer.ts
+++ b/lib/redis/RedisGroupNotificationConsumer.ts
@@ -1,6 +1,6 @@
 import type { RedisLike } from './RedisLike.js'
-import type { InMemoryGroupCache } from '../memory/InMemoryGroupCache.js'
 import { AbstractNotificationConsumer } from '../notifications/AbstractNotificationConsumer.js'
+import type { SynchronousGroupCache } from '../types/SyncDataSources.js'
 import type {
   DeleteFromGroupNotificationCommand,
   DeleteGroupNotificationCommand,
@@ -9,9 +9,11 @@ import type {
 import type { RedisConsumerConfig } from './RedisNotificationConsumer.js'
 import { defaultLogger } from '../util/Logger.js'
 
+// Typed against the interface rather than the concrete InMemoryGroupCache: the target cache handed
+// to a consumer is the owning loader's remote-invalidation facade, not the in-memory cache itself.
 export class RedisGroupNotificationConsumer<LoadedValue> extends AbstractNotificationConsumer<
   LoadedValue,
-  InMemoryGroupCache<LoadedValue>
+  SynchronousGroupCache<LoadedValue>
 > {
   private readonly redis: RedisLike
   private readonly channel: string

--- a/lib/types/BackgroundWork.ts
+++ b/lib/types/BackgroundWork.ts
@@ -1,0 +1,64 @@
+/**
+ * Why the loader started a piece of work it does not await.
+ *
+ * This is a closed set on purpose: hosts branch on it in practice, whatever the documentation says,
+ * so it is treated as part of the public contract rather than as a free-form log string. Adding a
+ * member is a minor version bump; renaming one is a major.
+ *
+ * - `refresh` - a preemptive background refresh (or the staleness probe and TTL bump that may
+ *   replace it), including the expiration-time lookup that decides whether the refresh is due.
+ * - `notification` - a publish to the notification channel, so other nodes learn that an entry was
+ *   invalidated or overwritten here.
+ */
+export type BackgroundWorkReason = 'refresh' | 'notification'
+
+export type BackgroundWorkMeta = {
+  /**
+   * The `cacheId` configured on `inMemoryCache`, if any. Intended for host-side logging, so that
+   * work from several loaders can be told apart.
+   */
+  cacheId: string | undefined
+  reason: BackgroundWorkReason
+}
+
+/**
+ * Hook for work the loader starts and does not await.
+ *
+ * By default such work is simply left to run detached (`void work`), which is correct on Node. It is
+ * not correct on runtimes where I/O is scoped to the request that created it - notably Cloudflare
+ * Workers and other isolate runtimes, where a promise that outlives its request fails with
+ * "Cannot perform I/O on behalf of a different request" unless it was handed to
+ * `ctx.waitUntil()`. Supplying this hook gives the host the promise so it can do exactly that.
+ *
+ * It is also useful on Node: tests can await quiescence instead of sleeping, and a shutdown path
+ * can drain in-flight refreshes before closing connections.
+ *
+ * The promise passed to the hook is guaranteed to settle *fulfilled*: the loader has already routed
+ * any error to the configured `loadErrorHandler` / `cacheUpdateErrorHandler` / publisher error
+ * handler and attached its own handler before handing it over. That guarantee matters, because
+ * `ctx.waitUntil()` on a rejecting promise fails the request that adopted it.
+ *
+ * The hook is supplied once, at construction, but the request context it usually needs is per
+ * request - so it must resolve that context at call time rather than close over one. On an isolate
+ * runtime the loader must be constructed at isolate scope (a loader rebuilt per request is a memo,
+ * not a cache), which means a `ctx` captured at construction belongs to whichever request happened
+ * to build the loader, and using it later reintroduces the very fault this hook exists to avoid.
+ * Read the ambient context instead:
+ *
+ * ```ts
+ * const requestCtx = new AsyncLocalStorage<ExecutionContext>()
+ *
+ * const loader = new Loader({
+ *   inMemoryCache: { ttlInMsecs: 60_000 },
+ *   scheduleBackgroundWork: (work) => {
+ *     const ctx = requestCtx.getStore()
+ *     if (ctx) {
+ *       ctx.waitUntil(work)
+ *     } else {
+ *       void work
+ *     }
+ *   },
+ * })
+ * ```
+ */
+export type BackgroundWorkScheduler = (work: Promise<void>, meta: BackgroundWorkMeta) => void

--- a/test/GroupLoader-async-refresh.spec.ts
+++ b/test/GroupLoader-async-refresh.spec.ts
@@ -327,7 +327,7 @@ describe('GroupLoader Async Refresh', () => {
       expect(loader.counter).toBe(3)
     })
 
-    it('does not crash when async expiration lookup rejects', async () => {
+    it('reports a rejecting async expiration lookup through loadErrorHandler', async () => {
       const asyncCache = new DummyGroupedCache(userValues)
       // Force the fire-and-forget expiration lookup to reject
       ;(asyncCache as any).ttlLeftBeforeRefreshInMsecs = 999999
@@ -335,7 +335,36 @@ describe('GroupLoader Async Refresh', () => {
         get: () => Promise.reject(new Error('expiration lookup failed')),
       }
 
-      const errors: unknown[] = []
+      const reported: { message: string; key: string | undefined; sourceName: string }[] = []
+      const operation = new GroupLoader<User>({
+        asyncCache,
+        loadErrorHandler: (err, key, source) => {
+          reported.push({ message: err.message, key, sourceName: source.name })
+        },
+      })
+
+      expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
+
+      await waitAndRetry(() => reported.length > 0, 5, 20)
+      expect(reported).toEqual([
+        {
+          message: 'expiration lookup failed',
+          key: user1.userId,
+          sourceName: asyncCache.name,
+        },
+      ])
+
+      await asyncCache.close()
+    })
+
+    it('still logs a rejecting async expiration lookup when no handler is configured', async () => {
+      const asyncCache = new DummyGroupedCache(userValues)
+      ;(asyncCache as any).ttlLeftBeforeRefreshInMsecs = 999999
+      ;(asyncCache as any).expirationTimeLoadingGroupedOperation = {
+        get: () => Promise.reject(new Error('expiration lookup failed')),
+      }
+
+      const errors: string[] = []
       const operation = new GroupLoader<User>({
         asyncCache,
         logger: { error: (msg) => errors.push(msg) },
@@ -344,7 +373,7 @@ describe('GroupLoader Async Refresh', () => {
       expect(await operation.get(user1.userId, user1.companyId)).toEqual(user1)
 
       await waitAndRetry(() => errors.length > 0, 5, 20)
-      expect(errors).toContain('expiration lookup failed')
+      expect(errors[0]).toContain('expiration lookup failed')
 
       await asyncCache.close()
     })

--- a/test/Loader-async-refresh.spec.ts
+++ b/test/Loader-async-refresh.spec.ts
@@ -188,14 +188,38 @@ describe('Loader Async', () => {
       expect(loader.counter).toBe(3)
     })
 
-    it('does not crash when async expiration lookup rejects', async () => {
+    it('reports a rejecting async expiration lookup through loadErrorHandler', async () => {
       const asyncCache = new DummyCache('value')
       // Force the fire-and-forget expiration lookup to reject
       ;(asyncCache as any).expirationTimeLoadingOperation = {
         get: () => Promise.reject(new Error('expiration lookup failed')),
       }
 
-      const errors: unknown[] = []
+      const reported: { message: string; key: string | undefined; sourceName: string }[] = []
+      const operation = new Loader<string>({
+        asyncCache,
+        loadErrorHandler: (err, key, source) => {
+          reported.push({ message: err.message, key, sourceName: source.name })
+        },
+      })
+
+      expect(await operation.get('key')).toBe('value')
+
+      await waitAndRetry(() => reported.length > 0, 5, 20)
+      expect(reported).toEqual([
+        { message: 'expiration lookup failed', key: 'key', sourceName: asyncCache.name },
+      ])
+
+      await asyncCache.close()
+    })
+
+    it('still logs a rejecting async expiration lookup when no handler is configured', async () => {
+      const asyncCache = new DummyCache('value')
+      ;(asyncCache as any).expirationTimeLoadingOperation = {
+        get: () => Promise.reject(new Error('expiration lookup failed')),
+      }
+
+      const errors: string[] = []
       const operation = new Loader<string>({
         asyncCache,
         logger: { error: (msg) => errors.push(msg) },
@@ -204,7 +228,7 @@ describe('Loader Async', () => {
       expect(await operation.get('key')).toBe('value')
 
       await waitAndRetry(() => errors.length > 0, 5, 20)
-      expect(errors).toContain('expiration lookup failed')
+      expect(errors[0]).toContain('expiration lookup failed')
 
       await asyncCache.close()
     })

--- a/test/backgroundWork.spec.ts
+++ b/test/backgroundWork.spec.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it } from 'vitest'
+import { GroupLoader } from '../lib/GroupLoader.js'
+import { Loader } from '../lib/Loader.js'
+import type { GroupNotificationPublisher } from '../lib/notifications/GroupNotificationPublisher.js'
+import type { NotificationPublisher } from '../lib/notifications/NotificationPublisher.js'
+import type { BackgroundWorkMeta } from '../lib/types/BackgroundWork.js'
+
+type Scheduled = { work: Promise<void>; meta: BackgroundWorkMeta }
+
+const createRecordingScheduler = () => {
+  const scheduled: Scheduled[] = []
+  return {
+    scheduled,
+    scheduleBackgroundWork: (work: Promise<void>, meta: BackgroundWorkMeta) => {
+      scheduled.push({ work, meta })
+    },
+    /** What a host on an isolate runtime does with ctx.waitUntil: await everything that was handed over. */
+    drain: () => Promise.all(scheduled.map((entry) => entry.work)),
+  }
+}
+
+const failingPublisher: NotificationPublisher<string> = {
+  channel: 'test-channel',
+  errorHandler: () => {},
+  subscribe: async () => {},
+  close: async () => {},
+  set: async () => {
+    throw new Error('publish failed')
+  },
+  delete: async () => {
+    throw new Error('publish failed')
+  },
+  deleteMany: async () => {
+    throw new Error('publish failed')
+  },
+  clear: async () => {
+    throw new Error('publish failed')
+  },
+}
+
+const failingGroupPublisher: GroupNotificationPublisher<string> = {
+  channel: 'test-channel',
+  errorHandler: () => {},
+  subscribe: async () => {},
+  close: async () => {},
+  deleteFromGroup: async () => {
+    throw new Error('publish failed')
+  },
+  deleteGroup: async () => {
+    throw new Error('publish failed')
+  },
+  clear: async () => {
+    throw new Error('publish failed')
+  },
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+describe('scheduleBackgroundWork', () => {
+  it('is optional, and omitting it leaves background work detached as before', async () => {
+    let loads = 0
+    const loader = new Loader<string>({
+      inMemoryCache: { ttlInMsecs: 100, ttlLeftBeforeRefreshInMsecs: 100 },
+      dataSourceGetOneFn: async () => {
+        loads++
+        return 'value'
+      },
+    })
+
+    expect(await loader.get('key')).toBe('value')
+    await sleep(5)
+    expect(await loader.get('key')).toBe('value')
+    await sleep(20)
+
+    expect(loads).toBe(2)
+  })
+
+  it('hands over preemptive in-memory refreshes, so the host can await quiescence', async () => {
+    const scheduler = createRecordingScheduler()
+    let loads = 0
+    const loader = new Loader<string>({
+      inMemoryCache: { ttlInMsecs: 100, ttlLeftBeforeRefreshInMsecs: 100, cacheId: 'users' },
+      scheduleBackgroundWork: scheduler.scheduleBackgroundWork,
+      dataSourceGetOneFn: async () => {
+        loads++
+        return `value-${loads}`
+      },
+    })
+
+    expect(await loader.get('key')).toBe('value-1')
+    await sleep(5)
+    // this read is inside the refresh window, so it schedules a background reload
+    expect(await loader.get('key')).toBe('value-1')
+
+    expect(scheduler.scheduled).toHaveLength(1)
+    expect(scheduler.scheduled[0].meta).toEqual({ cacheId: 'users', reason: 'refresh' })
+
+    await scheduler.drain()
+    expect(loads).toBe(2)
+    expect(loader.getInMemoryOnly('key')).toBe('value-2')
+  })
+
+  it('hands over the staleness probe and its TTL bump', async () => {
+    const scheduler = createRecordingScheduler()
+    let probes = 0
+    const loader = new Loader<string>({
+      inMemoryCache: { ttlInMsecs: 100, ttlLeftBeforeRefreshInMsecs: 100 },
+      scheduleBackgroundWork: scheduler.scheduleBackgroundWork,
+      dataSourceGetOneFn: async () => 'value',
+      isEntryStillCurrentFn: async () => {
+        probes++
+        return true
+      },
+    })
+
+    await loader.get('key')
+    await sleep(5)
+    await loader.get('key')
+
+    expect(scheduler.scheduled).toHaveLength(1)
+    expect(scheduler.scheduled[0].meta.reason).toBe('refresh')
+
+    await scheduler.drain()
+    expect(probes).toBe(1)
+  })
+
+  it('hands over notification publishes', async () => {
+    const scheduler = createRecordingScheduler()
+    const published: string[] = []
+    const loader = new Loader<string>({
+      inMemoryCache: { ttlInMsecs: 60_000 },
+      scheduleBackgroundWork: scheduler.scheduleBackgroundWork,
+      notificationPublisher: {
+        channel: 'test-channel',
+        errorHandler: () => {},
+        subscribe: async () => {},
+        close: async () => {},
+        set: async (key: string) => {
+          published.push(`set:${key}`)
+        },
+        delete: async (key: string) => {
+          published.push(`delete:${key}`)
+        },
+        deleteMany: async (keys: string[]) => {
+          published.push(`deleteMany:${keys.join(',')}`)
+        },
+        clear: async () => {
+          published.push('clear')
+        },
+      },
+      dataSourceGetOneFn: async () => 'value',
+    })
+
+    await loader.invalidateCacheFor('key')
+    await loader.invalidateCacheForMany(['a', 'b'])
+    await loader.invalidateCache()
+    await loader.forceSetValue('key', 'value')
+    await loader.forceRefresh('key')
+
+    expect(scheduler.scheduled).toHaveLength(5)
+    expect(scheduler.scheduled.map((entry) => entry.meta.reason)).toEqual([
+      'notification',
+      'notification',
+      'notification',
+      'notification',
+      'notification',
+    ])
+    expect(scheduler.scheduled[0].meta.cacheId).toBeUndefined()
+
+    await scheduler.drain()
+    expect(published).toEqual(['delete:key', 'deleteMany:a,b', 'clear', 'set:key', 'delete:key'])
+  })
+
+  it('never hands over a rejecting promise', async () => {
+    const scheduler = createRecordingScheduler()
+    const loader = new Loader<string>({
+      inMemoryCache: { ttlInMsecs: 100, ttlLeftBeforeRefreshInMsecs: 100 },
+      scheduleBackgroundWork: scheduler.scheduleBackgroundWork,
+      notificationPublisher: failingPublisher,
+      loadErrorHandler: () => {},
+      dataSourceGetOneFn: async () => {
+        throw new Error('data source is down')
+      },
+    })
+
+    // a failing publish
+    await loader.invalidateCacheFor('key')
+    // a failing background refresh: seed the entry, then read it inside the refresh window
+    await loader.forceSetValue('key', 'value')
+    await sleep(5)
+    await loader.get('key')
+
+    expect(scheduler.scheduled.length).toBeGreaterThanOrEqual(2)
+    // `ctx.waitUntil()` on a rejected promise fails the request that adopted it, so every promise
+    // handed to the host has to settle fulfilled
+    await expect(scheduler.drain()).resolves.toBeDefined()
+  })
+
+  it('works the same way for GroupLoader', async () => {
+    const scheduler = createRecordingScheduler()
+    let loads = 0
+    const loader = new GroupLoader<string>({
+      inMemoryCache: { ttlInMsecs: 100, ttlLeftBeforeRefreshInMsecs: 100, cacheId: 'users' },
+      scheduleBackgroundWork: scheduler.scheduleBackgroundWork,
+      dataSources: [
+        {
+          name: 'test',
+          getFromGroup: async () => {
+            loads++
+            return `value-${loads}`
+          },
+          getManyFromGroup: async () => [],
+        },
+      ],
+    })
+
+    expect(await loader.get('key', 'group')).toBe('value-1')
+    await sleep(5)
+    expect(await loader.get('key', 'group')).toBe('value-1')
+
+    expect(scheduler.scheduled).toHaveLength(1)
+    expect(scheduler.scheduled[0].meta).toEqual({ cacheId: 'users', reason: 'refresh' })
+
+    await scheduler.drain()
+    expect(loads).toBe(2)
+  })
+
+  it('hands over the staleness probe and notification publishes for GroupLoader', async () => {
+    const scheduler = createRecordingScheduler()
+    let probes = 0
+    const loader = new GroupLoader<string>({
+      inMemoryCache: { ttlInMsecs: 100, ttlLeftBeforeRefreshInMsecs: 100 },
+      scheduleBackgroundWork: scheduler.scheduleBackgroundWork,
+      notificationPublisher: failingGroupPublisher,
+      dataSources: [
+        {
+          name: 'test',
+          getFromGroup: async () => 'value',
+          getManyFromGroup: async () => [],
+        },
+      ],
+      isEntryStillCurrentFn: async () => {
+        probes++
+        return true
+      },
+    })
+
+    await loader.get('key', 'group')
+    await sleep(5)
+    await loader.get('key', 'group')
+    await loader.invalidateCacheFor('key', 'group')
+    await loader.invalidateCacheForGroup('group')
+
+    expect(scheduler.scheduled.map((entry) => entry.meta.reason)).toEqual([
+      'refresh',
+      'notification',
+      'notification',
+    ])
+
+    await expect(scheduler.drain()).resolves.toBeDefined()
+    expect(probes).toBe(1)
+  })
+})

--- a/test/backgroundWork.spec.ts
+++ b/test/backgroundWork.spec.ts
@@ -4,6 +4,7 @@ import { Loader } from '../lib/Loader.js'
 import type { GroupNotificationPublisher } from '../lib/notifications/GroupNotificationPublisher.js'
 import type { NotificationPublisher } from '../lib/notifications/NotificationPublisher.js'
 import type { BackgroundWorkMeta } from '../lib/types/BackgroundWork.js'
+import type { Cache, GroupCache } from '../lib/types/DataSources.js'
 
 type Scheduled = { work: Promise<void>; meta: BackgroundWorkMeta }
 
@@ -55,6 +56,47 @@ const failingGroupPublisher: GroupNotificationPublisher<string> = {
 }
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const EXPIRATION_LOOKUP_ERROR = new Error('expiration lookup failed')
+
+const notImplemented = () => {
+  throw new Error('Not implemented')
+}
+
+/** An async cache tier that always fails the expiration lookup the preemptive refresh starts with. */
+const failingExpirationLookupCache: Cache<string> = {
+  name: 'failing-expiration-lookup-cache',
+  ttlLeftBeforeRefreshInMsecs: 60_000,
+  expirationTimeLoadingOperation: {
+    get: () => Promise.reject(EXPIRATION_LOOKUP_ERROR),
+  } as unknown as Cache<string>['expirationTimeLoadingOperation'],
+  get: async () => 'cached-value',
+  set: async () => {},
+  delete: async () => {},
+  deleteMany: async () => {},
+  clear: async () => {},
+  close: async () => {},
+  getExpirationTime: async () => Date.now() + 1,
+  getMany: notImplemented,
+  setMany: notImplemented,
+}
+
+const failingExpirationLookupGroupCache: GroupCache<string> = {
+  name: 'failing-expiration-lookup-group-cache',
+  ttlLeftBeforeRefreshInMsecs: 60_000,
+  expirationTimeLoadingGroupedOperation: {
+    get: () => Promise.reject(EXPIRATION_LOOKUP_ERROR),
+  } as unknown as GroupCache<string>['expirationTimeLoadingGroupedOperation'],
+  getFromGroup: async () => 'cached-value',
+  setForGroup: async () => {},
+  deleteFromGroup: async () => {},
+  deleteGroup: async () => {},
+  clear: async () => {},
+  close: async () => {},
+  getExpirationTimeFromGroup: async () => Date.now() + 1,
+  getManyFromGroup: notImplemented,
+  setManyForGroup: notImplemented,
+}
 
 describe('scheduleBackgroundWork', () => {
   it('is optional, and omitting it leaves background work detached as before', async () => {
@@ -194,6 +236,62 @@ describe('scheduleBackgroundWork', () => {
     // `ctx.waitUntil()` on a rejected promise fails the request that adopted it, so every promise
     // handed to the host has to settle fulfilled
     await expect(scheduler.drain()).resolves.toBeDefined()
+  })
+
+  it('reports a failed expiration lookup through loadErrorHandler', async () => {
+    const scheduler = createRecordingScheduler()
+    const reported: { err: Error; key: string | undefined; sourceName: string }[] = []
+    const loader = new Loader<string>({
+      inMemoryCache: false,
+      asyncCache: failingExpirationLookupCache,
+      scheduleBackgroundWork: scheduler.scheduleBackgroundWork,
+      loadErrorHandler: (err, key, source) => {
+        reported.push({ err, key, sourceName: source.name })
+      },
+      dataSourceGetOneFn: async () => 'value',
+    })
+
+    expect(await loader.get('key')).toBe('cached-value')
+    await expect(scheduler.drain()).resolves.toBeDefined()
+
+    expect(reported).toEqual([
+      {
+        err: EXPIRATION_LOOKUP_ERROR,
+        key: 'key',
+        sourceName: 'failing-expiration-lookup-cache',
+      },
+    ])
+  })
+
+  it('reports a failed grouped expiration lookup through loadErrorHandler', async () => {
+    const scheduler = createRecordingScheduler()
+    const reported: { err: Error; key: string | undefined; sourceName: string }[] = []
+    const loader = new GroupLoader<string>({
+      inMemoryCache: false,
+      asyncCache: failingExpirationLookupGroupCache,
+      scheduleBackgroundWork: scheduler.scheduleBackgroundWork,
+      loadErrorHandler: (err, key, source) => {
+        reported.push({ err, key, sourceName: source.name })
+      },
+      dataSources: [
+        {
+          name: 'test',
+          getFromGroup: async () => 'value',
+          getManyFromGroup: async () => [],
+        },
+      ],
+    })
+
+    expect(await loader.get('key', 'group')).toBe('cached-value')
+    await expect(scheduler.drain()).resolves.toBeDefined()
+
+    expect(reported).toEqual([
+      {
+        err: EXPIRATION_LOOKUP_ERROR,
+        key: 'key',
+        sourceName: 'failing-expiration-lookup-group-cache',
+      },
+    ])
   })
 
   it('works the same way for GroupLoader', async () => {

--- a/test/remoteInvalidation.spec.ts
+++ b/test/remoteInvalidation.spec.ts
@@ -2,7 +2,12 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { GroupLoader } from '../lib/GroupLoader.js'
 import { Loader } from '../lib/Loader.js'
 import { AbstractNotificationConsumer } from '../lib/notifications/AbstractNotificationConsumer.js'
-import type { SynchronousCache, SynchronousGroupCache } from '../lib/types/SyncDataSources.js'
+import type { Cache, CacheEntry, GroupCache } from '../lib/types/DataSources.js'
+import type {
+  GetManyResult,
+  SynchronousCache,
+  SynchronousGroupCache,
+} from '../lib/types/SyncDataSources.js'
 
 /**
  * Stands in for a real notification consumer (Redis pub/sub, SQS): it applies commands that arrived
@@ -31,6 +36,152 @@ class FakeGroupConsumer extends AbstractNotificationConsumer<
 }
 
 const flushMicrotasks = () => new Promise((resolve) => setImmediate(resolve))
+
+/**
+ * An async cache tier whose entries are permanently inside their preemptive refresh window, so any
+ * read of an existing entry schedules the async-tier background refresh. That refresh reloads
+ * straight from the data sources instead of going through the fenced getAsyncOnlyResolved path,
+ * which is why it needs a background write fence of its own.
+ */
+class AlwaysRefreshingCache implements Cache<string> {
+  name = 'always-refreshing-cache'
+  readonly ttlLeftBeforeRefreshInMsecs = 60_000
+  public readonly storage = new Map<string, string | null>()
+
+  readonly expirationTimeLoadingOperation = {
+    get: () => Promise.resolve(Date.now() + 1),
+  } as unknown as Cache<string>['expirationTimeLoadingOperation']
+
+  get(key: string): Promise<string | undefined | null> {
+    return Promise.resolve(this.storage.get(key))
+  }
+
+  set(key: string, value: string | null): Promise<void> {
+    this.storage.set(key, value)
+    return Promise.resolve()
+  }
+
+  delete(key: string): Promise<void> {
+    this.storage.delete(key)
+    return Promise.resolve()
+  }
+
+  deleteMany(keys: string[]): Promise<void> {
+    for (const key of keys) {
+      this.storage.delete(key)
+    }
+    return Promise.resolve()
+  }
+
+  clear(): Promise<void> {
+    this.storage.clear()
+    return Promise.resolve()
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve()
+  }
+
+  getExpirationTime(): Promise<number> {
+    return Promise.resolve(Date.now() + 1)
+  }
+
+  getMany(): Promise<GetManyResult<string>> {
+    throw new Error('Not implemented')
+  }
+
+  setMany(_entries: readonly CacheEntry<string>[]): Promise<void> {
+    throw new Error('Not implemented')
+  }
+}
+
+/** Grouped counterpart of {@link AlwaysRefreshingCache}. */
+class AlwaysRefreshingGroupCache implements GroupCache<string> {
+  name = 'always-refreshing-group-cache'
+  readonly ttlLeftBeforeRefreshInMsecs = 60_000
+  public readonly storage = new Map<string, Map<string, string | null>>()
+
+  readonly expirationTimeLoadingGroupedOperation = {
+    get: () => Promise.resolve(Date.now() + 1),
+  } as unknown as GroupCache<string>['expirationTimeLoadingGroupedOperation']
+
+  private resolveGroup(group: string) {
+    let groupStorage = this.storage.get(group)
+    if (!groupStorage) {
+      groupStorage = new Map()
+      this.storage.set(group, groupStorage)
+    }
+    return groupStorage
+  }
+
+  getFromGroup(key: string, group: string): Promise<string | undefined | null> {
+    return Promise.resolve(this.storage.get(group)?.get(key))
+  }
+
+  setForGroup(key: string, value: string | null, group: string): Promise<void> {
+    this.resolveGroup(group).set(key, value)
+    return Promise.resolve()
+  }
+
+  deleteFromGroup(key: string, group: string): Promise<void> {
+    this.storage.get(group)?.delete(key)
+    return Promise.resolve()
+  }
+
+  deleteGroup(group: string): Promise<void> {
+    this.storage.delete(group)
+    return Promise.resolve()
+  }
+
+  clear(): Promise<void> {
+    this.storage.clear()
+    return Promise.resolve()
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve()
+  }
+
+  getExpirationTimeFromGroup(): Promise<number> {
+    return Promise.resolve(Date.now() + 1)
+  }
+
+  getManyFromGroup(): Promise<GetManyResult<string>> {
+    throw new Error('Not implemented')
+  }
+
+  setManyForGroup(_entries: readonly CacheEntry<string>[], _group: string): Promise<void> {
+    throw new Error('Not implemented')
+  }
+}
+
+/**
+ * A data source whose loads can be released one at a time, so a background refresh can be held open
+ * while an invalidation arrives.
+ */
+const createHeldDataSource = () => {
+  const releases: ((value: string) => void)[] = []
+  let signalStarted!: () => void
+  const started = new Promise<void>((resolve) => {
+    signalStarted = resolve
+  })
+  return {
+    load: () => {
+      const loadingPromise = new Promise<string>((resolve) => {
+        releases.push(resolve)
+      })
+      signalStarted()
+      return loadingPromise
+    },
+    /** Resolves once the first load has started. */
+    started,
+    release: (value: string) => {
+      for (const resolve of releases.splice(0)) {
+        resolve(value)
+      }
+    },
+  }
+}
 
 describe('applying invalidations that originated elsewhere', () => {
   describe('Loader', () => {
@@ -173,6 +324,83 @@ describe('applying invalidations that originated elsewhere', () => {
       target.clear()
       expect(target.get('key')).toBeUndefined()
     })
+
+    describe('async-tier background refresh', () => {
+      let asyncCache: AlwaysRefreshingCache
+      let dataSource: ReturnType<typeof createHeldDataSource>
+      let refreshingLoader: Loader<string>
+
+      beforeEach(() => {
+        asyncCache = new AlwaysRefreshingCache()
+        asyncCache.storage.set('key', 'stale-value')
+        dataSource = createHeldDataSource()
+        refreshingLoader = new Loader<string>({
+          inMemoryCache: { ttlInMsecs: 60_000 },
+          asyncCache,
+          dataSourceGetOneFn: dataSource.load,
+        })
+      })
+
+      it('writes the reloaded value into the in-memory tier when nothing invalidated it', async () => {
+        expect(await refreshingLoader.get('key')).toBe('stale-value')
+        await dataSource.started
+        dataSource.release('fresh-value')
+        await flushMicrotasks()
+
+        expect(refreshingLoader.getInMemoryOnly('key')).toBe('fresh-value')
+      })
+
+      it('is fenced by a remote invalidation, so the pre-invalidation reload is not written back', async () => {
+        expect(await refreshingLoader.get('key')).toBe('stale-value')
+        await dataSource.started
+        // the invalidation arrives from another node while the background refresh is still loading
+        refreshingLoader.applyRemoteInvalidationFor('key')
+        dataSource.release('value-loaded-before-the-invalidation')
+        await flushMicrotasks()
+
+        expect(refreshingLoader.getInMemoryOnly('key')).toBeUndefined()
+      })
+
+      it('is fenced by a batch remote invalidation', async () => {
+        expect(await refreshingLoader.get('key')).toBe('stale-value')
+        await dataSource.started
+        refreshingLoader.applyRemoteInvalidationForMany(['key', 'other-key'])
+        dataSource.release('value-loaded-before-the-invalidation')
+        await flushMicrotasks()
+
+        expect(refreshingLoader.getInMemoryOnly('key')).toBeUndefined()
+      })
+
+      it('is fenced by a remote value application, so the newer value is not clobbered', async () => {
+        expect(await refreshingLoader.get('key')).toBe('stale-value')
+        await dataSource.started
+        refreshingLoader.applyRemoteValue('key', 'value-from-another-node')
+        dataSource.release('value-loaded-before-the-invalidation')
+        await flushMicrotasks()
+
+        expect(refreshingLoader.getInMemoryOnly('key')).toBe('value-from-another-node')
+      })
+
+      it('is fenced by a remote cache-wide clear', async () => {
+        expect(await refreshingLoader.get('key')).toBe('stale-value')
+        await dataSource.started
+        refreshingLoader.applyRemoteInvalidation()
+        dataSource.release('value-loaded-before-the-invalidation')
+        await flushMicrotasks()
+
+        expect(refreshingLoader.getInMemoryOnly('key')).toBeUndefined()
+      })
+
+      it('is fenced by a locally originated invalidation too', async () => {
+        expect(await refreshingLoader.get('key')).toBe('stale-value')
+        await dataSource.started
+        await refreshingLoader.invalidateCacheFor('key')
+        dataSource.release('value-loaded-before-the-invalidation')
+        await flushMicrotasks()
+
+        expect(refreshingLoader.getInMemoryOnly('key')).toBeUndefined()
+      })
+    })
   })
 
   describe('GroupLoader', () => {
@@ -288,6 +516,104 @@ describe('applying invalidations that originated elsewhere', () => {
       target.setForGroup('key', 'again', 'group')
       target.clear()
       expect(target.getFromGroup('key', 'group')).toBeUndefined()
+    })
+
+    describe('async-tier background refresh', () => {
+      let asyncCache: AlwaysRefreshingGroupCache
+      let dataSource: ReturnType<typeof createHeldDataSource>
+      let refreshingLoader: GroupLoader<string>
+
+      beforeEach(() => {
+        asyncCache = new AlwaysRefreshingGroupCache()
+        dataSource = createHeldDataSource()
+        refreshingLoader = new GroupLoader<string>({
+          inMemoryCache: { ttlInMsecs: 60_000 },
+          asyncCache,
+          dataSources: [
+            {
+              name: 'test',
+              getFromGroup: dataSource.load,
+              getManyFromGroup: async () => [],
+            },
+          ],
+        })
+      })
+
+      const seed = async (group: string) => {
+        await asyncCache.setForGroup('key', 'stale-value', group)
+      }
+
+      it('writes the reloaded value into the in-memory tier when nothing invalidated it', async () => {
+        await seed('group')
+        expect(await refreshingLoader.get('key', 'group')).toBe('stale-value')
+        await dataSource.started
+        dataSource.release('fresh-value')
+        await flushMicrotasks()
+
+        expect(refreshingLoader.getInMemoryOnly('key', 'group')).toBe('fresh-value')
+      })
+
+      it('is fenced by a remote entry invalidation', async () => {
+        await seed('group')
+        expect(await refreshingLoader.get('key', 'group')).toBe('stale-value')
+        await dataSource.started
+        refreshingLoader.applyRemoteInvalidationFor('key', 'group')
+        dataSource.release('value-loaded-before-the-invalidation')
+        await flushMicrotasks()
+
+        expect(refreshingLoader.getInMemoryOnly('key', 'group')).toBeUndefined()
+      })
+
+      it('is fenced by a remote group invalidation, and only for that group', async () => {
+        await seed('group')
+        await seed('other-group')
+        expect(await refreshingLoader.get('key', 'group')).toBe('stale-value')
+        expect(await refreshingLoader.get('key', 'other-group')).toBe('stale-value')
+        await dataSource.started
+
+        refreshingLoader.applyRemoteInvalidationForGroup('group')
+        dataSource.release('value-loaded-before-the-invalidation')
+        await flushMicrotasks()
+
+        expect(refreshingLoader.getInMemoryOnly('key', 'group')).toBeUndefined()
+        // the untouched group's refresh was never fenced, so it wrote its result as usual
+        expect(refreshingLoader.getInMemoryOnly('key', 'other-group')).toBe(
+          'value-loaded-before-the-invalidation',
+        )
+      })
+
+      it('is fenced by a remote value application, so the newer value is not clobbered', async () => {
+        await seed('group')
+        expect(await refreshingLoader.get('key', 'group')).toBe('stale-value')
+        await dataSource.started
+        refreshingLoader.applyRemoteValue('key', 'value-from-another-node', 'group')
+        dataSource.release('value-loaded-before-the-invalidation')
+        await flushMicrotasks()
+
+        expect(refreshingLoader.getInMemoryOnly('key', 'group')).toBe('value-from-another-node')
+      })
+
+      it('is fenced by a remote cache-wide clear', async () => {
+        await seed('group')
+        expect(await refreshingLoader.get('key', 'group')).toBe('stale-value')
+        await dataSource.started
+        refreshingLoader.applyRemoteInvalidation()
+        dataSource.release('value-loaded-before-the-invalidation')
+        await flushMicrotasks()
+
+        expect(refreshingLoader.getInMemoryOnly('key', 'group')).toBeUndefined()
+      })
+
+      it('is fenced by a locally originated group invalidation too', async () => {
+        await seed('group')
+        expect(await refreshingLoader.get('key', 'group')).toBe('stale-value')
+        await dataSource.started
+        await refreshingLoader.invalidateCacheForGroup('group')
+        dataSource.release('value-loaded-before-the-invalidation')
+        await flushMicrotasks()
+
+        expect(refreshingLoader.getInMemoryOnly('key', 'group')).toBeUndefined()
+      })
     })
   })
 })

--- a/test/remoteInvalidation.spec.ts
+++ b/test/remoteInvalidation.spec.ts
@@ -1,0 +1,293 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { GroupLoader } from '../lib/GroupLoader.js'
+import { Loader } from '../lib/Loader.js'
+import { AbstractNotificationConsumer } from '../lib/notifications/AbstractNotificationConsumer.js'
+import type { SynchronousCache, SynchronousGroupCache } from '../lib/types/SyncDataSources.js'
+
+/**
+ * Stands in for a real notification consumer (Redis pub/sub, SQS): it applies commands that arrived
+ * from another node by calling the target cache it was handed, which is exactly what
+ * RedisNotificationConsumer and SqsNotificationConsumer do.
+ */
+class FakeConsumer extends AbstractNotificationConsumer<string, SynchronousCache<string>> {
+  async subscribe() {}
+  async close() {}
+
+  get target(): SynchronousCache<string> {
+    return this.targetCache
+  }
+}
+
+class FakeGroupConsumer extends AbstractNotificationConsumer<
+  string,
+  SynchronousGroupCache<string>
+> {
+  async subscribe() {}
+  async close() {}
+
+  get target(): SynchronousGroupCache<string> {
+    return this.targetCache
+  }
+}
+
+const flushMicrotasks = () => new Promise((resolve) => setImmediate(resolve))
+
+describe('applying invalidations that originated elsewhere', () => {
+  describe('Loader', () => {
+    let releaseLoad: (value: string) => void
+    let loadsStarted: number
+    let loader: Loader<string>
+    let consumer: FakeConsumer
+
+    beforeEach(() => {
+      loadsStarted = 0
+      consumer = new FakeConsumer('server-uuid')
+      loader = new Loader<string>({
+        inMemoryCache: { ttlInMsecs: 60_000, cacheId: 'test-cache' },
+        notificationConsumer: consumer,
+        dataSourceGetOneFn: () => {
+          loadsStarted++
+          return new Promise<string>((resolve) => {
+            releaseLoad = resolve
+          })
+        },
+      })
+    })
+
+    it('fences an in-flight load, so the pre-invalidation snapshot is not written back', async () => {
+      const inFlight = loader.get('key')
+      await flushMicrotasks()
+      // the invalidation arrives from another node while the load is still running
+      loader.applyRemoteInvalidationFor('key')
+      releaseLoad('value-from-before-the-invalidation')
+
+      // the caller that was already waiting still gets its value, as it does for a local invalidation
+      expect(await inFlight).toBe('value-from-before-the-invalidation')
+      await flushMicrotasks()
+
+      expect(loader.getInMemoryOnly('key')).toBeUndefined()
+      expect(loadsStarted).toBe(1)
+    })
+
+    it('fences an in-flight load when the invalidation arrives through a notification consumer', async () => {
+      const inFlight = loader.get('key')
+      await flushMicrotasks()
+      consumer.target.delete('key')
+      releaseLoad('value-from-before-the-invalidation')
+      await inFlight
+      await flushMicrotasks()
+
+      expect(loader.getInMemoryOnly('key')).toBeUndefined()
+    })
+
+    it('applies a batch invalidation', async () => {
+      const inFlight = loader.get('key')
+      await flushMicrotasks()
+      loader.applyRemoteInvalidationForMany(['key', 'other-key'])
+      releaseLoad('value')
+      await inFlight
+      await flushMicrotasks()
+
+      expect(loader.getInMemoryOnly('key')).toBeUndefined()
+    })
+
+    it('applies a cache-wide clear', async () => {
+      const inFlight = loader.get('key')
+      await flushMicrotasks()
+      loader.applyRemoteInvalidation()
+      releaseLoad('value')
+      await inFlight
+      await flushMicrotasks()
+
+      expect(loader.getInMemoryOnly('key')).toBeUndefined()
+    })
+
+    it('applies a value set elsewhere, and an older in-flight load does not clobber it', async () => {
+      const inFlight = loader.get('key')
+      await flushMicrotasks()
+      loader.applyRemoteValue('key', 'value-from-another-node')
+      releaseLoad('older-value')
+      await inFlight
+      await flushMicrotasks()
+
+      expect(loader.getInMemoryOnly('key')).toBe('value-from-another-node')
+    })
+
+    it('publishes nothing, so an applied invalidation is not echoed back onto the bus', async () => {
+      const published: string[] = []
+      const echoingLoader = new Loader<string>({
+        inMemoryCache: { ttlInMsecs: 60_000 },
+        notificationPublisher: {
+          channel: 'test-channel',
+          errorHandler: () => {},
+          subscribe: async () => {},
+          close: async () => {},
+          set: async () => {},
+          delete: async (key: string) => {
+            published.push(key)
+          },
+          deleteMany: async () => {},
+          clear: async () => {},
+        },
+        dataSourceGetOneFn: async () => 'value',
+      })
+
+      await echoingLoader.get('key')
+      echoingLoader.applyRemoteInvalidationFor('key')
+      await flushMicrotasks()
+      expect(published).toEqual([])
+
+      // ... whereas originating an invalidation locally does publish
+      await echoingLoader.invalidateCacheFor('key')
+      await flushMicrotasks()
+      expect(published).toEqual(['key'])
+    })
+
+    it('exposes the in-memory reads unchanged through the consumer target', async () => {
+      releaseLoad = () => {}
+      const readLoader = new Loader<string>({
+        inMemoryCache: { ttlInMsecs: 60_000, ttlLeftBeforeRefreshInMsecs: 100 },
+        notificationConsumer: new FakeConsumer('server-uuid'),
+        dataSourceGetOneFn: async () => 'value',
+      })
+      const target = (readLoader as unknown as { notificationConsumer: FakeConsumer })
+        .notificationConsumer.target
+
+      await readLoader.get('key')
+
+      expect(target.ttlLeftBeforeRefreshInMsecs).toBe(100)
+      expect(target.get('key')).toBe('value')
+      expect(target.getMany(['key', 'missing'])).toEqual({
+        resolvedValues: ['value'],
+        unresolvedKeys: ['missing'],
+      })
+      expect(target.getExpirationTime('key')).toBeGreaterThan(Date.now())
+      expect(target.resetTtl('key')).toBe(true)
+      expect(target.resetTtl('missing')).toBe(false)
+
+      target.set('key', 'replaced')
+      expect(target.get('key')).toBe('replaced')
+      target.deleteMany(['key'])
+      expect(target.get('key')).toBeUndefined()
+      target.set('key', 'again')
+      target.clear()
+      expect(target.get('key')).toBeUndefined()
+    })
+  })
+
+  describe('GroupLoader', () => {
+    let releaseLoad: (value: string) => void
+    let loader: GroupLoader<string>
+    let consumer: FakeGroupConsumer
+
+    beforeEach(() => {
+      consumer = new FakeGroupConsumer('server-uuid')
+      loader = new GroupLoader<string>({
+        inMemoryCache: { ttlInMsecs: 60_000 },
+        notificationConsumer: consumer,
+        dataSources: [
+          {
+            name: 'test',
+            getFromGroup: () =>
+              new Promise<string>((resolve) => {
+                releaseLoad = resolve
+              }),
+            getManyFromGroup: async () => [],
+          },
+        ],
+      })
+    })
+
+    it('fences an in-flight load, so the pre-invalidation snapshot is not written back', async () => {
+      const inFlight = loader.get('key', 'group')
+      await flushMicrotasks()
+      loader.applyRemoteInvalidationFor('key', 'group')
+      releaseLoad('value-from-before-the-invalidation')
+
+      expect(await inFlight).toBe('value-from-before-the-invalidation')
+      await flushMicrotasks()
+
+      expect(loader.getInMemoryOnly('key', 'group')).toBeUndefined()
+    })
+
+    it('fences an in-flight load when the invalidation arrives through a notification consumer', async () => {
+      const inFlight = loader.get('key', 'group')
+      await flushMicrotasks()
+      consumer.target.deleteFromGroup('key', 'group')
+      releaseLoad('value')
+      await inFlight
+      await flushMicrotasks()
+
+      expect(loader.getInMemoryOnly('key', 'group')).toBeUndefined()
+    })
+
+    it('applies a group-wide invalidation', async () => {
+      const inFlight = loader.get('key', 'group')
+      await flushMicrotasks()
+      loader.applyRemoteInvalidationForGroup('group')
+      releaseLoad('value')
+      await inFlight
+      await flushMicrotasks()
+
+      expect(loader.getInMemoryOnly('key', 'group')).toBeUndefined()
+    })
+
+    it('applies a cache-wide clear', async () => {
+      const inFlight = loader.get('key', 'group')
+      await flushMicrotasks()
+      loader.applyRemoteInvalidation()
+      releaseLoad('value')
+      await inFlight
+      await flushMicrotasks()
+
+      expect(loader.getInMemoryOnly('key', 'group')).toBeUndefined()
+    })
+
+    it('applies a value set elsewhere, and an older in-flight load does not clobber it', async () => {
+      const inFlight = loader.get('key', 'group')
+      await flushMicrotasks()
+      loader.applyRemoteValue('key', 'value-from-another-node', 'group')
+      releaseLoad('older-value')
+      await inFlight
+      await flushMicrotasks()
+
+      expect(loader.getInMemoryOnly('key', 'group')).toBe('value-from-another-node')
+    })
+
+    it('exposes the in-memory reads unchanged through the consumer target', async () => {
+      const readConsumer = new FakeGroupConsumer('server-uuid')
+      const readLoader = new GroupLoader<string>({
+        inMemoryCache: { ttlInMsecs: 60_000, ttlLeftBeforeRefreshInMsecs: 100 },
+        notificationConsumer: readConsumer,
+        dataSources: [
+          {
+            name: 'test',
+            getFromGroup: async () => 'value',
+            getManyFromGroup: async () => [],
+          },
+        ],
+      })
+      const target = readConsumer.target
+
+      await readLoader.get('key', 'group')
+
+      expect(target.ttlLeftBeforeRefreshInMsecs).toBe(100)
+      expect(target.getFromGroup('key', 'group')).toBe('value')
+      expect(target.getManyFromGroup(['key', 'missing'], 'group')).toEqual({
+        resolvedValues: ['value'],
+        unresolvedKeys: ['missing'],
+      })
+      expect(target.getExpirationTimeFromGroup('key', 'group')).toBeGreaterThan(Date.now())
+      expect(target.resetTtlFromGroup('key', 'group')).toBe(true)
+      expect(target.resetTtlFromGroup('missing', 'group')).toBe(false)
+
+      target.setForGroup('key', 'replaced', 'group')
+      expect(target.getFromGroup('key', 'group')).toBe('replaced')
+      target.deleteGroup('group')
+      expect(target.getFromGroup('key', 'group')).toBeUndefined()
+      target.setForGroup('key', 'again', 'group')
+      target.clear()
+      expect(target.getFromGroup('key', 'group')).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
Response to a downstream proposal asking for support for caching on isolate runtimes (Cloudflare Workers and similar) with no invalidation bus. The proposal made three asks; this PR implements two of them, in a different shape than requested, and deliberately does not implement the third. Reasoning and the direct answers to the proposal's open questions are below.

Everything here is additive and opt-in. A caller passing none of the new options gets today's behaviour unchanged.

## What changed

### 1. Applying an invalidation is now a distinct operation from originating one

The proposal asked whether calling `invalidateCacheFor` from outside the notification machinery is a supported way to apply a remote invalidation. It is not, and documenting it as one would have enshrined a bug. The library had two half-correct paths and no correct one:

- `invalidateCacheFor` **re-publishes** (`AbstractFlatCache.ts`). Applying a received invalidation through it rebroadcasts it — harmless with no publisher configured, an echo loop with one.
- Notification consumers applied commands straight to the in-memory cache via `targetCache.delete(key)`, which does **not** fence `runningLoads`. A load that started before the invalidation arrived still satisfied the `runningLoads.get(key) === loadingPromise` guard when it resolved, and wrote its pre-invalidation snapshot back.

That second one is a live bug for every Redis user with a notification pair, independent of edge runtimes, and it bites exactly when invalidations matter — when one races a load. Measured before the fix:

| path | in-memory contents after the invalidation |
| --- | --- |
| consumer `targetCache.delete` | `"stale-value"` |
| public `invalidateCacheFor` | `undefined` |

New methods, synchronous so a pull-based transport can call them at request start without awaiting:

- flat: `applyRemoteInvalidationFor(key)`, `applyRemoteInvalidationForMany(keys)`, `applyRemoteValue(key, value)`, `applyRemoteInvalidation()`
- group: `applyRemoteInvalidationFor(key, group)`, `applyRemoteInvalidationForGroup(group)`, `applyRemoteValue(key, value, group)`, `applyRemoteInvalidation()`

They fence running loads, touch neither the shared async tier (the origin already deleted from it) nor the publisher (the origin already broadcast).

`AbstractCache` now hands notification consumers a facade over the owning cache instead of the in-memory cache itself, so **every existing consumer gets the fencing with no code change** — including the four in `@layered-loader/sqs`, which type-check and pass unmodified against this branch.

No new transport abstraction was added. The proposal offered to use a `consumer.drain()` if we would rather own one; the host owns the cursor and the transport, so a method on the cache is the whole surface required.

### 2. `scheduleBackgroundWork`

Optional hook receiving every fire-and-forget promise — preemptive refreshes, staleness probes, notification publishes — with `{ cacheId, reason }`. Default is today's behaviour, byte for byte.

Two things were fixed relative to the proposed shape:

- **The promise is guaranteed to settle fulfilled.** `ctx.waitUntil()` on a rejecting promise fails the request that adopted it, and several of these promises do reject even though nothing currently goes unhandled. Handing raw promises over would have turned a data-source blip into failed requests.
- **The promise covers the whole operation.** Where a background chain kicked off further work (the expiration lookup that decides whether a refresh is due, then the refresh itself), the inner chain was detached, so a host would have adopted only the lookup and the actual refresh I/O would still have escaped. Those are now `return`ed. Nothing awaits these chains, so this changes no timing.

`BackgroundWorkReason` is a closed union (`'refresh' | 'notification'`) rather than a free string, because hosts branch on it whatever the docs say.

The proposal's worked example — `scheduleBackgroundWork: (work) => ctx.waitUntil(work)` — is wrong in a way that matters, and the README documents the correct pattern instead. The hook is constructor-scoped; `ctx` is request-scoped; and an isolate deployment must hoist the loader to isolate scope for it to be a cache at all. A `ctx` captured at construction therefore belongs to whichever request happened to build the loader, and using it later reintroduces the exact "Cannot perform I/O on behalf of a different request" fault the hook exists to prevent. The hook must resolve the ambient context at call time (`AsyncLocalStorage`, supported on workerd).

### 3. Documentation

- **Applying invalidations from your own transport** — the originate-vs-apply table and the pull-transport pattern.
- **Background work** — the hook, the fulfilled-promise guarantee, and the Node uses (test quiescence, shutdown drain).
- **Isolate runtimes with no invalidation bus** — the full deployment shape: hoist to isolate scope, pull invalidations, adopt background work, validate on every read, and what the library deliberately does not do.
- Clarifications folded into the existing staleness-check and preemptive-refresh sections.
- `CLAUDE.md` records the originate-vs-apply invariant and the two background-work invariants, so neither gets "simplified" away later.

## What was deliberately not implemented

**Blocking (`must-revalidate`) validation.** The proposal called this the load-bearing ask. It is not included, for three reasons:

1. **Half the proposed API already exists.** `{ when: 'every-hit' }` is reachable today by setting `ttlLeftBeforeRefreshInMsecs` equal to `ttlInMsecs`, which keeps every entry permanently inside the refresh window. Measured: 5 sequential hits produce 5 probes. Only `mode: 'blocking'` is genuinely absent, so the proposed 2×2 is one axis, of which two combinations the proposal itself would accept being rejected at construction.

2. **The guarantee collides with three public methods the proposal does not mention.** "No hit is served without the probe having answered" is falsified by `getInMemoryOnly` (synchronous, cannot await without a breaking signature change), `getManyInMemoryOnly`, and `getMany`'s all-hit fast path, which never enters the refresh path at all. The three ways out each cost something real — throw at call time, document them as bypasses (making the guarantee quietly false for batch reads), or probe per key in `getMany` (uncoalesced, so a 50-key batch becomes 50 round trips to the version store). None is obviously right, which is a signal about the primitive rather than about effort.

3. **The dominant use case is better served by something the proposal says it can already build.** Ask 1 conflates two mechanisms: a per-entry version token (a document version, a branch head sha — where `isEntryStillCurrentFn` is the right shape) and a per-scope generation counter (where it is the wrong shape, fanning O(1) information into O(keys) probes). The 14 caches the proposal wants to re-enable are the second kind, and for those a generation counter plus `invalidateCacheForGroup` at request start — listed in the proposal's own "what we can already do" section — is informationally identical and cheaper. That path should be built and measured before anything blocking is added upstream.

Worth restating: `must-revalidate` would not deliver the property it was justified by. It does not make a stale decision impossible; it bounds the staleness window by probe-to-serve latency instead of by `ttlInMsecs`, with the read ordered after the last committed generation bump. That is a real strengthening and a good pitch — it is just not "never stale", and a feature should not land on a premise it does not satisfy.

If the generation-counter path is built and leaves a real residual, a single `revalidate: 'blocking'` option is worth revisiting — with the `getMany` / `getInMemoryOnly` hole resolved explicitly in the API, and with `onProbeError: 'load' | 'throw'` included, since the proposed "probe throws → await the load" behaviour turns a version-store blip into a simultaneous primary-database stampede across every isolate.

Also not added, per the proposal's own non-asks, which are correct and now recorded in the README: no async cache tier over edge KV, and no Cloudflare-specific package.

## Direct answers to the proposal's open questions

**1. Is the every-hit / blocking behaviour genuinely absent today, or reachable via a configuration we have missed?**

Half of it was missed. Every-hit is reachable today: set `ttlLeftBeforeRefreshInMsecs` equal to `ttlInMsecs` and every entry stays permanently inside the refresh window, so every read runs the check. Blocking is genuinely absent, and is not being added — see above. The reading of current behaviour was otherwise correct: `get()` never awaits a probe, the cached value is served regardless, and `true` bumps the TTL while `false`/throw schedules a reload for whoever reads next. That is stale-while-revalidate, and the README now says so in those words.

**2. Are concurrent `isEntryStillCurrentFn` calls for one key already coalesced?**

Yes, and they always have been — `README.md` line 902 already stated it, and `Loader.isKeyRefreshing` / `GroupLoader.groupRefreshFlags` guard both the async and in-memory paths. Measured: 4 concurrent `get()` calls on one key produce 1 probe. The hand-rolled per-key probe memo downstream is redundant and can be deleted today, on Node, with no library change.

They are **not** coalesced across keys — 3 concurrent gets on 3 distinct keys produce 3 probes — and that cannot change: `IsEntryStillCurrentFn` is typed per entry, so one branch head sha covering many file keys is read once per key. This is the real reason that memo exists, and no version of the blocking ask fixes it. If a token is shared across many keys, a scope-wide generation counter is the right primitive. Now documented.

**3. Does the in-memory-only loader schedule anything on a timer (eviction sweep, refresh tick)?**

No. `grep -rn "setInterval\|setTimeout" lib/` returns nothing, and `toad-cache` contains none either — expiry is evaluated lazily on read. An in-memory-only loader schedules no periodic work of any kind, so there is nothing that behaves differently under workerd's timer restrictions. Now documented.

One runtime caveat, offered as something to verify on the target rather than as a claim about this library: workerd pins `Date.now()` to the time of the last I/O, so a loader doing no I/O between reads sees a frozen clock and TTL does not advance within a request. It advances across requests, so a TTL used as a freshness backstop still works — just at request granularity rather than wall-clock.

**4. Would you prefer these as independent options, or as one named preset for the no-invalidation-bus deployment shape?**

Independent. A preset would bundle a coherence policy with a scheduling hook that have nothing to do with each other, and the two are close to alternatives in practice: a host that blocks on validation may have no background work left to schedule, while a host that keeps background refresh needs the scheduler and no blocking. Bundling them would make each harder to reason about. The README section documents the deployment shape instead, which is what a preset would really have been for.

## Semver

`minor` — new exports and new optional config, all additive.

One type-level nuance worth a reviewer's eye: `RedisGroupNotificationConsumer`'s second generic argument narrows from the concrete `InMemoryGroupCache<T>` to the `SynchronousGroupCache<T>` interface. This is required — the target cache is now a facade, and a concrete class type will not accept one because private fields defeat structural assignment — and it is what the abstract base was always declared over. It only breaks a subclass reaching for a member of `InMemoryGroupCache` that is not on the interface (in practice only `name`), which is why this is filed as minor rather than major.

## Verification

- `pnpm run lint` (Biome + `tsc --noEmit` + redis-compat) passes.
- Full suite passes with a local Redis: 22 files, 391 tests.
- Coverage thresholds met: statements 100%, lines 100%, branches 95.86% (≥95), functions 97.74% (≥97).
- `@layered-loader/sqs` type-checks and its 42 tests pass unmodified against this branch.
- `test/entrypoints.spec.ts` passes, so the `ioredis` optional-peer invariants are intact.
- New: `test/remoteInvalidation.spec.ts` (pins the fencing on both the direct and consumer paths, and pins that applying publishes nothing while originating does), `test/backgroundWork.spec.ts` (pins the reasons, the fulfilled-promise guarantee, and that omitting the option changes nothing).

---
_Generated by [Claude Code](https://claude.ai/code/session_018SAn4AfcCzjKEzipDGYHp2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added remote cache invalidation and value updates for individual keys, groups, batches, and entire caches.
  * Added configurable background-work scheduling with refresh and notification metadata.
  * Added public APIs and types for coordinating remote cache changes and background tasks.
* **Bug Fixes**
  * Improved handling of in-flight loads to prevent stale data after remote invalidation.
  * Prevented notification echoes and unhandled background-work failures.
* **Documentation**
  * Expanded guidance for remote invalidation, refresh behavior, scheduling, deployment constraints, and cache staleness validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->